### PR TITLE
Made sure sort actions are not passed a record

### DIFF
--- a/docs/2.0/records-reordering.md
+++ b/docs/2.0/records-reordering.md
@@ -51,10 +51,10 @@ class CourseLinkResource < Avo::BaseResource
     display_inline: true,
     visible_on: :index,
     actions: {
-      higher: -> (record) { record.move_higher },
-      lower: -> (record) { record.move_lower },
-      to_top: -> (record) { record.move_to_top },
-      to_bottom: -> (record) { record.move_to_bottom },
+      higher: -> { record.move_higher },
+      lower: -> { record.move_lower },
+      to_top: -> { record.move_to_top },
+      to_bottom: -> { record.move_to_bottom },
     }
   }
 end


### PR DESCRIPTION
They shouldn't take a record parameter. The example further up the page is correct, but this example doesn't work.