### PR TITLE
Use route helpers in actions documentation

### DIFF
--- a/docs/2.0/actions.md
+++ b/docs/2.0/actions.md
@@ -183,7 +183,7 @@ def handle(**args)
   end
 
   succeed 'Done!'
-  redirect_to '/avo/resources/users'
+  redirect_to avo.resources_users_path
 end
 ```
 


### PR DESCRIPTION
When I wrote my own actions it wasn’t clear to me how to redirect to a page within avo. I’ve updated the docs to show how to access routes from the avo engine.