### PR TITLE
Update api key authentication example to use secure comparison

### DIFF
--- a/docs/4.0/rest-api/authentication.md
+++ b/docs/4.0/rest-api/authentication.md
@@ -84,8 +84,9 @@ module Avo
       module V1
         class UsersController < BaseResourcesController
           def setup_authentication
-            api_key = request.headers['Authorization']&.sub(/^ApiKey /, '')
-            unless ApiKey.active.exists?(key: api_key)
+            expected_api_key = ENV.fetch("API_KEY")
+            provided_api_key = request.headers['Authorization']&.sub(/^ApiKey /, '')
+            unless ActiveSupport::SecurityUtils.secure_compare(provided_api_key, expected_api_key)
               raise Avo::Api::AuthenticationError
             end
           end


### PR DESCRIPTION
This aims to draw attention to the importance of using a utility like [secure_compare](https://api.rubyonrails.org/classes/ActiveSupport/SecurityUtils.html) when comparing strings for authentication purposes, to mitigate [timing attacks](https://sqreen.github.io/DevelopersSecurityBestPractices/timing-attack/python).