### PR TITLE
Document search_on_type global search config

### DIFF
--- a/docs/4.0/search/global-search.md
+++ b/docs/4.0/search/global-search.md
@@ -21,12 +21,13 @@ The global search shows a limited number of quick results in the dropdown, with 
 
 Use the `global_search` configuration to enable/disable the feature and control related options.
 
-```ruby{3-6}
+```ruby{3-7}
 # config/initializers/avo.rb
 Avo.configure do |config|
   config.global_search = {
     enabled: true,
     navigation_section: true,
+    search_on_type: true,
   }
 end
 ```
@@ -44,6 +45,22 @@ Avo.configure do |config|
   }
 end
 ```
+
+<Option name="`search_on_type`">
+
+By default, Avo runs the search as you type in the global search input. Set `search_on_type: false` to disable this behavior — the dropdown still opens on focus or <kbd>Cmd</kbd> + <kbd>K</kbd>, but typing no longer triggers a search. The user must press <kbd>Enter</kbd> to run the search and navigate to the dedicated results page.
+
+```ruby{5}
+# config/initializers/avo.rb
+Avo.configure do |config|
+  config.global_search = {
+    enabled: true,
+    search_on_type: false,
+  }
+end
+```
+
+</Option>
 
 <Option name="`item`">
 


### PR DESCRIPTION
## Summary

Documents the new `search_on_type` option for `config.global_search`, paired with [avo-pro#162](https://github.com/avo-hq/avo-pro/pull/162).

- Adds `search_on_type: true` to the `global_search` config example
- New `<Option name="search_on_type">` block explaining what `false` does: dropdown still opens on focus/Cmd+K, but typing no longer triggers a search — user presses Enter to navigate to the results page

## Test plan

- [ ] `npx vitepress build docs` succeeds
- [ ] `npx vitepress dev docs --port 3011` renders the page with the new Option block, anchor, and code highlight lines

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds guidance for a new global search behavior toggle; no runtime code changes.
> 
> **Overview**
> Documents a new `config.global_search.search_on_type` option, including adding it to the main configuration example and describing how setting it to `false` disables “search as you type” while keeping the dropdown opening behavior.
> 
> Adds a dedicated `<Option>` section with an example snippet showing `search_on_type: false` and updated code highlighting ranges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 241f8c20977e4afd87821a6f06e6c7b49d061c69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->