### PR TITLE
expand always true for dynamic filter

### DIFF
--- a/docs/4.0/avo-3-avo-4-upgrade.md
+++ b/docs/4.0/avo-3-avo-4-upgrade.md
@@ -768,6 +768,30 @@ config.container_width = { index: :full }
 
 More info on the [Container width](./customization.html#container-width) section.
 
+## Dynamic filters bar is now always expanded
+
+The dynamic filters bar is now permanently visible on resource index pages. The show/hide toggle button is gone, and so are the `button_label` and `always_expanded` settings that used to control it.
+
+To upgrade, remove this block from your `config/initializers/avo.rb`:
+
+```ruby
+if defined?(Avo::DynamicFilters)              # [!code --]
+  Avo::DynamicFilters.configure do |config|   # [!code --]
+    config.button_label = "Advanced filters"  # [!code --]
+    config.always_expanded = true             # [!code --]
+  end                                         # [!code --]
+end                                           # [!code --]
+```
+
+If you don't, the app won't boot. Depending on which line Ruby hits first, you'll see one of:
+
+```
+NoMethodError: undefined method 'button_label=' for an instance of Avo::DynamicFilters::Configuration
+NoMethodError: undefined method 'always_expanded=' for an instance of Avo::DynamicFilters::Configuration
+```
+
+More info on the [Dynamic filters](./dynamic-filters) page.
+
 ## Added `sidebar_toggle_visible` configuration option
 
 More info on the [Toggle the sidebar button visibility](./customization.html#toggle-the-sidebar-button-visibility) section.

--- a/docs/4.0/dynamic-filters.md
+++ b/docs/4.0/dynamic-filters.md
@@ -280,33 +280,6 @@ Check how to do a more advanced configuration on the [custom dynamic filters](#c
 
 </Option>
 
-## Options
-
-You can have a few customization options available that you can add in your `avo.rb` initializer file.
-
-```ruby
-Avo.configure do |config|
-  # Other Avo configurations
-end
-
-if defined?(Avo::DynamicFilters)
-  Avo::DynamicFilters.configure do |config|
-    config.button_label = "Advanced filters"
-    config.always_expanded = true
-  end
-end
-```
-
-<Option name="`button_label`">
-
-This will change the label on the expand label.
-</Option>
-
-<Option name="`always_expanded`">
-
-You may opt-in to have them always expanded and have the button hidden.
-</Option>
-
 ## Field to filter matching
 On versions **lower** than <Version version="3.10.0" /> the filters are not configurable so each field will have a dedicated filter type. Check how to do a more advanced configuration on the [custom dynamic filters](#custom-dynamic-filters) section.
 
@@ -333,9 +306,7 @@ end
 
 ## Caveats
 
-At some point we'll integrate the [Basic filters](./basic-filters) into the dynamic filters bar. Until then, if you have both basic and dynamic filters on your resource you'll have two `Filters` buttons on your <Index /> view.
-
-To mitigate that you can toggle the `always_expanded` option to true.
+[Basic filters](./basic-filters) and dynamic filters are independent UIs. If a resource declares both, the basic `Filters` button sits in the toolbar while the dynamic filters bar stays expanded above the table.
 
 ## Custom Dynamic Filters
 


### PR DESCRIPTION
Removes the toggle button that showed/hid the dynamic filters bar. The bar is now always visible on resource index pages. With it goes the button_label and always_expanded config attributes, the toggle button rendering in avo core, the toggleFilter / toggleFiltersArea Stimulus actions, the dynamic_filters_component_id plumbing, and the el-transition npm dep.

<img width="897" height="59" alt="Screenshot 2026-05-22 at 07 41 52" src="https://github.com/user-attachments/assets/cfccbec2-8e1e-4c77-aafc-c6c27cb77c68" />
