### PR TITLE
docs: clarify avo:all_resources only targets ActiveRecord models

### DIFF
--- a/docs/3.0/resources.md
+++ b/docs/3.0/resources.md
@@ -158,9 +158,11 @@ rails generate avo:all_resources
 
 ### What it does
 
-1. Scans your `app/models` directory for all model files
-2. Excludes `ApplicationRecord` from the generation process
-3. For each model found, it:
+1. Scans your `app/models` directory for model files
+2. Includes only classes that inherit from `ActiveRecord::Base` (database-backed models)
+3. Excludes abstract classes (e.g. `ApplicationRecord`)
+4. Skips non-model files (concerns, POROs, `Current`, form objects)
+5. For each match, it:
    - Generates a corresponding Avo resource using the `avo:resource` generator
    - Handles errors gracefully, printing error messages if generation fails for any model
 

--- a/docs/4.0/resources.md
+++ b/docs/4.0/resources.md
@@ -158,9 +158,11 @@ bin/rails generate avo:all_resources
 
 ### What it does
 
-1. Scans your `app/models` directory for all model files
-2. Excludes `ApplicationRecord` from the generation process
-3. For each model found, it:
+1. Scans your `app/models` directory for model files
+2. Includes only classes that inherit from `ActiveRecord::Base` (database-backed models)
+3. Excludes abstract classes (e.g. `ApplicationRecord`)
+4. Skips non-model files (concerns, POROs, `Current`, form objects)
+5. For each match, it:
    - Generates a corresponding Avo resource using the `avo:resource` generator
    - Handles errors gracefully, printing error messages if generation fails for any model
 


### PR DESCRIPTION
## Summary

- Update the `avo:all_resources` generator documentation in 3.0 and 4.0 resources guides
- Clarify that only `ActiveRecord::Base` descendants are included, not POROs, `Current`, or concerns

Related to avo-hq/avo#3518 and avo-hq/avo#4523

## Test plan

- [ ] Review updated "Generating resources for all models" section in both docs versions


Made with [Cursor](https://cursor.com)