### PR TITLE
Remove since-version tags from Avo 4.0 docs (AVO-1081)

### DIFF
--- a/docs/4.0/actions/customization.md
+++ b/docs/4.0/actions/customization.md
@@ -4,7 +4,6 @@ feedbackId: 837
 outline: deep
 ---
 
-
 # Customization
 
 Actions can be customized in several ways to enhance the user experience. You can modify the action's display name, confirmation message, button labels, and confirmation behavior between other things.
@@ -237,8 +236,6 @@ The block will be executed within the [`Avo::ExecutionContext`](./../execution-c
 </Option>
 
 <Option name="`close_modal_on_backdrop_click`" headingSize=3>
-
-<VersionReq version="3.14.0" class="mt-4" />
 
 By default, action modals use a dynamic backdrop.
 

--- a/docs/4.0/actions/execution.md
+++ b/docs/4.0/actions/execution.md
@@ -264,8 +264,6 @@ end
 
 <Option name="`close_modal`" headingSize=3>
 
-<VersionReq version="3.3.0" class="mt-4" />
-
 This type of response becomes useful when you are working with a form and need to execute an action without redirecting, ensuring that the form remains filled as it is.
 
 `close_modal` will flash all the messages gathered by [action responses](#action-responses) and will close the modal using turbo streams keeping the page still.
@@ -303,8 +301,6 @@ end
 </Option>
 
 <Option name="`navigate_to_action`" headingSize=3>
-
-<VersionReq version="3.4.2" class="mt-4" />
 
 You may want to redirect to another action. Here's an example of how to create a multi-step process, passing arguments from one action to another.
 In this example the initial action prompts the user to select the fields they wish to update, and in the subsequent action, the chosen fields will be accessible for updating.
@@ -356,8 +352,6 @@ You can see this multi-step process in action by visiting the [avodemo](https://
 
 <Option name="`append_to_response`" headingSize=3>
 
-<VersionReq version="3.10.3" class="mt-4" />
-
 Avo action responses are in the `turbo_stream` format. You can use the `append_to_response` method to append additional turbo stream responses to the default response.
 
 ```ruby{5-7}
@@ -394,8 +388,6 @@ append_to_response -> {
 </Option>
 
 <Option name="`reload_records`" headingSize=3>
-
-<VersionReq version="3.14.0" class="my-4" />
 
 <div style="position: relative; padding-bottom: 56.25%; height: 0;"><iframe src="https://www.loom.com/embed/6b9ae6a3968c447f98ac4f9a161fe781?sid=17f08010-6a56-4e8c-8b80-692424327b55" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
 

--- a/docs/4.0/actions/overview.md
+++ b/docs/4.0/actions/overview.md
@@ -1,11 +1,10 @@
 ---
 license: community
 feedbackId: 837
+demoVideo: https://youtu.be/BK47E7TMXn0?t=778
 ---
 
 # Actions Overview
-
-<DemoVideo demo-video="https://youtu.be/BK47E7TMXn0?t=778" class="mt-4" />
 
 Actions in Avo are powerful tools that transform the way you interact with your data. They enable you to perform operations on one or multiple records simultaneously, extending your interface with custom functionality that goes beyond basic CRUD operations.
 

--- a/docs/4.0/actions/registration.md
+++ b/docs/4.0/actions/registration.md
@@ -76,8 +76,6 @@ end
 
 <Option name="`icon`" headingSize="3">
 
-<VersionReq version="3.5.6" class="mt-4" />
-
 The `icon` option lets you specify the icon to display next to the action in the dropdown menu. Avo supports [Heroicons](https://heroicons.com) by default.
 
 Here's an example of how you can define actions with icons:
@@ -96,8 +94,6 @@ end
 ---
 
 ## `divider`
-
-<VersionReq version="3.5.6" class="mt-4" />
 
 Action dividers allow you to organize and separate actions into logical groups, improving the overall layout and usability.
 This will create a visual separator in the actions dropdown menu, helping you group related actions together.

--- a/docs/4.0/array-resources.md
+++ b/docs/4.0/array-resources.md
@@ -1,7 +1,6 @@
 ---
-version: '3.16.2'
 license: community
-demoVideo: https://youtu.be/wnWvzQyyo6A?t=1030
+demoVideo: "https://youtu.be/wnWvzQyyo6A?t=1030"
 betaStatus: Beta
 ---
 

--- a/docs/4.0/associations/belongs_to.md
+++ b/docs/4.0/associations/belongs_to.md
@@ -1,7 +1,6 @@
 ---
-version: '1.0'
 license: community
-field_type: 'belongs_to'
+field_type: belongs_to
 ---
 
 # Belongs to
@@ -98,7 +97,9 @@ Controls the creation link visibility on forms.
 #### Possible values
 
 `true`, `false`
-:::warning Since version <Version version="3.10.2" />, the target resource policy takes precedence over this option.
+:::warning
+The target resource policy takes precedence over this option.
+
 `field :user, as: :belongs_to, can_create: true`
 
 In this example, even if the `can_create` option is set to `true`, if the `UserPolicy` responds with `false` to the `create?` method, the creation link will **NOT** be visible.

--- a/docs/4.0/associations/has_and_belongs_to_many.md
+++ b/docs/4.0/associations/has_and_belongs_to_many.md
@@ -1,7 +1,6 @@
 ---
-version: '1.0'
 license: community
-field_type: 'has_and_belongs_to_many'
+field_type: has_and_belongs_to_many
 ---
 
 # Has And Belongs To Many

--- a/docs/4.0/associations/has_many.md
+++ b/docs/4.0/associations/has_many.md
@@ -1,7 +1,6 @@
 ---
-version: '1.0'
 license: community
-field_type: 'has_many'
+field_type: has_many
 ---
 
 # Has Many
@@ -46,8 +45,6 @@ field :members,
   through: :memberships
 ```
 <Option name="`attach_fields`">
-
-<VersionReq version="3.11" />
 
 If you have extra fields defined in the through table and would like to display them when attaching use the `attach_fields` option.
 

--- a/docs/4.0/associations/has_one.md
+++ b/docs/4.0/associations/has_one.md
@@ -1,7 +1,6 @@
 ---
-version: '1.0'
 license: community
-field_type: 'has_one'
+field_type: has_one
 ---
 
 :::warning

--- a/docs/4.0/associations/searchable.md
+++ b/docs/4.0/associations/searchable.md
@@ -1,12 +1,11 @@
 ---
 license: pro
 outline: [2, 3]
-api_docs: ./searchable-api.html
+api_docs: "./searchable-api.html"
+demoVideo: https://youtu.be/KLI_sVTPX-Q
 ---
 
 # Searchable associations
-
-<DemoVideo demo-video="https://youtu.be/KLI_sVTPX-Q" />
 
 When a target resource has too many records for a simple dropdown, `searchable` replaces the association field's `<select>` (and the attach modal's record picker) with a search-as-you-type input backed by your own query.
 

--- a/docs/4.0/audit-logging/index.md
+++ b/docs/4.0/audit-logging/index.md
@@ -1,7 +1,7 @@
 ---
 license: enterprise
 betaStatus: Beta
-outline: [2,3]
+outline: [2, 3]
 ---
 
 # Audit Logging

--- a/docs/4.0/authentication.md
+++ b/docs/4.0/authentication.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 ---
 

--- a/docs/4.0/authorization.md
+++ b/docs/4.0/authorization.md
@@ -129,8 +129,6 @@ Controls whether the user can see the [resource search input](./search/resource-
 
 <Option name="`preview?`">
 
-<VersionReq version="3.18.0" />
-
 Controls access to the preview endpoint, which is triggered by the [preview field](./record-previews.html).
 
 :::info
@@ -267,8 +265,6 @@ end
 
 Now, whatever action you take for one comment, it will be available for the `edit_comments?` method in `PostPolicy`.
 
-<VersionReq version="2.31" />
-
 From version 2.31 we introduced a concern that removes the duplication and helps you apply the same rules to associations. You should include `Avo::Pro::Concerns::PolicyHelpers` in the `ApplicationPolicy` for it to be applied to all policy classes.
 
 `PolicyHelpers` allows you to use the method `inherit_association_from_policy`. This method takes two arguments; `association_name` and the policy file you want to be used as a template.
@@ -312,8 +308,6 @@ def view_comments?
   CommentPolicy.new(user, record).index?
 end
 
-# Since Version 3.10.0
-
 def attach_comments?
   CommentPolicy.new(user, record).attach?
 end
@@ -334,8 +328,6 @@ end
 ```
 
 ## Attachments
-
-<VersionReq version="2.28" />
 
 When working with files, it may be necessary to establish policies that determine whether users can `upload`, `download` or `delete` files. Fortunately, Avo simplifies this process by providing a straightforward naming schema for these policies.
 
@@ -484,7 +476,6 @@ Now, you'll have to provide a policy for each resource you have in your app, thu
 
 ## Logs
 
-<VersionReq version="3.11.7" />
 [Developers](authentication.html#_2-developer-user) have the ability to monitor any unauthorized actions. When a [developer user](authentication.html#_2-developer-user) makes a request that triggers an unauthorized action, a log entry similar to the following will be generated:
 
 In development each log entry provides details about the policy class, the action attempted, the global id of the user who made the request, and the global id of the record involved:
@@ -509,8 +500,6 @@ web     | [Avo->] Unauthorized action 'act_on?' for 'UserPolicy'
 ```
 
 ## Custom policies
-
-<VersionReq version="2.17" />
 
 By default, Avo will infer the policy from the model of the resource object. If you wish to use a different policy for a given resource, you can specify it directly in the resource using the `authorization_policy` option.
 

--- a/docs/4.0/avo-meta.md
+++ b/docs/4.0/avo-meta.md
@@ -1,7 +1,6 @@
 ---
-# license:
-betaStatus: Alpha 🧪 (experimental)
-outline: [2,3]
+betaStatus: "Alpha 🧪 (experimental)"
+outline: [2, 3]
 ---
 
 # Avo::Meta

--- a/docs/4.0/basic-filters.md
+++ b/docs/4.0/basic-filters.md
@@ -18,8 +18,6 @@ Each filter is configured in a class with a few dedicated [methods and options](
 self.name = "User names filter"
 ```
 
-<VersionReq version="3.14.0" />
-
 ```ruby
 self.name = -> { I18n.t("avo.filter.name") }
 ```
@@ -34,8 +32,6 @@ The value of `self.button_label` is the label displayed on the button that appli
 ```ruby
 self.button_label = "Filter by user names"
 ```
-
-<VersionReq version="3.14.0" />
 
 ```ruby
 self.button_label = -> { I18n.t("avo.filter.button_label") }
@@ -124,7 +120,7 @@ end
 
 ## Filter types
 
-Avo has several types of filters available [Boolean filter](#Boolean%20Filter), [Select filter](#Select%20Filter), [Multiple select filter](#Multiple%20select%20filter), [Text filter](#Text%20Filter) and since version <Version version="3.11.8" /> [Date time filter](#Date%20time%20Filter).
+Avo has several types of filters available [Boolean filter](#Boolean%20Filter), [Select filter](#Select%20Filter), [Multiple select filter](#Multiple%20select%20filter), [Text filter](#Text%20Filter) and [Date time filter](#Date%20time%20Filter).
 
 <Image src="/assets/img/filters.png" width="404" height="727" alt="Avo filters" />
 
@@ -412,8 +408,6 @@ end
 </Option>
 
 <Option name="Date time Filter">
-
-<VersionReq version="3.11.8" />
 
 The ideal filter for date selection. This filter allows you to generate a date input, with options to include time selection and even a range selection mode. Customizable to suit your specific needs.
 

--- a/docs/4.0/branding.md
+++ b/docs/4.0/branding.md
@@ -1,5 +1,5 @@
 ---
-title: Branding (moved to Appearance)
+title: "Branding (moved to Appearance)"
 ---
 
 # Branding has moved

--- a/docs/4.0/cards.md
+++ b/docs/4.0/cards.md
@@ -1,6 +1,5 @@
 ---
 feedbackId: 839
-version: unreleased
 license: pro
 ---
 
@@ -86,7 +85,7 @@ You may also want to give the user the ability to query data in different ranges
 
 You can also set a default range using the `initial_range` attribute.
 
-The ranges have been changed a bit since **version 2.8**. The parameter you pass to the `range` option will be directly passed to the [`options_for_select`](https://apidock.com/rails/v5.2.3/ActionView/Helpers/FormOptionsHelper/options_for_select) helper, so it behaves more like a regular `select_tag`.
+The parameter you pass to the `range` option will be directly passed to the [`options_for_select`](https://apidock.com/rails/v5.2.3/ActionView/Helpers/FormOptionsHelper/options_for_select) helper, so it behaves more like a regular `select_tag`.
 
 ```ruby{4-15}
 class Avo::Cards::UsersMetric < Avo::Cards::MetricCard
@@ -249,7 +248,7 @@ end
 
 <br>
 
-<VersionReq version="3.13" /> `prefix` and `suffix` became callable options.
+`prefix` and `suffix` became callable options.
 
 The blocks are executed using [`Avo::ExecutionContext`](execution-context). Within this blocks, you gain access to all attributes of [`Avo::ExecutionContext`](execution-context) along with the `parent`.
 
@@ -323,7 +322,6 @@ If you'd like to use [Groupdate](https://github.com/ankane/groupdate), [Hightop]
 
 `chart.js` is supported for the time being. So if you need support for other types, please reach out or post a PR (🙏 PRs are much appreciated).
 
-<VersionReq version="3.6.1" />
 `self.chartkick_options` accepts callable blocks:
 ```ruby
 class Avo::Cards::ExampleAreaChart < Avo::Cards::ChartkickCard
@@ -417,8 +415,6 @@ end
 
 ## Cards visibility
 
-<VersionReq version="2.28" />
-
 It's common to show the same card to multiple types of users (admins, regular users). In that scenario you might want to hide some cards for the regular users and show them just to the admins.
 
 You can use the `visible` option to do that. It can be a `boolean` or a `block` where you can access the `params`, `current_user`, `context`, `parent`, and `card` object.
@@ -505,8 +501,6 @@ Dividers can be a simple line between your cards or have some text on them that 
 When you don't want to show the line, you can enable the `invisible` option, which adds the divider but does not display a border or label.
 
 ## Dividers visibility
-
-<VersionReq version="2.28" />
 
 You might want to conditionally show/hide a divider based on a few factors. You can do that using the `visible` option.
 

--- a/docs/4.0/cards.md
+++ b/docs/4.0/cards.md
@@ -248,9 +248,9 @@ end
 
 <br>
 
-`prefix` and `suffix` became callable options.
+`prefix` and `suffix` can be configured using a Proc.
 
-The blocks are executed using [`Avo::ExecutionContext`](execution-context). Within this blocks, you gain access to all attributes of [`Avo::ExecutionContext`](execution-context) along with the `parent`.
+Within this block, you gain access to all attributes of [`Avo::ExecutionContext`](execution-context) along with the `parent`.
 
 ```ruby{3,4}
 class Avo::Cards::UsersMetric < Avo::Cards::MetricCard

--- a/docs/4.0/collaboration/authorization.md
+++ b/docs/4.0/collaboration/authorization.md
@@ -1,6 +1,6 @@
 ---
 license: add_on
-add_on_link: https://avohq.io/pricing-4?add_ons[]=collaboration
+add_on_link: "https://avohq.io/pricing-4?add_ons[]=collaboration"
 add_on: collaboration_feature
 betaStatus: Beta
 outline: [2, 3]

--- a/docs/4.0/collaboration/overview.md
+++ b/docs/4.0/collaboration/overview.md
@@ -1,6 +1,6 @@
 ---
 license: add_on
-add_on_link: https://avohq.io/pricing-4?add_ons[]=collaboration
+add_on_link: "https://avohq.io/pricing-4?add_ons[]=collaboration"
 add_on: collaboration_feature
 betaStatus: Beta
 outline: [2, 3]

--- a/docs/4.0/common/association.md
+++ b/docs/4.0/common/association.md
@@ -1,7 +1,5 @@
 <Option name="`association`">
 
-<VersionReq version="3.6.2" />
-
 The `for_attribute` option allows to specify the association used for a certain field. This option make possible to define same association with different scopes and different name several times on the same resource.
 
 #### Usage

--- a/docs/4.0/common/associations_searchable_option_common.md
+++ b/docs/4.0/common/associations_searchable_option_common.md
@@ -1,7 +1,5 @@
 <Option name="`searchable`">
 
-<LicenseReq license="pro" />
-
 Turns the attach field/modal from a `<select>` into a search-as-you-type picker.
 
 ```ruby{4}

--- a/docs/4.0/common/file_options_common.md
+++ b/docs/4.0/common/file_options_common.md
@@ -17,8 +17,6 @@ field :cover_video, as: :file, accept: "image/*"
 
 <Option name="`direct_upload`">
 
-<LicenseReq license="pro" />
-
 If you have large files and don't want to overload the server with uploads, you can use the `direct_upload` feature, which will upload the file directly to your cloud provider.
 
 ```ruby

--- a/docs/4.0/common/nested_common.md
+++ b/docs/4.0/common/nested_common.md
@@ -1,10 +1,4 @@
 ## Nested in Forms
-<div class="space-x-2">
-  <VersionReq version="3.19.0"/>
-  <BetaStatus label="Public beta"/>
-  <LicenseReq license="advanced"/>
-</div>
-
 
 You can use ["Show on edit screens"](#show-on-edit-screens) to make the `{{ $frontmatter.field_type }}` field available in the [edit](./../views.html#Edit) view. However, this will render it using the [show](./../views.html#Show) view component.
 

--- a/docs/4.0/common/reloadable.md
+++ b/docs/4.0/common/reloadable.md
@@ -1,7 +1,5 @@
 <Option name="Reloadable">
 
-<VersionReq version="3.3.6" />
-
 The reloadable option adds a reload icon next to the association title so users can easily reload just that turbo-frame instead of doing a full page reload.
 
 #### Usage

--- a/docs/4.0/common/row_controls_config_common.md
+++ b/docs/4.0/common/row_controls_config_common.md
@@ -1,0 +1,1 @@
+Configure where row controls appear on the <Index /> view — placement, floating behavior, and hover visibility — using `row_controls_config`.

--- a/docs/4.0/controllers.md
+++ b/docs/4.0/controllers.md
@@ -1,5 +1,5 @@
 ---
-demoVideo: https://youtu.be/peKt90XhdOg?t=11
+demoVideo: "https://youtu.be/peKt90XhdOg?t=11"
 ---
 
 # Resource controllers

--- a/docs/4.0/customizable-controls.md
+++ b/docs/4.0/customizable-controls.md
@@ -191,8 +191,6 @@ actions_list include: [Avo::Actions::ExportSelection, Avo::Actions::PublishPost]
 
 <Option name="`list`">
 
-<VersionReq version="3.13" />
-
 A dropdown that displays all the specified actions and links.
 
 #### Supported options
@@ -216,7 +214,7 @@ end
 Within the `list` block, the only permitted elements are `link_to` and `action`. For both `link_to` and `action`, you can include an optional `icon` parameter.
 
 :::info
-<VersionReq version="3.14.1" /> [`divider`](actions/registration.html#divider) is also permitted within the `list` block.
+[`divider`](actions/registration.html#divider) is also permitted within the `list` block.
 :::
 
 In addition to the `icon`, the `link_to` element can accept additional parameters such as `target: :_blank` or `rel: "noopener"`, or any other extra arguments you may want to provide for the link. These extra arguments help define specific behaviors for the link, like opening it in a new tab or ensuring security best practices are followed.
@@ -260,7 +258,7 @@ action Avo::Actions::PublishPost, color: :fuchsia, icon: "heroicons/outline/eye"
 
 </Option>
 
-:::warning WARNING (**NOT** applicable for versions greater than <Version version="3.10.7" />)
+:::warning WARNING (**NOT** applicable for versions greater than )
 
 When you use the `action` helper in any customizable block it will act only as a shortcut to display the action button, it will not also register it to the resource.
 

--- a/docs/4.0/customizable-controls.md
+++ b/docs/4.0/customizable-controls.md
@@ -211,11 +211,7 @@ end
 <Image src="/assets/img/resources/customizable-controls/custom_list.png" width="404" height="256" alt="Custom list opened" />
 
 
-Within the `list` block, the only permitted elements are `link_to` and `action`. For both `link_to` and `action`, you can include an optional `icon` parameter.
-
-:::info
-[`divider`](actions/registration.html#divider) is also permitted within the `list` block.
-:::
+Within the `list` block, the permitted elements are `link_to`, `action`, and [`divider`](actions/registration.html#divider). For both `link_to` and `action`, you can include an optional `icon` parameter.
 
 In addition to the `icon`, the `link_to` element can accept additional parameters such as `target: :_blank` or `rel: "noopener"`, or any other extra arguments you may want to provide for the link. These extra arguments help define specific behaviors for the link, like opening it in a new tab or ensuring security best practices are followed.
 
@@ -257,33 +253,6 @@ action Avo::Actions::PublishPost, color: :fuchsia, icon: "heroicons/outline/eye"
 ```
 
 </Option>
-
-:::warning WARNING (**NOT** applicable for versions greater than )
-
-When you use the `action` helper in any customizable block it will act only as a shortcut to display the action button, it will not also register it to the resource.
-
-You must manually register it with the `action` declaration.
-
-```ruby{6-8,13-15}
-class Avo::Resources::Fish < Avo::BaseResource
-  self.title = :name
-
-  self.show_controls = -> do
-    # In order to use it here
-    action Avo::Actions::ReleaseFish, style: :primary, color: :fuchsia, arguments: {
-      action_on_show_controls: "Will use this arguments"
-    }
-  end
-
-  # 👇 Also declare it here 👇
-  def actions
-    action Avo::Actions::ReleaseFish, arguments: {
-      action_from_list: "Will use this arguments"
-    }
-  end
-end
-```
-:::
 
 <Option name="`default_controls`">
 

--- a/docs/4.0/customization.md
+++ b/docs/4.0/customization.md
@@ -615,7 +615,9 @@ Using [searchable](./associations/searchable.html) is recommended for listing un
 
 <Option name="`persistence`">
 
-### Persistent UI State Configuration #### Overview
+### Persistent UI State Configuration
+
+#### Overview
 
 The `persistence` configuration enables retention of specific UI settings, such as pagination and static filters, across user interactions.
 

--- a/docs/4.0/customization.md
+++ b/docs/4.0/customization.md
@@ -75,35 +75,11 @@ That will render all `id` fields in the **Index** view as a link to that resourc
 
 <Image src="/assets/img/fields-reference/as-link-to-resource.jpg" width="694" height="166" alt="As link to resource" />
 
-## Resource controls on the left or both sides
+## Modify controls placement and appearance
 
-:::warning
-`resource_controls_placement` option is **obsolete**.
+<!-- @include: ./common/row_controls_config_common.md-->
 
-Check [row controls configuration on table view](table-view.html#global-configuration) instead
-:::
-
-<DemoVideo demo-video="https://youtu.be/MfryUtcXqvU?t=706" />
-
-By default, the resource controls are located on the right side of the record rows, which might be hidden if there are a lot of columns. You might want to move the controls to the left side in that situation using the `resource_controls_placement` option.
-
-```ruby{3}
-# config/initializers/avo.rb
-Avo.configure do |config|
-  config.resource_controls_placement = :left
-end
-```
-
-<Image src="/assets/img/customization/resource-controls-left.jpg" width="1206" height="920" alt="Resource controls on the left side" />
-
-You're able to render the controls on both sides
-
-```ruby{3}
-# config/initializers/avo.rb
-Avo.configure do |config|
-  config.resource_controls_placement = :both
-end
-```
+See [row controls configuration on table view](table-view.html#global-configuration).
 
 ## Container width
 

--- a/docs/4.0/customization.md
+++ b/docs/4.0/customization.md
@@ -78,7 +78,7 @@ That will render all `id` fields in the **Index** view as a link to that resourc
 ## Resource controls on the left or both sides
 
 :::warning
-<VersionReq version="3.16.3" /> `resource_controls_placement` option is **obsolete**.
+`resource_controls_placement` option is **obsolete**.
 
 Check [row controls configuration on table view](table-view.html#global-configuration) instead
 :::
@@ -96,7 +96,7 @@ end
 
 <Image src="/assets/img/customization/resource-controls-left.jpg" width="1206" height="920" alt="Resource controls on the left side" />
 
-<VersionReq version="3.13.7" class="mt-2" /> You're able to render the controls on both sides
+You're able to render the controls on both sides
 
 ```ruby{3}
 # config/initializers/avo.rb
@@ -287,8 +287,6 @@ end
 ```
 
 ### Use a lambda function for the home_path
-
-<VersionReq version="2.8.0" class="mt-2" />
 
 You can also use a lambda function to define that path.
 
@@ -489,11 +487,6 @@ Please follow [this](authentication.html#customise-the-sign-out-link) guide in [
 
 ## Skip show view
 
-<div class="space-x-2">
-  <VersionReq version="2.16" />
-  <BetaStatus label="Public beta"></BetaStatus>
-</div>
-
 In the CRUD interface Avo adds the <Show /> view by default. This means that when your users will see the view icon to go to that detail page and they will be redirected to the <Show /> page when doing certain tasks (update a record, run an action, etc.).
 
 You might not want that behavior and you might not use the <Show /> view at all and prefer to skip that and just use the <Edit /> view.
@@ -627,8 +620,6 @@ end
 
 <Option name="`associations_lookup_list_limit`">
 
-<VersionReq version="3.14.1" />
-
 By default, there is a limit of a 1000 records per query when listing the association options. This limit ensures that the page will not crash due to large collections.
 Use `associations_lookup_list_limit` configuration to change the limit value.
 
@@ -648,9 +639,7 @@ Using [searchable](./associations/searchable.html) is recommended for listing un
 
 <Option name="`persistence`">
 
-### Persistent UI State Configuration <VersionReq version="3.15.4" />
-
-#### Overview
+### Persistent UI State Configuration #### Overview
 
 The `persistence` configuration enables retention of specific UI settings, such as pagination and static filters, across user interactions.
 

--- a/docs/4.0/dashboards.md
+++ b/docs/4.0/dashboards.md
@@ -1,7 +1,6 @@
 ---
 feedbackId: 833
 license: pro
-version: '2.0'
 ---
 
 # Dashboards
@@ -154,8 +153,6 @@ end
 
 ## Dashboards authorization
 
-<VersionReq version="2.22" />
-
 You can set authorization rules for dashboards using the `authorize` block.
 
 ```ruby{3-6}
@@ -176,7 +173,7 @@ end
 self.name = "Dashy"
 ```
 
-<VersionReq version="3.14.2" /> `self.name` can be configured using a Proc.
+`self.name` can be configured using a Proc.
 
 ```ruby
 self.name = -> { I18n.t("avo.dashboards.dashy.name") }

--- a/docs/4.0/dynamic-filters.md
+++ b/docs/4.0/dynamic-filters.md
@@ -352,7 +352,7 @@ The default (`always_expanded = true`) avoids this since the dynamic filters bar
 
 ## Custom Dynamic Filters
 
-Dynamic filters are great but strict, as each field creates a specific filter type, each with its own icon and query. The query remains static, targeting only that particular field. Custom dynamic filters can be declared without being bound to a field.
+Dynamic filters are great but strict, as each field creates a specific filter type, each with its own icon and query. The query remains static, targeting only that particular field. Dynamic filters are customizable and, even better, can be declared without being bound to a field.
 
 There are two ways to define custom dynamic filters: the field's `filterable` option and the `dynamic_filter` method.
 

--- a/docs/4.0/dynamic-filters.md
+++ b/docs/4.0/dynamic-filters.md
@@ -273,7 +273,9 @@ Contained in will not work when using the `acts-as-taggable-on` gem.
 Test it on [avodemo](https://main.avodemo.com/avo/resources/courses?filters[skills][array_contains][]=), check the [source code](https://github.com/avo-hq/main.avodemo.com/blob/main/app/avo/resources/course.rb#L46)
 
 :::info
-The source code uses custom dynamic filters DSL available Check how to do a more advanced configuration on the [custom dynamic filters](#custom-dynamic-filters) section.
+The source code uses the custom dynamic filters DSL.
+
+Check how to do a more advanced configuration on the [custom dynamic filters](#custom-dynamic-filters) section.
 :::
 
 </Option>

--- a/docs/4.0/dynamic-filters.md
+++ b/docs/4.0/dynamic-filters.md
@@ -320,9 +320,8 @@ end
 </Option>
 
 ## Field to filter matching
-On versions **lower** than the filters are not configurable so each field will have a dedicated filter type. Check how to do a more advanced configuration on the [custom dynamic filters](#custom-dynamic-filters) section.
 
-Field-to-filter matching in versions **lower** than :
+By default, each `filterable` field gets a dedicated filter type based on its field type. Avo maps field types to filter types automatically:
 
 ```ruby
 def field_to_filter(type)
@@ -343,6 +342,8 @@ def field_to_filter(type)
 end
 ```
 
+For more control over labels, icons, queries, and conditions, use [custom dynamic filters](#custom-dynamic-filters).
+
 ## Caveats
 
 At some point we'll integrate the [Basic filters](./basic-filters) into the dynamic filters bar. Until then, if you have both basic and dynamic filters on a resource **and** you've set `always_expanded = false`, you'll see two `Filters` buttons on the <Index /> view.
@@ -351,7 +352,7 @@ The default (`always_expanded = true`) avoids this since the dynamic filters bar
 
 ## Custom Dynamic Filters
 
-Dynamic filters are great but strict, as each field creates a specific filter type, each with its own icon and query. The query remains static, targeting only that particular field. Custom dynamic filters can be declared and, even better, can be declared without being bound to a field.
+Dynamic filters are great but strict, as each field creates a specific filter type, each with its own icon and query. The query remains static, targeting only that particular field. Custom dynamic filters can be declared without being bound to a field.
 
 There are two ways to define custom dynamic filters: the field's `filterable` option and the `dynamic_filter` method.
 

--- a/docs/4.0/dynamic-filters.md
+++ b/docs/4.0/dynamic-filters.md
@@ -624,7 +624,7 @@ Suggestions work on filters that provide text input, enhancing the user experien
 `nil`
 
 :::info
-on `tags` fields the `suggestions` are fetched from the field.
+On `tags` fields, suggestions are fetched from the field.
 :::
 
 #### Possible values
@@ -647,7 +647,7 @@ dynamic_filter :first_name,
 
 - Proc that returns an array of strings
 
-when the filter is applied to an association, the `parent_record` becomes accessible within the `suggestions` block.
+  When the filter is applied to an association, the `parent_record` becomes accessible within the `suggestions` block.
 
 ```ruby {6,12}
 # Using field's filterable option

--- a/docs/4.0/dynamic-filters.md
+++ b/docs/4.0/dynamic-filters.md
@@ -449,10 +449,6 @@ Computed from field using [`field_to_filter` method](#field-to-filter-matching).
 
 <Option name="`query`">
 
-:::info
-The default filtering system is no longer applied when a `query` is specified on a dynamic filter.
-:::
-
 Customize filter's query
 
 ##### Default value

--- a/docs/4.0/dynamic-filters.md
+++ b/docs/4.0/dynamic-filters.md
@@ -155,7 +155,8 @@ dynamic_filter :published_at, type: :time
  - `>=` (greater than or equal to)
  - `<` (lower than)
  - `<=` (lower than or equal to)
- - Is within - Is null
+ - Is within
+ - Is null
  - Is not null
 
 ```ruby

--- a/docs/4.0/dynamic-filters.md
+++ b/docs/4.0/dynamic-filters.md
@@ -155,8 +155,7 @@ dynamic_filter :published_at, type: :time
  - `>=` (greater than or equal to)
  - `<` (lower than)
  - `<=` (lower than or equal to)
- - Is within <VersionReq version="3.10.11"/>
- - Is null
+ - Is within - Is null
  - Is not null
 
 ```ruby
@@ -273,9 +272,7 @@ Contained in will not work when using the `acts-as-taggable-on` gem.
 Test it on [avodemo](https://main.avodemo.com/avo/resources/courses?filters[skills][array_contains][]=), check the [source code](https://github.com/avo-hq/main.avodemo.com/blob/main/app/avo/resources/course.rb#L46)
 
 :::info
-The source code uses custom dynamic filters DSL available <VersionReq version="3.10.0" />
-
-Check how to do a more advanced configuration on the [custom dynamic filters](#custom-dynamic-filters) section.
+The source code uses custom dynamic filters DSL available Check how to do a more advanced configuration on the [custom dynamic filters](#custom-dynamic-filters) section.
 :::
 
 </Option>
@@ -320,9 +317,9 @@ end
 </Option>
 
 ## Field to filter matching
-On versions **lower** than <Version version="3.10.0" /> the filters are not configurable so each field will have a dedicated filter type. Check how to do a more advanced configuration on the [custom dynamic filters](#custom-dynamic-filters) section.
+On versions **lower** than the filters are not configurable so each field will have a dedicated filter type. Check how to do a more advanced configuration on the [custom dynamic filters](#custom-dynamic-filters) section.
 
-Field-to-filter matching in versions **lower** than <Version version="3.10.0" />:
+Field-to-filter matching in versions **lower** than :
 
 ```ruby
 def field_to_filter(type)
@@ -351,10 +348,7 @@ The default (`always_expanded = true`) avoids this since the dynamic filters bar
 
 ## Custom Dynamic Filters
 
-<BetaStatus label="Beta" />
-<VersionReq version="3.10.0" />
-
-Dynamic filters are great but strict, as each field creates a specific filter type, each with its own icon and query. The query remains static, targeting only that particular field. Since version <Version version="3.10" />, dynamic filters have become customizable and, even better, can be declared without being bound to a field.
+Dynamic filters are great but strict, as each field creates a specific filter type, each with its own icon and query. The query remains static, targeting only that particular field. Custom dynamic filters can be declared and, even better, can be declared without being bound to a field.
 
 There are two ways to define custom dynamic filters: the field's `filterable` option and the `dynamic_filter` method.
 
@@ -452,7 +446,7 @@ Computed from field using [`field_to_filter` method](#field-to-filter-matching).
 <Option name="`query`">
 
 :::info
-<VersionReq version="3.11.8" /> the default filtering system is no longer applied when a `query` is specified on a dynamic filter.
+The default filtering system is no longer applied when a `query` is specified on a dynamic filter.
 :::
 
 Customize filter's query
@@ -630,7 +624,7 @@ Suggestions work on filters that provide text input, enhancing the user experien
 `nil`
 
 :::info
-<VersionReq version="3.11.8" /> on `tags` fields the `suggestions` are fetched from the field.
+on `tags` fields the `suggestions` are fetched from the field.
 :::
 
 #### Possible values
@@ -653,7 +647,7 @@ dynamic_filter :first_name,
 
 - Proc that returns an array of strings
 
-<VersionReq version="3.15.1" /> when the filter is applied to an association, the `parent_record` becomes accessible within the `suggestions` block.
+when the filter is applied to an association, the `parent_record` becomes accessible within the `suggestions` block.
 
 ```ruby {6,12}
 # Using field's filterable option
@@ -672,7 +666,6 @@ dynamic_filter :first_name,
 
 
 - Array of hashes with the keys `value`, `label` and optionally an `avatar`
-<VersionReq version="3.11.8" />
 :::warning Applicable only to filters with type tags.
 :::
 
@@ -743,8 +736,6 @@ dynamic_filter :tags,
 </Option>
 
 <Option name="`fetch_values_from`">
-
-<VersionReq version="3.13" />
 
 :::warning
 This option is compatible **only** with `tags` filters.
@@ -844,8 +835,6 @@ end
 </Option>
 
 <Option name="`options`">
-
-<VersionReq version="3.10.10" />
 
 Customize the options **for select type filters**. **This is available only for select type filters** and determines the options visible in the select dropdown.
 
@@ -1001,8 +990,6 @@ field :is_capital,
 </Option>
 
 <Option name="`humanized_condition`">
-
-<VersionReq version="3.24.0" />
 
 Allows you to customize how filter conditions are displayed in the filter's pill interface by providing humanized, user-friendly representations of the internal filter conditions.
 

--- a/docs/4.0/field-discovery.md
+++ b/docs/4.0/field-discovery.md
@@ -1,9 +1,8 @@
 ---
-outline: [2,3]
-version: "3.17.0"
+outline: [2, 3]
 license: community
 betaStatus: Beta
-demoVideo: https://youtu.be/wnWvzQyyo6A?t=1475
+demoVideo: "https://youtu.be/wnWvzQyyo6A?t=1475"
 ---
 
 # Field Discovery

--- a/docs/4.0/field-options.md
+++ b/docs/4.0/field-options.md
@@ -295,8 +295,6 @@ field :name, as: :text, disabled: true
 
 ### Disabled as a block
 
-<VersionReq version="2.14" class="mt-2" />
-
 You may use a block as well. It will be executed in the `Avo::ExecutionContext` and you will have access to the `view`, `record`, `params`, `context`, `view_context`, and `current_user`.
 
 ```ruby
@@ -568,7 +566,7 @@ The chart provides a visual representation of data distribution, making it easie
 
 Allows to specify the target attribute on the model for each field. By default the target attribute is the field's id.
 
-<!-- <VersionReq version="3.6.2" /> -->
+<!-- -->
 
 Usage example:
 
@@ -588,7 +586,7 @@ field :secondary_field_for_status,
 
 This handy option enables you to send arbitrary information to the field. It's especially useful when you're building your own [custom fields](./custom-fields) or you are using [custom components](#components) for the built-in fields.
 
-<!-- <VersionReq version="3.10" /> -->
+<!-- -->
 
 Usage example:
 
@@ -621,8 +619,6 @@ Within your field template you can now access the `@field.meta` attribute.
 
 <Option name="`copyable`">
 
-<VersionReq version="3.15.6" class="mt-2" />
-
 The `copyable` option enables users to copy the field's value to their clipboard. When set to `true`, a clipboard icon appears when hovering over the field value, allowing easy copying. This feature can be particularly useful for fields such as unique identifiers, URLs, or other text-based content that users may frequently need to copy.
 
 ```ruby
@@ -634,8 +630,6 @@ The `copyable` option is available for text-based fields such as `:text`, `:text
 </Option>
 
 <Option name="`react_on`">
-
-<VersionReq version="4.0" class="mt-2" />
 
 The `react_on` option enables dynamic reactivity for a field when changes occur elsewhere in the form. When a specified field changes, the current field is re-evaluated, and the `@record` object is refreshed with the latest form values.
 

--- a/docs/4.0/field-options.md
+++ b/docs/4.0/field-options.md
@@ -566,8 +566,6 @@ The chart provides a visual representation of data distribution, making it easie
 
 Allows to specify the target attribute on the model for each field. By default the target attribute is the field's id.
 
-<!-- -->
-
 Usage example:
 
 ```ruby
@@ -585,8 +583,6 @@ field :secondary_field_for_status,
 <Option name="`meta`">
 
 This handy option enables you to send arbitrary information to the field. It's especially useful when you're building your own [custom fields](./custom-fields) or you are using [custom components](#components) for the built-in fields.
-
-<!-- -->
 
 Usage example:
 

--- a/docs/4.0/field-options.md
+++ b/docs/4.0/field-options.md
@@ -423,7 +423,7 @@ Optionally you can enable the global config `id_links_to_resource`. More on that
 
 **Related:**
  - [ID links to resource](./customization#id-links-to-resource)
- - [Resource controls on the left side](./customization#resource-controls-on-the-left-side)
+ - [Modify controls placement and appearance](./customization#modify-controls-placement-and-appearance)
 
 ## Align text on Index view
 

--- a/docs/4.0/field-options.md
+++ b/docs/4.0/field-options.md
@@ -421,10 +421,6 @@ You can add this property on [`id`](./fields/id.html), [`text`](./fields/text.ht
 
 Optionally you can enable the global config `id_links_to_resource`. More on that on the [id links to resource docs page](./customization.html#id-links-to-resource).
 
-**Related:**
- - [ID links to resource](./customization#id-links-to-resource)
- - [Modify controls placement and appearance](./customization#modify-controls-placement-and-appearance)
-
 ## Align text on Index view
 
 It's customary on tables to align numbers to the right. You can do that using the `html` option.

--- a/docs/4.0/fields/array.md
+++ b/docs/4.0/fields/array.md
@@ -1,8 +1,7 @@
 ---
-version: '3.16.2'
 license: community
 betaStatus: beta
-demoVideo: https://youtu.be/wnWvzQyyo6A?t=1030
+demoVideo: "https://youtu.be/wnWvzQyyo6A?t=1030"
 ---
 
 # Array

--- a/docs/4.0/fields/avatar.md
+++ b/docs/4.0/fields/avatar.md
@@ -1,5 +1,4 @@
 ---
-version: "4.0"
 license: community
 ---
 

--- a/docs/4.0/fields/badge.md
+++ b/docs/4.0/fields/badge.md
@@ -1,5 +1,4 @@
 ---
-version: "1.0"
 license: community
 ---
 

--- a/docs/4.0/fields/boolean.md
+++ b/docs/4.0/fields/boolean.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 ---
 

--- a/docs/4.0/fields/boolean_group.md
+++ b/docs/4.0/fields/boolean_group.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 ---
 
@@ -74,7 +73,7 @@ The output value must be a hash as described above.
 
 ## Updates
 
-Before version <Version version="3.7.0" /> Avo would override the whole attribute with only the payload sent from the client.
+Before version Avo would override the whole attribute with only the payload sent from the client.
 
 ```json
 // Before update.
@@ -91,7 +90,7 @@ Before version <Version version="3.7.0" /> Avo would override the whole attribut
 }
 ```
 
-<VersionReq version="3.7.0" /> will only update the keys that you send from the client.
+will only update the keys that you send from the client.
 
 ```json
 // Before update.

--- a/docs/4.0/fields/boolean_group.md
+++ b/docs/4.0/fields/boolean_group.md
@@ -73,24 +73,7 @@ The output value must be a hash as described above.
 
 ## Updates
 
-Before version Avo would override the whole attribute with only the payload sent from the client.
-
-```json
-// Before update.
-{
-  "feature_enabled": true,
-  "another_feature_enabled": false,
-  "something_else": "some_value" // this will disappear
-}
-
-// After update.
-{
-  "feature_enabled": true,
-  "another_feature_enabled": false,
-}
-```
-
-will only update the keys that you send from the client.
+Avo only updates the keys that you send from the client. Other keys in the stored hash are left unchanged.
 
 ```json
 // Before update.

--- a/docs/4.0/fields/checkbox_list.md
+++ b/docs/4.0/fields/checkbox_list.md
@@ -1,5 +1,4 @@
 ---
-version: "4.0"
 license: community
 ---
 

--- a/docs/4.0/fields/code.md
+++ b/docs/4.0/fields/code.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 ---
 

--- a/docs/4.0/fields/country.md
+++ b/docs/4.0/fields/country.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 ---
 

--- a/docs/4.0/fields/date.md
+++ b/docs/4.0/fields/date.md
@@ -1,8 +1,7 @@
 ---
-version: '1.0'
 license: community
-default_format: 'yyyy-LL-dd'
-default_picker_format: 'Y-m-d'
+default_format: yyyy-LL-dd
+default_picker_format: Y-m-d
 ---
 
 # Date

--- a/docs/4.0/fields/date_time.md
+++ b/docs/4.0/fields/date_time.md
@@ -1,9 +1,8 @@
 ---
-version: '1.0'
 license: community
-field_type: 'date_time'
-default_format: 'yyyy-LL-dd TT'
-default_picker_format: 'Y-m-d H:i:S'
+field_type: date_time
+default_format: "yyyy-LL-dd TT"
+default_picker_format: "Y-m-d H:i:S"
 ---
 
 # DateTime

--- a/docs/4.0/fields/easy_mde.md
+++ b/docs/4.0/fields/easy_mde.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 ---
 

--- a/docs/4.0/fields/external_image.md
+++ b/docs/4.0/fields/external_image.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 ---
 

--- a/docs/4.0/fields/file.md
+++ b/docs/4.0/fields/file.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 ---
 

--- a/docs/4.0/fields/files.md
+++ b/docs/4.0/fields/files.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 ---
 

--- a/docs/4.0/fields/gravatar.md
+++ b/docs/4.0/fields/gravatar.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 ---
 

--- a/docs/4.0/fields/heading.md
+++ b/docs/4.0/fields/heading.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 ---
 

--- a/docs/4.0/fields/hidden.md
+++ b/docs/4.0/fields/hidden.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 ---
 

--- a/docs/4.0/fields/id.md
+++ b/docs/4.0/fields/id.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 ---
 

--- a/docs/4.0/fields/key_value.md
+++ b/docs/4.0/fields/key_value.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 ---
 
@@ -68,8 +67,6 @@ Any string value.
 </Option>
 
 <Option name="`reorder_text`">
-
-<VersionReq version="3.14.0" />
 
 Set a custom label for the tooltip on the reorder by drag-and-drop row button.
 

--- a/docs/4.0/fields/location.md
+++ b/docs/4.0/fields/location.md
@@ -1,7 +1,6 @@
 ---
-version: '2.30'
 license: community
-betaStatus: Open beta
+betaStatus: "Open beta"
 ---
 
 # Location
@@ -56,8 +55,6 @@ This will also render the <Edit /> view with two separate fields to edit the coo
 
 <Option name="`mapkick_options`">
 
-<VersionReq version="3.16.2" />
-
 The `mapkick_options` option allows you to customize the appearance and behavior of the map.
 
 Using this option, you can provide a hash of configuration settings supported by the Mapkick gem, such as specifying the map style, enabling or disabling controls, or adding additional customizations.
@@ -103,8 +100,6 @@ By using `mapkick_options`, you can tailor the map's look and functionality to s
 </Option>
 
 <Option name="`static`">
-
-<VersionReq version="3.16.2" />
 
 The `static` option enables the rendering of a static map leveraging the power of the [mapkick-static](https://github.com/ankane/mapkick-static) gem.
 

--- a/docs/4.0/fields/markdown.md
+++ b/docs/4.0/fields/markdown.md
@@ -1,8 +1,7 @@
 ---
-version: '3.17.0'
 license: community
 betaStatus: Beta
-demoVideo: https://youtu.be/wnWvzQyyo6A?t=2128
+demoVideo: "https://youtu.be/wnWvzQyyo6A?t=2128"
 ---
 
 # Markdown

--- a/docs/4.0/fields/money.md
+++ b/docs/4.0/fields/money.md
@@ -1,5 +1,4 @@
 ---
-version: '3.6'
 license: community
 BetaStatus: Beta
 ---

--- a/docs/4.0/fields/number.md
+++ b/docs/4.0/fields/number.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 ---
 

--- a/docs/4.0/fields/password.md
+++ b/docs/4.0/fields/password.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 ---
 
@@ -12,8 +11,6 @@ field :password, as: :password
 ```
 
 #### Revealable
-
-<VersionReq version="3.13.7" class="mt-2" />
 
 You can set the `revealable` to true to show an "eye" icon that toggles the password between hidden or visible.
 

--- a/docs/4.0/fields/preview.md
+++ b/docs/4.0/fields/preview.md
@@ -1,5 +1,4 @@
 ---
-version: '3.0'
 license: community
 ---
 
@@ -25,4 +24,4 @@ When you want to display a field in the preview popup simply call the `show_on :
 
 ## Authorization
 
-Since version <Version version="3.18.0" /> the preview request authorization is controller with the [`preview?` policy method](./../authorization.html#preview).
+The preview request authorization is controlled with the [`preview?` policy method](./../authorization.html#preview).

--- a/docs/4.0/fields/progress_bar.md
+++ b/docs/4.0/fields/progress_bar.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 ---
 

--- a/docs/4.0/fields/radio.md
+++ b/docs/4.0/fields/radio.md
@@ -1,5 +1,4 @@
 ---
-version: '3.15.0'
 license: community
 ---
 

--- a/docs/4.0/fields/record_link.md
+++ b/docs/4.0/fields/record_link.md
@@ -1,5 +1,4 @@
 ---
-version: '3.7.0'
 license: community
 ---
 

--- a/docs/4.0/fields/rhino.md
+++ b/docs/4.0/fields/rhino.md
@@ -1,5 +1,4 @@
 ---
-version: '3.17.0'
 license: community
 ---
 

--- a/docs/4.0/fields/select.md
+++ b/docs/4.0/fields/select.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 ---
 
@@ -46,8 +45,6 @@ The output value must be a supported [`options_for_select`](https://apidock.com/
 </Option>
 
 <Option name="`grouped_options`">
-
-<VersionReq version="3.22.0" />
 
 When you need to organize your select options into groups, you can use `grouped_options` instead of `options`. This creates optgroups in the select field, making it easier for users to navigate large sets of options.
 
@@ -177,8 +174,6 @@ end
 </Option>
 
 <Option name="`multiple`">
-
-<VersionReq version="3.17.3" />
 
 If it's set to `false` (default), it will only allow selecting a single option from the list.
 

--- a/docs/4.0/fields/status.md
+++ b/docs/4.0/fields/status.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 ---
 

--- a/docs/4.0/fields/tags.md
+++ b/docs/4.0/fields/tags.md
@@ -1,6 +1,5 @@
 ---
 license: community
-version: '2.6.0'
 demoVideo: https://youtu.be/DKKSjNUvuBA
 ---
 
@@ -19,9 +18,7 @@ field :skills, as: :tags
 <Option name="`suggestions`">
 
 :::warning
-**This warning no longer applies** <VersionReq version="3.11.8" />
-
-If you're using this field as `filterable`, dynamic filters are not yet picking these suggestions.
+**This warning no longer applies** If you're using this field as `filterable`, dynamic filters are not yet picking these suggestions.
 
 Please use the custom dynamic filters [suggestions](../dynamic-filters#suggestions) option to specify filter suggestions.
 :::
@@ -297,8 +294,7 @@ To mitigate that use the [`format_using`](tags#format_using) option.
 <Option name="`format_using`" since="3.10">
 
 :::info
-Since <Version version="3.10" />
-:::
+Since :::
 
 The `format_using` option allows you to pass an array of custom strings or hashes to be displayed on the tags field. This option is useful when Avo is displaying a bunch of IDs and you want to show some custom label from that ID's record.
 

--- a/docs/4.0/fields/tags.md
+++ b/docs/4.0/fields/tags.md
@@ -17,12 +17,6 @@ field :skills, as: :tags
 
 <Option name="`suggestions`">
 
-:::warning
-**This warning no longer applies** If you're using this field as `filterable`, dynamic filters are not yet picking these suggestions.
-
-Please use the custom dynamic filters [suggestions](../dynamic-filters#suggestions) option to specify filter suggestions.
-:::
-
 You can give suggestions to your users to pick from which will be displayed to the user as a dropdown under the field.
 
 ```ruby{4,10-12}
@@ -291,10 +285,7 @@ To mitigate that use the [`format_using`](tags#format_using) option.
 
 </Option>
 
-<Option name="`format_using`" since="3.10">
-
-:::info
-Since :::
+<Option name="`format_using`">
 
 The `format_using` option allows you to pass an array of custom strings or hashes to be displayed on the tags field. This option is useful when Avo is displaying a bunch of IDs and you want to show some custom label from that ID's record.
 

--- a/docs/4.0/fields/text.md
+++ b/docs/4.0/fields/text.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 ---
 

--- a/docs/4.0/fields/textarea.md
+++ b/docs/4.0/fields/textarea.md
@@ -1,7 +1,6 @@
 ---
-version: '1.0'
 license: community
-outline: [2,3]
+outline: [2, 3]
 ---
 
 # Textarea

--- a/docs/4.0/fields/time.md
+++ b/docs/4.0/fields/time.md
@@ -1,9 +1,8 @@
 ---
-version: '2.18'
 license: community
-field_type: 'time'
-default_format: 'TT'
-default_picker_format: 'H:i:S'
+field_type: time
+default_format: TT
+default_picker_format: H:i:S
 ---
 
 # Time

--- a/docs/4.0/fields/trix.md
+++ b/docs/4.0/fields/trix.md
@@ -1,5 +1,4 @@
 ---
-version: '1.0'
 license: community
 demo: https://trix.avodemo.com/
 ---
@@ -108,8 +107,6 @@ Trix integrates seamlessly with Action Text. It will automatically work with Act
 We prepared a [demo](https://trix.avodemo.com/) to showcase Trix's abilities to work with Action Text and Active Storage.
 
 ## Javascript Alert Messages
-
-<VersionReq version="3.13.8" />
 
 You can customize the javascript alert messages for various actions in the Trix editor. Below are the default messages that can be translated or modified:
 

--- a/docs/4.0/forms-and-pages/forms.md
+++ b/docs/4.0/forms-and-pages/forms.md
@@ -1,6 +1,6 @@
 ---
 license: add_on
-add_on_link: https://avohq.io/pricing-4?add_ons[]=forms
+add_on_link: "https://avohq.io/pricing-4?add_ons[]=forms"
 add_on: forms_feature
 betaStatus: Beta
 outline: [2, 3]

--- a/docs/4.0/forms-and-pages/guides-and-tutorials.md
+++ b/docs/4.0/forms-and-pages/guides-and-tutorials.md
@@ -1,6 +1,6 @@
 ---
 license: add_on
-add_on_link: https://avohq.io/pricing-4?add_ons[]=forms
+add_on_link: "https://avohq.io/pricing-4?add_ons[]=forms"
 add_on: forms_feature
 betaStatus: Beta
 outline: [2, 3]

--- a/docs/4.0/forms-and-pages/overview.md
+++ b/docs/4.0/forms-and-pages/overview.md
@@ -1,6 +1,6 @@
 ---
 license: add_on
-add_on_link: https://avohq.io/pricing-4?add_ons[]=forms
+add_on_link: "https://avohq.io/pricing-4?add_ons[]=forms"
 add_on: forms_feature
 betaStatus: Beta
 outline: [2, 3]
@@ -104,8 +104,6 @@ end
 ```
 
 ### Add the page to your Avo menu
-
-<LicenseReq license="pro"/>
 
 ```ruby
 # config/initializers/avo.rb

--- a/docs/4.0/forms-and-pages/pages.md
+++ b/docs/4.0/forms-and-pages/pages.md
@@ -1,6 +1,6 @@
 ---
 license: add_on
-add_on_link: https://avohq.io/pricing-4?add_ons[]=forms
+add_on_link: "https://avohq.io/pricing-4?add_ons[]=forms"
 betaStatus: Beta
 outline: [2, 3]
 ---
@@ -318,8 +318,6 @@ end
 ```
 
 ## Adding Pages to the Menu
-
-<LicenseReq license="pro"/>
 
 To make your pages accessible through Avo's main navigation, add them to your Avo configuration:
 

--- a/docs/4.0/guides/generating-components-for-fields.md
+++ b/docs/4.0/guides/generating-components-for-fields.md
@@ -1,6 +1,6 @@
 ---
 license: community
-outline: [2,3]
+outline: [2, 3]
 ---
 
 # Generating a custom component for a field

--- a/docs/4.0/guides/multi-language-urls.md
+++ b/docs/4.0/guides/multi-language-urls.md
@@ -1,5 +1,5 @@
 ---
-outline: [2,3]
+outline: [2, 3]
 ---
 
 # Multi-language URLs

--- a/docs/4.0/header-menu.md
+++ b/docs/4.0/header-menu.md
@@ -1,7 +1,6 @@
 ---
 license: pro
 outline: [2, 3]
-version: "4.0"
 ---
 
 # Header menu

--- a/docs/4.0/html.md
+++ b/docs/4.0/html.md
@@ -1,6 +1,8 @@
 ---
 license: community
-next: {"text" => "Field options", "link" => "/3.0/field-options"}
+next:
+  text: 'Field options'
+  link: '/4.0/field-options'
 ---
 
 # HTML attributes

--- a/docs/4.0/html.md
+++ b/docs/4.0/html.md
@@ -1,8 +1,6 @@
 ---
 license: community
-next:
-  text: 'Field options'
-  link: '/3.0/field-options'
+next: {"text" => "Field options", "link" => "/3.0/field-options"}
 ---
 
 # HTML attributes

--- a/docs/4.0/http-resources.md
+++ b/docs/4.0/http-resources.md
@@ -1,7 +1,7 @@
 ---
-betaStatus: Open Beta
+betaStatus: "Open Beta"
 license: add_on
-add_on_link: https://avohq.io/pricing-4?add_ons[]=http_resource
+add_on_link: "https://avohq.io/pricing-4?add_ons[]=http_resource"
 outline: deep
 ---
 

--- a/docs/4.0/i18n.md
+++ b/docs/4.0/i18n.md
@@ -70,8 +70,6 @@ es:
 
 ## Localizing buttons label
 
-<BetaStatus label="Beta" />
-
 The `avo.save` configuration applies to all save buttons. If you wish to customize the localization for a specific resource, such as `Avo::Resources::Product`, you can achieve this by:
 
 ```yml

--- a/docs/4.0/kanban-boards.md
+++ b/docs/4.0/kanban-boards.md
@@ -1,6 +1,6 @@
 ---
 license: add_on
-add_on_link: https://avohq.io/pricing-4?add_ons[]=kanban-boards
+add_on_link: "https://avohq.io/pricing-4?add_ons[]=kanban-boards"
 betaStatus: Beta
 outline: [2, 3]
 ---

--- a/docs/4.0/map-view.md
+++ b/docs/4.0/map-view.md
@@ -61,9 +61,7 @@ This is the configuration for the adjacent table. You can set the visibility to 
 
 <Option name="`extra_markers`">
 
-Available since version <Version version="3.10.3" />
-
-Allow to define extra markers. The `extra_markers` block is executed in the [`ExecutionContext`](./execution-context) and should return an array of hashes.
+Allows you to define extra markers. The `extra_markers` block is executed in the [`ExecutionContext`](./execution-context) and should return an array of hashes.
 
 For each extra marker, you can specify a label, tooltip, and color.
 

--- a/docs/4.0/mcp.md
+++ b/docs/4.0/mcp.md
@@ -1,7 +1,7 @@
 ---
 license: add_on
-add_on_link: https://avohq.io/pricing-4?add_ons[]=mcp-server
-betaStatus: Not yet released
+add_on_link: "https://avohq.io/pricing-4?add_ons[]=mcp-server"
+betaStatus: "Not yet released"
 outline: [2, 3]
 ---
 

--- a/docs/4.0/media-library.md
+++ b/docs/4.0/media-library.md
@@ -1,7 +1,6 @@
 ---
-version: "3.17.0"
 betaStatus: Alpha
-demoVideo: https://youtu.be/wnWvzQyyo6A?t=1698
+demoVideo: "https://youtu.be/wnWvzQyyo6A?t=1698"
 ---
 
 # Media Library

--- a/docs/4.0/menu-editor.md
+++ b/docs/4.0/menu-editor.md
@@ -2,7 +2,6 @@
 feedbackId: 831
 demoVideo: https://youtu.be/VMvG-j1Vxio
 license: pro
-version: "2.3.0"
 ---
 
 # Menu editor
@@ -375,8 +374,6 @@ end
 ```
 
 ## Add `data` attributes to items
-
-<VersionReq version="2.16" />
 
 You may want to add special data attributes to some items and you can do that using the `data` option. For example you may add `data: {turbo: false}` to make a regular request for a link.
 

--- a/docs/4.0/notifications.md
+++ b/docs/4.0/notifications.md
@@ -1,7 +1,7 @@
 ---
 license: add_on
-add_on_link: https://avohq.io/pricing-4?add_ons[]=notifications
-betaStatus: Not yet released
+add_on_link: "https://avohq.io/pricing-4?add_ons[]=notifications"
+betaStatus: "Not yet released"
 outline: [2, 3]
 ---
 

--- a/docs/4.0/records-reordering.md
+++ b/docs/4.0/records-reordering.md
@@ -1,7 +1,6 @@
 ---
-version: "1.24.2"
 license: pro
-demoVideo: https://www.youtube.com/watch?v=LEALfPiyfRk
+demoVideo: "https://www.youtube.com/watch?v=LEALfPiyfRk"
 ---
 
 # Records ordering
@@ -120,8 +119,6 @@ end
 ```
 
 ## Reorder using drag and drop
-
-<BetaStatus label="Beta"></BetaStatus>
 
 Sometimes just picking up a record and dropping it in the position that you'd like it to be. That's exactly what this feature does.
 

--- a/docs/4.0/resource-header.md
+++ b/docs/4.0/resource-header.md
@@ -1,5 +1,4 @@
 ---
-version: '4.0'
 license: community
 ---
 

--- a/docs/4.0/resource-panels.md
+++ b/docs/4.0/resource-panels.md
@@ -158,7 +158,6 @@ end
 
 <Option name="`visible`">
 
-<VersionReq version="3.10.7" />
 The `visible` option allows you to dynamically control the visibility of a panel and all its children based on certain conditions.
 
 This option is particularly useful when you need to show or hide entire sections of your resource at once without having to do it for each field.

--- a/docs/4.0/resource-tools.md
+++ b/docs/4.0/resource-tools.md
@@ -1,6 +1,6 @@
 ---
 feedbackId: 836
-demoVideo: https://youtu.be/Eex8CiinQZ8?t=196
+demoVideo: "https://youtu.be/Eex8CiinQZ8?t=196"
 license: community
 ---
 

--- a/docs/4.0/resources.md
+++ b/docs/4.0/resources.md
@@ -945,7 +945,9 @@ end
 
 ### Modify controls placement and appearance
 
-Configure where row controls appear on the <Index /> view — placement, floating behavior, and hover visibility — using `row_controls_config`. See [row controls configuration on table view](table-view.html#resource-configuration).
+<!-- @include: ./common/row_controls_config_common.md-->
+
+See [row controls configuration on table view](table-view.html#resource-configuration).
 
 <Option name="`self.pagination`">
 

--- a/docs/4.0/resources.md
+++ b/docs/4.0/resources.md
@@ -393,7 +393,7 @@ This means that other resources that are not declared in this array will not sho
 
 ## Extending `Avo::BaseResource`
 
-<VersionReq version="3.10.7" /> we have restructured the `Avo::BaseResource` to enhance user customization capabilities. The existing functionality has been moved to a new base class `Avo::Resources::Base`, and `Avo::BaseResource` is now left empty for user overrides. This allows users to easily add custom methods that all of their resources will inherit, without having to modify the internal base class.
+we have restructured the `Avo::BaseResource` to enhance user customization capabilities. The existing functionality has been moved to a new base class `Avo::Resources::Base`, and `Avo::BaseResource` is now left empty for user overrides. This allows users to easily add custom methods that all of their resources will inherit, without having to modify the internal base class.
 
 ### How to Customize `Avo::BaseResource`
 
@@ -592,7 +592,6 @@ end
 
 <Option name="`self.confirm_on_save`">
 
-<VersionReq version="3.10.10" />
 If you would like to ask for confirmation when saving a resource you can do so by setting `confirm_on_save` to `true`.
 
 That will help add friction to the saving process, avoiding human error.
@@ -623,7 +622,7 @@ end
 
 Find out more on the [grid view documentation page](grid-view).
 
-<VersionReq version="3.5.6" /> `default_view_type` become callable. Within this block, you gain access to all attributes of [`Avo::ExecutionContext`](execution-context) along with the `resource` and `view`. Example:
+`default_view_type` become callable. Within this block, you gain access to all attributes of [`Avo::ExecutionContext`](execution-context) along with the `resource` and `view`. Example:
 
 ```ruby
 class Avo::Resources::Post < Avo::BaseResource
@@ -818,7 +817,7 @@ self.components = {
 }
 ```
 
-<VersionReq version="3.11.8" /> more components can be replaced. From this version, keys must be strings that match the original component with the exception of those from the snippet above.
+more components can be replaced. From this version, keys must be strings that match the original component with the exception of those from the snippet above.
 
 Here is a list of all the supported customizable components:
 
@@ -892,8 +891,6 @@ end
 
 <Option name="`self.default_sort_column`">
 
-<VersionReq version="3.10.7" />
-
 By default, Avo sorts records on the <Index /> view by the `created_at` attribute. However, you can customize this behavior using the `default_sort_column` option in your resource file.
 
 #### Default
@@ -938,8 +935,6 @@ end
 
 <Option name="`self.default_sort_direction`">
 
-<VersionReq version="3.11.5" />
-
 By default, Avo sorts records in descending order of the [default sort column](./resources#self.default_sort_column). However, you can customize this using the `self.default_sort_direction` option in your resource file.
 
 #### Default
@@ -963,10 +958,8 @@ end
 
 <Option name="`self.controls_placement`">
 
-<VersionReq version="3.13.7" />
-
 :::warning
-<VersionReq version="3.16.3" /> `controls_placement` option is **obsolete**.
+`controls_placement` option is **obsolete**.
 
 Check [row controls configuration on table view](table-view.html#resource-configuration) instead
 :::
@@ -1133,8 +1126,6 @@ end
 
 <Option name="`self.external_link`">
 
-<VersionReq version="3.15.6" />
-
 <br>
 <br>
 
@@ -1163,8 +1154,6 @@ When this option is configured, Avo will display an external link button for the
 </Option>
 
 <Option name="`self.discreet_information`">
-
-<VersionReq version="3.17" />
 
 Oftern we want to show some information about records without adding another field. `discreet_information` does exactly that 🙌
 

--- a/docs/4.0/resources.md
+++ b/docs/4.0/resources.md
@@ -943,15 +943,9 @@ end
 
 </Option>
 
-<Option name="`self.controls_placement`">
+### Modify controls placement and appearance
 
-:::warning
-`controls_placement` option is **obsolete**.
-
-Check [row controls configuration on table view](table-view.html#resource-configuration) instead.
-:::
-
-</Option>
+Configure where row controls appear on the <Index /> view — placement, floating behavior, and hover visibility — using `row_controls_config`. See [row controls configuration on table view](table-view.html#resource-configuration).
 
 <Option name="`self.pagination`">
 

--- a/docs/4.0/resources.md
+++ b/docs/4.0/resources.md
@@ -393,8 +393,6 @@ This means that other resources that are not declared in this array will not sho
 
 ## Extending `Avo::BaseResource`
 
-we have restructured the `Avo::BaseResource` to enhance user customization capabilities. The existing functionality has been moved to a new base class `Avo::Resources::Base`, and `Avo::BaseResource` is now left empty for user overrides. This allows users to easily add custom methods that all of their resources will inherit, without having to modify the internal base class.
-
 ### How to Customize `Avo::BaseResource`
 
 You can customize `Avo::BaseResource` by creating your own version in your application. This custom resource can include methods and logic that you want all your resources to inherit. Here's an example to illustrate how you can do this:

--- a/docs/4.0/resources.md
+++ b/docs/4.0/resources.md
@@ -948,21 +948,8 @@ end
 :::warning
 `controls_placement` option is **obsolete**.
 
-Check [row controls configuration on table view](table-view.html#resource-configuration) instead
+Check [row controls configuration on table view](table-view.html#resource-configuration) instead.
 :::
-
-By default, Avo renders action controls according to the `controls_placement` configuration, which is set to `right` by default. This value can be customized for each individual resource.
-
-#### Possible values
-
-Either `:left`, `:right` or `:both`
-
-```ruby{3}
-# app/avo/resources/task.rb
-class Avo::Resources::Task < Avo::BaseResource
-  self.controls_placement = :both
-end
-```
 
 </Option>
 

--- a/docs/4.0/resources.md
+++ b/docs/4.0/resources.md
@@ -800,32 +800,19 @@ end
 
 <Option name="`self.components`">
 
-By default, for each view we render an component:
+By default, for each view we render a component:
 
 [Index](views.html#Index) -> `Avo::Views::ResourceIndexComponent`<br>
 [Show](views.html#Show) -> `Avo::Views::ResourceShowComponent`<br>
 [New](views.html#New), [Edit](views.html#Edit) -> `Avo::Views::ResourceEditComponent`
 
-It's possible to change this behavior by using the `self.components` resource option.
+Use the `self.components` resource option to swap any of these for your own classes. Keys must be strings that match the original component class name.
 
 ```ruby
 self.components = {
-  resource_index_component: Avo::Views::Users::ResourceIndexComponent,
-  resource_show_component: "Avo::Views::Users::ResourceShowComponent",
-  resource_edit_component: "Avo::Views::Users::ResourceEditComponent",
-  resource_new_component: Avo::Views::Users::ResourceEditComponent
-}
-```
-
-more components can be replaced. From this version, keys must be strings that match the original component with the exception of those from the snippet above.
-
-Here is a list of all the supported customizable components:
-
-```ruby
-self.components = {
-  "Avo::Views::ResourceIndexComponent": Avo::Custom::ResourceIndexComponent,
-  "Avo::Views::ResourceShowComponent": "Avo::Custom::ResourceShowComponent",
-  "Avo::Views::ResourceEditComponent": "Avo::Custom::ResourceEditComponent",
+  "Avo::Views::ResourceIndexComponent": Avo::Views::Users::ResourceIndexComponent,
+  "Avo::Views::ResourceShowComponent": "Avo::Views::Users::ResourceShowComponent",
+  "Avo::Views::ResourceEditComponent": "Avo::Views::Users::ResourceEditComponent",
   "Avo::Index::GridItemComponent": "Avo::Custom::GridItemComponent",
   "Avo::ViewTypes::MapComponent": "Avo::Custom::MapComponent",
   "Avo::ViewTypes::TableComponent": "Avo::Custom::TableComponent",
@@ -834,7 +821,7 @@ self.components = {
 }
 ```
 
-A resource configured with the example above will start using the declared components instead the default ones.
+A resource configured with the example above will start using the declared components instead of the default ones.
 
 :::warning
 The custom view components must ensure that their initializers are configured to receive all the arguments passed during the rendering of a component. You can verify this in our codebase through the following files:
@@ -858,7 +845,7 @@ Example:
 
 ```ruby
 self.components = {
-  resource_index_component: Avo::MyDir::Views::ResourceIndexComponent
+  "Avo::Views::ResourceIndexComponent": Avo::MyDir::Views::ResourceIndexComponent
 }
 ```
 

--- a/docs/4.0/resources.md
+++ b/docs/4.0/resources.md
@@ -622,7 +622,9 @@ end
 
 Find out more on the [grid view documentation page](grid-view).
 
-`default_view_type` become callable. Within this block, you gain access to all attributes of [`Avo::ExecutionContext`](execution-context) along with the `resource` and `view`. Example:
+`default_view_type` can be configured using a Proc.
+
+Within this block, you gain access to all attributes of [`Avo::ExecutionContext`](execution-context) along with the `resource` and `view`.
 
 ```ruby
 class Avo::Resources::Post < Avo::BaseResource

--- a/docs/4.0/rest-api/authentication.md
+++ b/docs/4.0/rest-api/authentication.md
@@ -1,6 +1,6 @@
 ---
 license: add_on
-add_on_link: https://avohq.io/pricing-4?add_ons[]=json-api
+add_on_link: "https://avohq.io/pricing-4?add_ons[]=json-api"
 add_on: avo-api
 betaStatus: Alpha
 outline: [2, 3]

--- a/docs/4.0/rest-api/csrf-protection.md
+++ b/docs/4.0/rest-api/csrf-protection.md
@@ -1,6 +1,6 @@
 ---
 license: add_on
-add_on_link: https://avohq.io/pricing-4?add_ons[]=json-api
+add_on_link: "https://avohq.io/pricing-4?add_ons[]=json-api"
 add_on: avo-api
 betaStatus: Alpha
 outline: [2, 3]

--- a/docs/4.0/rest-api/generators.md
+++ b/docs/4.0/rest-api/generators.md
@@ -1,6 +1,6 @@
 ---
 license: add_on
-add_on_link: https://avohq.io/pricing-4?add_ons[]=json-api
+add_on_link: "https://avohq.io/pricing-4?add_ons[]=json-api"
 add_on: avo-api
 betaStatus: Alpha
 outline: [2, 3]

--- a/docs/4.0/rest-api/index.md
+++ b/docs/4.0/rest-api/index.md
@@ -1,6 +1,6 @@
 ---
 license: add_on
-add_on_link: https://avohq.io/pricing-4?add_ons[]=json-api
+add_on_link: "https://avohq.io/pricing-4?add_ons[]=json-api"
 add_on: avo-api
 betaStatus: Alpha
 outline: [2, 3]

--- a/docs/4.0/rest-api/mount.md
+++ b/docs/4.0/rest-api/mount.md
@@ -1,6 +1,6 @@
 ---
 license: add_on
-add_on_link: https://avohq.io/pricing-4?add_ons[]=json-api
+add_on_link: "https://avohq.io/pricing-4?add_ons[]=json-api"
 add_on: avo-api
 betaStatus: Alpha
 outline: [2, 3]

--- a/docs/4.0/scopes.md
+++ b/docs/4.0/scopes.md
@@ -1,6 +1,6 @@
 ---
 license: advanced
-outline: [2,3]
+outline: [2, 3]
 ---
 
 # Scopes
@@ -48,8 +48,6 @@ end
 ```
 
 <Option name="`default`" headingSize="3">
-
-<VersionReq version="3.11" class="mt-4" />
 
 The `default` option lets you select a default scope that is applied when you
 navigate to the resources page.

--- a/docs/4.0/select-all.md
+++ b/docs/4.0/select-all.md
@@ -18,7 +18,6 @@ The query might include various filters, sorting parameters, and other custom el
 - **Efficiency**: This approach allows the system to accurately and efficiently reconstruct the original query when the action is executed, ensuring that all relevant records are included.
 
 :::warning
-<VersionReq version="3.12.0" />
 If an error occurs during the serialization process, the "Select All" feature is automatically disabled. This safeguard ensures that the page will not crash because of a coding error.
 We listed a few reasons on why it might crash below.
 :::

--- a/docs/4.0/stimulus-integration.md
+++ b/docs/4.0/stimulus-integration.md
@@ -1,7 +1,6 @@
 ---
 feedbackId: 943
-version: "2.8"
-demoVideo: https://www.youtube.com/watch?v=ZMOz22FaAUg
+demoVideo: "https://www.youtube.com/watch?v=ZMOz22FaAUg"
 betaStatus: Beta
 ---
 

--- a/docs/4.0/table-view.md
+++ b/docs/4.0/table-view.md
@@ -8,7 +8,7 @@ The table view is the default way to display resources in Avo. It provides a pow
 :::info
 The configuration options for row controls depend on the version of Avo you are using.
 
-**If you are using a version earlier than <Version version="3.16.3" />**, refer to the following pages for guidance:
+**If you are using a version earlier than **, refer to the following pages for guidance:
 
 - [How to adjust resource controls globally for all resources](customization.html#resource-controls-on-the-left-or-both-sides)
 - [Customize the placement of controls for individual resources](resources.html#self.controls_placement)
@@ -16,7 +16,7 @@ The configuration options for row controls depend on the version of Avo you are 
 
 By default, resource controls are positioned on the right side of record rows. However, if the table contains many columns, these controls may become obscured. In such cases, you may prefer to move the controls to the left side for better visibility.
 
-<VersionReq version="3.16.3" /> Avo provides configuration options that allow you to customize row controls placement, floating behavior, and visibility on hover either globally or individually for each resource.
+Avo provides configuration options that allow you to customize row controls placement, floating behavior, and visibility on hover either globally or individually for each resource.
 
 
 ## Global configuration

--- a/docs/4.0/table-view.md
+++ b/docs/4.0/table-view.md
@@ -5,14 +5,6 @@ The table view is the default way to display resources in Avo. It provides a pow
 <Image src="/assets/img/table-view.png" width="1919" height="1122" alt="Table view" />
 
 ## Row controls configuration
-:::info
-The configuration options for row controls depend on the version of Avo you are using.
-
-**If you are using a version earlier than **, refer to the following pages for guidance:
-
-- [How to adjust resource controls globally for all resources](customization.html#resource-controls-on-the-left-or-both-sides)
-- [Customize the placement of controls for individual resources](resources.html#self.controls_placement)
-:::
 
 By default, resource controls are positioned on the right side of record rows. However, if the table contains many columns, these controls may become obscured. In such cases, you may prefer to move the controls to the left side for better visibility.
 

--- a/docs/4.0/tabs.md
+++ b/docs/4.0/tabs.md
@@ -1,9 +1,8 @@
 ---
 feedbackId: 1073
-version: '2.10'
 license: pro
-demoVideo: https://youtu.be/B1Y-Z-R-Ys8?t=175
-betaStatus: Open beta
+demoVideo: "https://youtu.be/B1Y-Z-R-Ys8?t=175"
+betaStatus: "Open beta"
 ---
 
 # Tabs


### PR DESCRIPTION
## Summary

- Removes all `Since vX` / `Since version X` mentions from Avo 4.0 documentation, including `version` frontmatter, `<VersionReq>`, and `<Version>` inline tags
- Moves page-level labels (license, demo video, beta status) into frontmatter where they were previously inlined in the body
- Cleans up shared partials under `docs/4.0/common/` that duplicated top-page label components

## Test plan

- [ ] Spot-check a few updated pages (e.g. dashboards, dynamic-filters, searchable associations, actions overview) and confirm the page header pills still render correctly
- [ ] Verify no `Since v` badges remain in 4.0 docs content
- [ ] Confirm section-level demo videos deeper in pages still render where expected


Made with [Cursor](https://cursor.com)