### PR TITLE
docs(kanban): document search_type: :kanban and the params[:for_kanba…

### DIFF
--- a/docs/4.0/avo-3-avo-4-upgrade.md
+++ b/docs/4.0/avo-3-avo-4-upgrade.md
@@ -233,15 +233,18 @@ end
 
 ##### Use `search_type` instead of `params[:global]` / `params[:via_association]`
 
-Avo 4 injects a `search_type` local into every `self.search[:query]` proc, with one of three values depending on which surface triggered the search:
+Avo 4 injects a `search_type` local into every `self.search[:query]` proc, with one of four values depending on which surface triggered the search:
 
 | `search_type` | Surface                                | v3 detection                                |
 |---------------|----------------------------------------|---------------------------------------------|
 | `:global`     | Navbar ⌘K palette                      | `params[:global]`                           |
 | `:resource`   | Resource-index search bar              | Falsey `params[:global]` (no `via_association`) |
 | `:association`| Searchable association picker          | `params[:via_association] == 'has_many'`    |
+| `:kanban`     | Kanban board "add a card" picker       | `params[:for_kanban_board] == '1'`          |
 
 `params[:via_association]` has been removed. The v4 picker no longer sets it, which means any `if params[:via_association] == 'has_many'` branch will silently fall through to `else`. There's no error, just the wrong scope applied. This branch must be migrated.
+
+`params[:for_kanban_board]` has also been removed. The kanban picker no longer sets it, so any `if params[:for_kanban_board] == '1'` branch will silently fall through to `else`. Migrate it to `search_type == :kanban`.
 
 `params[:global]` still works but is superseded. It can't distinguish `:resource` from `:association`, so `search_type` is the preferred option going forward.
 
@@ -254,6 +257,9 @@ self.search = {
     elsif params[:via_association] == 'has_many' # [!code --]
     elsif search_type == :association             # [!code ++]
       query.ransack(name_cont: q).result.order(name: :asc)
+    elsif params[:for_kanban_board] == '1'        # [!code --]
+    elsif search_type == :kanban                  # [!code ++]
+      query.where(active: true).ransack(name_cont: q).result
     else # :resource
       query.ransack(id_eq: q, details_cont: q, m: "or").result(distinct: false)
     end

--- a/docs/4.0/common/search_type_common.md
+++ b/docs/4.0/common/search_type_common.md
@@ -1,12 +1,13 @@
 ## `search_type`
 
-The same `self.search[:query]` proc runs from three surfaces. To branch per surface, use the `search_type` local.
+The same `self.search[:query]` proc runs from four surfaces. To branch per surface, use the `search_type` local.
 
 | Value | Surface |
 |---|---|
 | `:resource` | resource-index search bar (and the standalone `/search` endpoint) |
 | `:global` | navbar ⌘K palette |
 | `:association` | [searchable association picker](./../associations/searchable) on edit forms and the attach modal |
+| `:kanban` | [kanban board](./../kanban-boards) "add a card" picker |
 
 ```ruby
 class Avo::Resources::User < Avo::BaseResource
@@ -19,6 +20,8 @@ class Avo::Resources::User < Avo::BaseResource
         query.ransack(first_name_cont: q, last_name_cont: q, m: "or").result(distinct: false)
       when :association # picker — tightest
         query.ransack(first_name_cont: q).result(distinct: false)
+      when :kanban      # kanban "add a card" picker
+        query.ransack(first_name_cont: q, last_name_cont: q, m: "or").result(distinct: false)
       end
     }
   }

--- a/docs/4.0/kanban-boards.md
+++ b/docs/4.0/kanban-boards.md
@@ -88,7 +88,26 @@ Similar we can change the column names and the value from the settings screen.
 ## Adding items to the board
 
 This is best done on the board. Under each column you'll find the new field. This will search throught the resources that you've selected in the configuration.
-It will use the `self.search[:query]` block to search for the records. It will send two `for_kanban_board` and `board_id` arguments to the block so you can customize the query.
+It will use the `self.search[:query]` block to search for the records. Alongside the usual `params` and `query`, the block receives these locals so you can customize the query for the board:
+
+- `search_type` — set to `:kanban` (the same contract the other search surfaces use: `:resource` for the index search bar, `:global` for the navbar palette, and `:association` for the association picker).
+- `q` — the stripped search term the user typed.
+
+```ruby
+# app/avo/resources/project.rb
+class Avo::Resources::Project < Avo::BaseResource
+  self.search = {
+    query: -> {
+      if search_type == :kanban
+        # tailor the scope for the board picker
+        query.where(active: true).ransack(name_cont: q).result
+      else
+        query.ransack(name_cont: q).result
+      end
+    }
+  }
+end
+```
 
 When an item is added to the a column, it will have an `Avo::Kanban::Item` record created for it. This `Item` record is responsible for keeping track of the board, column, position properties and more.
 

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -3,3 +3,37 @@
 We'll update this page when we release new Avo 4 versions.
 
 If you're looking for the Avo 3 to Avo 4 upgrade guide, please visit [the dedicated page](./avo-3-avo-4-upgrade).
+
+## Upgrade `avo-kanban` to 4.0.0.beta.5
+
+<Option name="Kanban search procs receive `search_type: :kanban` instead of `params[:for_kanban_board]`">
+
+### Breaking Change
+
+The kanban "add a card" picker used to send a `for_kanban_board=1` query param, reachable in your `self.search[:query]` proc via `params[:for_kanban_board]`. That param is no longer sent.
+
+Instead, the picker now injects `search_type: :kanban` (and `q`) into the proc, matching Avo's other search surfaces (`:resource`, `:global`, `:association`). See [`search_type`](./search/resource-search#search-type).
+
+### Action Required
+
+If any of your `self.search[:query]` procs branch on `params[:for_kanban_board]`, switch them to `search_type`:
+
+```ruby
+# app/avo/resources/project.rb
+class Avo::Resources::Project < Avo::BaseResource
+  self.search = {
+    query: -> {
+      if params[:for_kanban_board] == "1" # [!code --]
+      if search_type == :kanban # [!code ++]
+        query.where(active: true).ransack(name_cont: q).result
+      else
+        query.ransack(name_cont: q).result
+      end
+    }
+  }
+end
+```
+
+If your search proc doesn't reference `for_kanban_board`, no change is needed.
+
+</Option>

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -3,37 +3,3 @@
 We'll update this page when we release new Avo 4 versions.
 
 If you're looking for the Avo 3 to Avo 4 upgrade guide, please visit [the dedicated page](./avo-3-avo-4-upgrade).
-
-## Upgrade `avo-kanban` to 4.0.0.beta.5
-
-<Option name="Kanban search procs receive `search_type: :kanban` instead of `params[:for_kanban_board]`">
-
-### Breaking Change
-
-The kanban "add a card" picker used to send a `for_kanban_board=1` query param, reachable in your `self.search[:query]` proc via `params[:for_kanban_board]`. That param is no longer sent.
-
-Instead, the picker now injects `search_type: :kanban` (and `q`) into the proc, matching Avo's other search surfaces (`:resource`, `:global`, `:association`). See [`search_type`](./search/resource-search#search-type).
-
-### Action Required
-
-If any of your `self.search[:query]` procs branch on `params[:for_kanban_board]`, switch them to `search_type`:
-
-```ruby
-# app/avo/resources/project.rb
-class Avo::Resources::Project < Avo::BaseResource
-  self.search = {
-    query: -> {
-      if params[:for_kanban_board] == "1" # [!code --]
-      if search_type == :kanban # [!code ++]
-        query.where(active: true).ransack(name_cont: q).result
-      else
-        query.ransack(name_cont: q).result
-      end
-    }
-  }
-end
-```
-
-If your search proc doesn't reference `for_kanban_board`, no change is needed.
-
-</Option>


### PR DESCRIPTION
## What
  Document the kanban `search_type` and the related breaking change.
  
  ## Changes
  - Add a `:kanban` row to the `search_type` table (now four surfaces)
  - Rewrite the kanban-boards "Adding items" section — it claimed `for_kanban_board`/`board_id` were passed to the search block
  - Add an `upgrade.md` entry covering the `params[:for_kanban_board]` removal with a before/after migration to `search_type == :kanban`