### PR TITLE
Document explicit_authorization default change in Avo 3→4 upgrade guide

### DIFF
--- a/docs/4.0/avo-3-avo-4-upgrade.md
+++ b/docs/4.0/avo-3-avo-4-upgrade.md
@@ -914,3 +914,19 @@ end
 ```
 
 More info on the [`always_expanded` option](./dynamic-filters.html#always_expanded) section.
+
+## `explicit_authorization` default changed to `true`
+
+In Avo 3 the default for `config.explicit_authorization` was `false`, so an action whose policy class or method was missing fell back to being **authorized**. In Avo 4 the default was flipped to `true`, so any action without an explicit policy method is now **denied** by default.
+
+This is a safer default, but it can hide records, fields, or actions that were previously visible if your policies are incomplete. **Review your policies** to make sure every action you expect to be available has a corresponding policy method defined.
+
+If you want to restore the previous behavior, set the option back to `false` in your `config/initializers/avo.rb`:
+
+```ruby
+Avo.configure do |config|
+  config.explicit_authorization = false
+end
+```
+
+More info on the [`explicit_authorization` option](./authorization.html#explicit_authorization) section.

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -3,32 +3,3 @@
 We'll update this page when we release new Avo 4 versions.
 
 If you're looking for the Avo 3 to Avo 4 upgrade guide, please visit [the dedicated page](./avo-3-avo-4-upgrade).
-
-## Upgrade to 4.0.0.beta.45
-
-<Option name="`explicit_authorization` now defaults to `true`">
-
-### Breaking Change
-
-The default value of `config.explicit_authorization` changed from `false` to `true`.
-
-With explicit authorization enabled, Avo no longer falls back to a permissive default when a policy method is missing — any action whose policy method isn't defined is treated as **not authorized**. This is a safer default, but it can hide records, fields, or actions that were previously visible if your policies are incomplete.
-
-### Action Required
-
-**Review your policies** to make sure every action you expect to be available has a corresponding policy method defined. Pay special attention to resources that rely on the previous permissive fallback.
-
-### Maintaining Previous Behavior
-
-If you want to keep the old behavior, set the option back to `false` in your initializer:
-
-```ruby
-# config/initializers/avo.rb
-Avo.configure do |config|
-  config.explicit_authorization = false
-end
-```
-
-See the [authorization documentation](./authorization.html) for more details on how explicit authorization works.
-
-</Option>

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -3,3 +3,32 @@
 We'll update this page when we release new Avo 4 versions.
 
 If you're looking for the Avo 3 to Avo 4 upgrade guide, please visit [the dedicated page](./avo-3-avo-4-upgrade).
+
+## Upgrade to 4.0.0.beta.45
+
+<Option name="`explicit_authorization` now defaults to `true`">
+
+### Breaking Change
+
+The default value of `config.explicit_authorization` changed from `false` to `true`.
+
+With explicit authorization enabled, Avo no longer falls back to a permissive default when a policy method is missing — any action whose policy method isn't defined is treated as **not authorized**. This is a safer default, but it can hide records, fields, or actions that were previously visible if your policies are incomplete.
+
+### Action Required
+
+**Review your policies** to make sure every action you expect to be available has a corresponding policy method defined. Pay special attention to resources that rely on the previous permissive fallback.
+
+### Maintaining Previous Behavior
+
+If you want to keep the old behavior, set the option back to `false` in your initializer:
+
+```ruby
+# config/initializers/avo.rb
+Avo.configure do |config|
+  config.explicit_authorization = false
+end
+```
+
+See the [authorization documentation](./authorization.html) for more details on how explicit authorization works.
+
+</Option>


### PR DESCRIPTION
## Summary

Documents the change in avo-hq/avo#4553, which flips the default of `config.explicit_authorization` from `false` to `true` in Avo 4.

Adds an `## explicit_authorization default changed to true` section to the **Avo 3 to Avo 4 upgrade guide**, alongside the other default-change notes (e.g. Dynamic Filters `always_expanded`). It explains that missing policy methods are now denied by default, the action required (review policies for completeness), and how to opt back into the old permissive behavior.

The `authorization.md` reference page already documents the `true` default, so no change was needed there.