### PR TITLE
Use diff markers in scope BaseScope upgrade example

### DIFF
--- a/docs/4.0/avo-3-avo-4-upgrade.md
+++ b/docs/4.0/avo-3-avo-4-upgrade.md
@@ -659,11 +659,8 @@ Every scope class under `app/avo/scopes/` must inherit from **`Avo::Scopes::Base
 
 ```ruby
 # app/avo/scopes/admins.rb
-# before
-class Avo::Scopes::Admins < Avo::Advanced::Scopes::BaseScope
-
-# after
-class Avo::Scopes::Admins < Avo::Scopes::BaseScope
+class Avo::Scopes::Admins < Avo::Advanced::Scopes::BaseScope # [!code --]
+class Avo::Scopes::Admins < Avo::Scopes::BaseScope # [!code ++]
 ```
 
 Search your app for any remaining references:


### PR DESCRIPTION
## Summary
- Update the Resource scopes section in the Avo 3 → 4 upgrade guide to use `--`/`++` code highlights instead of before/after comments

## Test plan
- [ ] Upgrade guide renders the scope example with diff styling on the docs site


Made with [Cursor](https://cursor.com)