### PR TITLE
Revert avo-records_reordering to avo-record_reordering (AVO-1364)

### DIFF
--- a/docs/4.0/avo-3-avo-4-upgrade.md
+++ b/docs/4.0/avo-3-avo-4-upgrade.md
@@ -87,7 +87,7 @@ source "https://packager.dev/avo-hq/" do
   gem "avo-authorization", ">= 4.0.0"
   gem "avo-advanced_search", ">= 4.0.0"
   gem "avo-advanced_file_uploads", ">= 4.0.0"
-  gem "avo-records_reordering", ">= 4.0.0"
+  gem "avo-record_reordering", ">= 4.0.0"
   gem "avo-menu_editor", ">= 4.0.0"
   gem "avo-menu", ">= 4.0.0"
   gem "avo-dashboards", ">= 4.0.0"
@@ -640,7 +640,7 @@ Add only the gems for the features you use.
 | [Menu editor](./menu-editor)                                                                  | `avo-menu`              |
 | [Global search](./search/global-search), [searchable associations](./associations/searchable) | `avo-advanced_search`   |
 | [Authorization](./authorization)                                                              | `avo-authorization`     |
-| [Record reordering](./records-reordering)                                                     | `avo-records_reordering` |
+| [Record reordering](./records-reordering)                                                     | `avo-record_reordering` |
 
 If your `Gemfile` had `avo-pro`, remove it and add the gems for the features you use:
 
@@ -651,7 +651,7 @@ source "https://packager.dev/avo-hq/" do
   gem "avo-menu", ">= 4.0.0.beta" # [!code ++]
   gem "avo-advanced_search", ">= 4.0.0.beta" # [!code ++]
   gem "avo-authorization", ">= 4.0.0.beta" # [!code ++]
-  gem "avo-records_reordering", ">= 4.0.0.beta" # [!code ++]
+  gem "avo-record_reordering", ">= 4.0.0.beta" # [!code ++]
 end
 ```
 
@@ -675,7 +675,7 @@ source "https://packager.dev/avo-hq/" do
   gem "avo-menu", ">= 4.0.0.beta" # [!code ++]
   gem "avo-advanced_search", ">= 4.0.0.beta" # [!code ++]
   gem "avo-authorization", ">= 4.0.0.beta" # [!code ++]
-  gem "avo-records_reordering", ">= 4.0.0.beta" # [!code ++]
+  gem "avo-record_reordering", ">= 4.0.0.beta" # [!code ++]
   gem "avo-scopes", ">= 4.0.0.beta" # [!code ++]
   gem "avo-custom_controls", ">= 4.0.0.beta" # [!code ++]
   gem "avo-dynamic_filters", ">= 4.0.0.beta" # [!code ++]


### PR DESCRIPTION
## Summary
- Restores Avo 4 upgrade guide gem name references

## Test plan
- [ ] Docs build passes

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/avo-hq/codesmith/docs.avohq.io/pr/528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784297703&installation_id=139851646&pr_number=528&repository=avo-hq%2Fdocs.avohq.io&return_to=https%3A%2F%2Fgithub.com%2Favo-hq%2Fdocs.avohq.io%2Fpull%2F528&signature=298e1524a83776b9c6d757c28904798022f4b2e536284617aafe0fd596ac0240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->