### PR TITLE
Remove leaked pricing-4 URLs

### DIFF
--- a/docs/.vitepress/theme/components/LicenseReq.vue
+++ b/docs/.vitepress/theme/components/LicenseReq.vue
@@ -31,7 +31,6 @@ const labels = {
   custom: "Custom",
   add_on: "Add-on",
 };
-console.log(props);
 const href = computed(() => {
   if (props.add_on_link) {
     return props.add_on_link;

--- a/docs/3.0/collaborate/authorization.md
+++ b/docs/3.0/collaborate/authorization.md
@@ -1,6 +1,5 @@
 ---
 license: add_on
-add_on_link: https://avohq.io/pricing-4?add_ons[]=collaboration
 add_on: collaboration_feature
 betaStatus: Beta
 outline: [2, 3]

--- a/docs/3.0/collaborate/overview.md
+++ b/docs/3.0/collaborate/overview.md
@@ -1,6 +1,5 @@
 ---
 license: add_on
-add_on_link: https://avohq.io/pricing-4?add_ons[]=collaboration
 add_on: collaboration_feature
 betaStatus: Beta
 outline: [2, 3]

--- a/docs/3.0/kanban-boards.md
+++ b/docs/3.0/kanban-boards.md
@@ -1,6 +1,5 @@
 ---
 license: add_on
-add_on_link: https://avohq.io/pricing-4?add_ons[]=kanban-boards
 betaStatus: Beta
 outline: [2, 3]
 ---

--- a/docs/4.0/avo-3-avo-4-upgrade.md
+++ b/docs/4.0/avo-3-avo-4-upgrade.md
@@ -4,8 +4,8 @@ outline: [2, 3]
 
 # Upgrade guide
 
-:::info Subscribe to Avo 4
-Ensure you have an active Avo 4 subscription from https://avohq.io/pricing-4
+:::info Stay up to date
+The up-to-date status of all the gems is available at [github.com/avo-hq/avo/issues/4349](https://github.com/avo-hq/avo/issues/4349)
 :::
 
 The upgrade process from Avo 3 to Avo 4 contains several important improvements and changes.
@@ -55,9 +55,15 @@ Depending on how you use Avo you might not need to do all the steps.
 
 ## Get started with Avo 4
 
+:::info Beta access and private gems
+During the Avo 4 open beta, you can try **all** Avo gems (including Pro, Advanced, and other private gems) **regardless of your subscription tier**, including on Community. See [Avo 4 status and feedback #4349](https://github.com/avo-hq/avo/issues/4349) for the latest. Once Avo 4 pricing is finalized, you will need an appropriate paid license to keep using paid gems.
+
+Private beta gems are still served from `packager.dev`. After you enroll at [avohq.io/try-4](https://avohq.io/try-4), your licenses (including Community) include a **Gem Server Token** on your [license page](https://v3.avohq.io/licenses). Configure Bundler with that token so `bundle install` can download private gems. Follow [Gem server authentication](./gem-server-authentication).
+:::
+
 Assuming you are upgrading your Avo 3 app, you need to do three things:
 
-1. Subscribe to Avo 4 [here](https://avohq.io/pricing-4).
+1. Enroll to the Avo 4 beta program by going to [avohq.io/try-4](https://avohq.io/try-4).
 
 2. Upgrade your Avo gems
 

--- a/docs/4.0/collaboration/authorization.md
+++ b/docs/4.0/collaboration/authorization.md
@@ -1,6 +1,5 @@
 ---
 license: add_on
-add_on_link: "https://avohq.io/pricing-4?add_ons[]=collaboration"
 add_on: collaboration_feature
 betaStatus: Beta
 outline: [2, 3]

--- a/docs/4.0/collaboration/overview.md
+++ b/docs/4.0/collaboration/overview.md
@@ -1,6 +1,5 @@
 ---
 license: add_on
-add_on_link: "https://avohq.io/pricing-4?add_ons[]=collaboration"
 add_on: collaboration_feature
 betaStatus: Beta
 outline: [2, 3]

--- a/docs/4.0/forms-and-pages/forms-api.md
+++ b/docs/4.0/forms-and-pages/forms-api.md
@@ -1,6 +1,5 @@
 ---
 license: add_on
-add_on_link: "https://avohq.io/pricing-4?add_ons[]=forms"
 add_on: forms_feature
 betaStatus: Beta
 outline: [2, 3]

--- a/docs/4.0/forms-and-pages/forms.md
+++ b/docs/4.0/forms-and-pages/forms.md
@@ -1,6 +1,5 @@
 ---
 license: add_on
-add_on_link: "https://avohq.io/pricing-4?add_ons[]=forms"
 add_on: forms_feature
 betaStatus: Beta
 outline: [2, 3]

--- a/docs/4.0/forms-and-pages/overview.md
+++ b/docs/4.0/forms-and-pages/overview.md
@@ -1,6 +1,5 @@
 ---
 license: add_on
-add_on_link: "https://avohq.io/pricing-4?add_ons[]=forms"
 add_on: forms_feature
 betaStatus: Beta
 outline: [2, 3]

--- a/docs/4.0/forms-and-pages/pages-api.md
+++ b/docs/4.0/forms-and-pages/pages-api.md
@@ -1,6 +1,5 @@
 ---
 license: add_on
-add_on_link: "https://avohq.io/pricing-4?add_ons[]=forms"
 betaStatus: Beta
 outline: [2, 3]
 guide: ./pages.html

--- a/docs/4.0/forms-and-pages/pages.md
+++ b/docs/4.0/forms-and-pages/pages.md
@@ -1,6 +1,5 @@
 ---
 license: add_on
-add_on_link: "https://avohq.io/pricing-4?add_ons[]=forms"
 betaStatus: Beta
 outline: [2, 3]
 api_docs: ./pages-api.html

--- a/docs/4.0/http-resources.md
+++ b/docs/4.0/http-resources.md
@@ -1,7 +1,6 @@
 ---
 betaStatus: "Open Beta"
 license: add_on
-add_on_link: "https://avohq.io/pricing-4?add_ons[]=http_resource"
 outline: deep
 ---
 

--- a/docs/4.0/kanban-boards.md
+++ b/docs/4.0/kanban-boards.md
@@ -1,6 +1,5 @@
 ---
 license: add_on
-add_on_link: https://avohq.io/pricing-4?add_ons[]=kanban-boards
 betaStatus: Beta
 outline: [2, 3]
 ---

--- a/docs/4.0/mcp.md
+++ b/docs/4.0/mcp.md
@@ -1,6 +1,5 @@
 ---
 license: add_on
-add_on_link: "https://avohq.io/pricing-4?add_ons[]=mcp-server"
 betaStatus: "Not yet released"
 outline: [2, 3]
 ---

--- a/docs/4.0/notifications.md
+++ b/docs/4.0/notifications.md
@@ -1,6 +1,5 @@
 ---
 license: add_on
-add_on_link: "https://avohq.io/pricing-4?add_ons[]=notifications"
 betaStatus: "Not yet released"
 outline: [2, 3]
 ---

--- a/docs/4.0/rest-api/authentication.md
+++ b/docs/4.0/rest-api/authentication.md
@@ -1,6 +1,5 @@
 ---
 license: add_on
-add_on_link: "https://avohq.io/pricing-4?add_ons[]=json-api"
 add_on: avo-api
 betaStatus: Alpha
 outline: [2, 3]

--- a/docs/4.0/rest-api/csrf-protection.md
+++ b/docs/4.0/rest-api/csrf-protection.md
@@ -1,6 +1,5 @@
 ---
 license: add_on
-add_on_link: "https://avohq.io/pricing-4?add_ons[]=json-api"
 add_on: avo-api
 betaStatus: Alpha
 outline: [2, 3]

--- a/docs/4.0/rest-api/generators.md
+++ b/docs/4.0/rest-api/generators.md
@@ -1,6 +1,5 @@
 ---
 license: add_on
-add_on_link: "https://avohq.io/pricing-4?add_ons[]=json-api"
 add_on: avo-api
 betaStatus: Alpha
 outline: [2, 3]

--- a/docs/4.0/rest-api/index.md
+++ b/docs/4.0/rest-api/index.md
@@ -1,6 +1,5 @@
 ---
 license: add_on
-add_on_link: "https://avohq.io/pricing-4?add_ons[]=json-api"
 add_on: avo-api
 betaStatus: Alpha
 outline: [2, 3]

--- a/docs/4.0/rest-api/mount.md
+++ b/docs/4.0/rest-api/mount.md
@@ -1,6 +1,5 @@
 ---
 license: add_on
-add_on_link: "https://avohq.io/pricing-4?add_ons[]=json-api"
 add_on: avo-api
 betaStatus: Alpha
 outline: [2, 3]


### PR DESCRIPTION
## Summary
- Remove 19 `add_on_link` frontmatter entries pointing at private `avohq.io/pricing-4` from add-on doc pages
- Restore public beta enrollment (`try-4`) and GitHub #4349 status callouts on the Avo 3→4 upgrade guide
- License badges on add-on pages fall back to SavvyCal booking links via `add_on` frontmatter
- Remove leftover `console.log` debug in `LicenseReq.vue`

## Test plan
- [x] `git grep pricing-4` returns zero matches
- [ ] Spot-check one add-on page (e.g. Kanban) — license badge should link to SavvyCal, not `pricing-4`
- [ ] Spot-check upgrade guide — top callout links to GitHub #4349; step 1 links to `try-4`


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/avo-hq/codesmith/docs.avohq.io/pr/531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784735768&installation_id=139851646&pr_number=531&repository=avo-hq%2Fdocs.avohq.io&return_to=https%3A%2F%2Fgithub.com%2Favo-hq%2Fdocs.avohq.io%2Fpull%2F531&signature=254a5daec03f77cafbc5bc698ac6146fc884c92ef00f4d126125c644000fd7d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->