### PR TITLE
Clean up screenshot harness: drop scratch probes, update skill docs

### DIFF
--- a/.claude/skills/docs-screenshots/SKILL.md
+++ b/.claude/skills/docs-screenshots/SKILL.md
@@ -46,14 +46,21 @@ image bytes, or rule-checking transcripts yourself — workers do that and retur
 
 ## Hard rules (pass these into every worker)
 
-- **Read `tools/screenshots/RULES.md` first and obey ALL of it** — every lesson, not a subset:
-  capture approach (1–5), demo techniques (6–9), editorial (10–14, e.g. image-after-code,
-  match the code example), and the framing lessons (15, 15a–15v, 16–20).
-- **Before any temp demo edit, run `git -C gems/main.avodemo.com status`** and treat every
-  file that already has uncommitted changes as OFF-LIMITS — that's the user's work-in-progress,
-  and reverting it would destroy their changes. Only temp-edit otherwise-clean resource files,
-  then **revert every edit** (`git -C gems/main.avodemo.com checkout <file>`) so the demo shows
-  ONLY the user's pre-existing changes. Leave it at that clean baseline.
+- **Read `tools/screenshots/CHECKLIST.md` first and obey ALL of it** — the compact rulebook
+  covering every rule for the common case (setup, context, single-field, framing/sizing,
+  marking, border hygiene, editorial, apply, GIFs). Each line is tagged with the source `#ref`
+  in `RULES.md`; **open the full lesson in `RULES.md` only for an unusual shot or when a `#ref`
+  line doesn't fully answer your case** (developer overlays, canvas charts, native `<select>`
+  popups, odd width/border edge cases). Obeying the checklist = obeying the rules — it loses no
+  enforceable rule, just the long-form prose. Don't skip a line because it seems minor.
+- **The `main.avodemo.com` demo is disposable scratch space — don't track its state, move fast.**
+  Edit whatever you need (resource files, controllers, models, initializer, seeds), reuse whatever
+  already fits, and create resources/controllers/models from scratch when nothing does. You do NOT
+  need to preserve or restore the demo: no `git status` pre-check, no treating modified files as
+  off-limits, no reverting. Do what the shot needs and leave the demo as-is. (This freedom is ONLY
+  for the demo project — still never commit/push there, and never touch the docs repo beyond the
+  intended doc + asset changes.) Note: the initializer does not hot-reload, so restart the overmind
+  `web` process after editing it; resource/controller files hot-reload on their own.
 - **Capture light AND dark**, every image.
 - **Never commit / push / branch / PR.** Leave changes unstaged.
 - If a shot needs a UI state the demo can't reach (missing data, no Mapbox token, demo drift),
@@ -70,16 +77,19 @@ image bytes, or rule-checking transcripts yourself — workers do that and retur
 > (If this is a retry, also: previous verify failures = `{reasons}` — fix exactly these.)
 >
 > **Steps:**
-> 1. Read `tools/screenshots/RULES.md` (all framing lessons) and `tools/screenshots/PROCESS.md`.
+> 1. Read `tools/screenshots/CHECKLIST.md` (the compact rulebook — obey every line) and
+>    `tools/screenshots/PROCESS.md`. Open the matching lesson in `RULES.md` by its `#ref` only
+>    when a shot is unusual or a checklist line doesn't fully answer your case.
 > 2. Understand the feature from the prompt + section + adjacent code. Find where it lives in
 >    the demo: read the relevant `gems/main.avodemo.com/app/avo/resources/*.rb`, and use
 >    `node tools/screenshots/probe.mjs <path> [selector]` to inspect the live DOM and get exact
 >    selectors / bounding boxes. Never eyeball coordinates.
-> 3. If the state isn't visible by default, make the **smallest reversible** temp edit to a
->    demo resource to surface it — see PROCESS.md "Surfacing specific field / component states"
->    for the virtual-field method + the date_time / boolean_group / progress_bar / actions_list
->    tricks. FIRST run `git -C gems/main.avodemo.com status`; NEVER edit a file that already has
->    uncommitted changes (that's the user's WIP) — pick an otherwise-clean resource.
+> 3. If the state isn't visible by default, edit the demo to surface it — see PROCESS.md "Surfacing
+>    specific field / component states" for the virtual-field method + the date_time / boolean_group
+>    / progress_bar / actions_list tricks. The demo is disposable scratch space: edit any file, reuse
+>    what fits, or create a resource/controller/model from scratch — no `git status` check, no
+>    off-limits files. (Initializer edits need an overmind `web` restart; resource/controller files
+>    hot-reload.)
 > 4. Author a spec object and **append it to `tools/screenshots/specs.mjs`** (add it to the
 >    `SPECS` array). Shape:
 >    `{ id, path, viewport?, settle?, prepare?, selector|clip, pad?, marks?, out, display?, alt, source:{file,prompt} }`
@@ -94,10 +104,10 @@ image bytes, or rule-checking transcripts yourself — workers do that and retur
 >    `node tools/screenshots/capture.mjs <id>` then
 >    `AVO_COLOR_SCHEME=dark node tools/screenshots/capture.mjs <id>`. If the spec has `marks`,
 >    also run `annotate.mjs` (+ `ANNOTATE_DARK=1`).
-> 6. **Revert every temp demo edit** and confirm `git -C gems/main.avodemo.com status` shows only
->    the user's pre-existing files. Confirm `tools/screenshots/out/<id>.png` and `<id>-dark.png` exist.
+> 6. Leave the demo as-is — no need to revert your edits. Confirm `tools/screenshots/out/<id>.png`
+>    and `<id>-dark.png` exist.
 > 7. **Return ONLY a short summary** (no transcripts): `{ id, status: "resolved"|"unresolvable",
->    route, prepareUsed, tempEdits: "none"|"reverted", reason? }`.
+>    route, prepareUsed, demoEdits?: "<what you changed>", reason? }`.
 > Never commit/push. Never stage anything.
 
 ### GIF route addendum (paste this INSTEAD of steps 4–5 when `kind === "gif"`)
@@ -121,7 +131,7 @@ image bytes, or rule-checking transcripts yourself — workers do that and retur
 >    `node tools/screenshots/record-gif.mjs <id>` then
 >    `AVO_COLOR_SCHEME=dark node tools/screenshots/record-gif.mjs <id>`.
 >    Confirm `tools/screenshots/out/<id>.gif` and `<id>-dark.gif` exist. (Then steps 6–7 as above —
->    revert temp edits, return the short summary; set `route: "gif"`.)
+>    leave the demo as-is, return the short summary; set `route: "gif"`.)
 > If the interaction can't be driven reliably (state unreachable, element never appears), flag it
 > `unresolvable` with a reason — never ship a misleading animation.
 
@@ -138,7 +148,8 @@ image bytes, or rule-checking transcripts yourself — workers do that and retur
 > say so in `reasons` and pass on framing alone unless the frame itself violates a rule.
 >
 > **Steps:**
-> 1. Read `tools/screenshots/RULES.md` (framing lessons 1–20, 15a–15v).
+> 1. Read `tools/screenshots/CHECKLIST.md` (the compact rulebook — judge against every line).
+>    Open a lesson in `RULES.md` by its `#ref` only if a checklist line is ambiguous for this shot.
 > 2. **View both PNGs** (Read tool renders images). Check:
 >    - It shows what the prompt asks for, with trigger context where relevant (15a).
 >    - The component is shown WHOLE — none of its real controls/affordances are missing (15y). A

--- a/tools/screenshots/.gitignore
+++ b/tools/screenshots/.gitignore
@@ -3,3 +3,7 @@ out/
 
 # Installed Playwright/ImageMagick deps.
 node_modules/
+
+# One-off scratch probe scripts — written to inspect/position a single shot,
+# never reusable. Fold any lasting lesson into RULES.md/PROCESS.md instead.
+probe-*-tmp.mjs

--- a/tools/screenshots/CHECKLIST.md
+++ b/tools/screenshots/CHECKLIST.md
@@ -1,0 +1,84 @@
+# Screenshot checklist (compact)
+
+The fast-path rulebook. Workers read THIS by default. Every line is a hard rule distilled
+from `RULES.md`; the `#refs` point to the full lesson — **open `RULES.md` and read the full
+lesson ONLY when a shot is unusual or a `#ref` line below doesn't fully answer your case.**
+Obeying this checklist = obeying the rules for the common case. Do not skip a line because
+it seems minor; each one is a defect a reviewer will fail.
+
+## Setup (always)
+- Capture from the **demo app** `localhost:3020/avo`, login `avo@cado.com` / `secreto` — NOT the test dummy. `#1`
+- Capture **light AND dark** for every image (`AVO_COLOR_SCHEME=dark`). Re-shoot both when a screen changes. `#header,18`
+- DPR 2 (retina). Assets land in `docs/public/assets/img/4_0/<page>/<name>.png`. `#setup`
+- Demo is disposable scratch — edit any resource/controller/model/initializer/seed, no revert, no `git status`. Resource/controller hot-reload; **initializer needs an overmind `web` restart**. `#6,7,18`
+
+## What to shoot
+- **Obey the placeholder prompt first** — if it names a VIEW (show/edit/index), a state, or a field, shoot exactly that. Prompt wording overrides every framing default below. `#15q′`
+- Match a **sibling image's view** (an `inline` shot next to a `stacked` shot use the same view). `#15q′`
+- **Visible text must match the adjacent code snippet** — column header = code's `name:`, option labels = code's `options` hash. Rename the temp field/options to match before shooting. `#13`
+- Build a **minimal temp resource** rendering only the relevant fields rather than the rich demo resource. `#13`
+- When no view is specified: default to the **Form (New/Edit) view** for interactive fields (shows all controls); default to **Show** for read-only/display features. `#15y,screenshot-view-default-show`
+
+## Context — never a bare fragment
+- Show the element **inside its real container** (field→card, cell→table, control→toolbar, overlay→trigger). A lone element on bare mat is the #1 rejection. `#10b`
+- **Triggered component** (modal/popover/dropdown): show the surrounding element + the open component + the **highlighted trigger** (the row/cell/button that opened it). `#15a`
+- Show the **WHOLE component with all controls** (add/delete/drag/`+`) — not a read-only Show projection that drops them. `#15y`
+- Bare-element-on-mat is a **LAST RESORT** (single icon/swatch with no meaningful container). `#10b,15s`
+
+## Single-field / single-component shots
+- **Preferred:** wrap the field in its OWN `panel do card do … end end` via the DSL and shoot that real, content-sized card (true borders all four sides). Supersedes crop-and-neutralize. `#15z`
+- Produce states with **Avo's real DSL** (`disabled:`, `stacked:`, etc.) — never fake the look with injected CSS or fabricated classes. `#15w`
+- Populate **2–3 real rows/pairs** of data (key_value etc.) so it reads as a real example. `#15w`
+- On Show/Form cards, **fields must fill the card** — set `width:` so no row has a dead empty half (1 field→`width:100`; two short→`width:50` each; long values→stack at `100`). `#15x`
+- A single-FIELD FORM-CARD shot uses a **narrow viewport ~720–900** so it displays ~1× and the label stacks above the input (not a 9:1 slim strip). `#9b`
+
+## Framing & sizing
+- Frame by **`selector` + symmetric `pad: {x:10,y:10}`** (engine reads the live bbox), or a **probed bbox + equal pad** — never an eyeballed clip. `#15e`
+- **Pad ≤ 10px, symmetric** on all sides — hard ceiling. `#15f,4`
+- **Never slice a bordered component** (card/table/control/input/select/editor). Go **fully-around** (all four borders) OR **fully-inside** (crop between content and border, no border shows) — never partway. `#15r,15v`
+- Crop a single table row from a **middle row** (`tr:nth-child(3)`), never first/last (they carry the rounded outer corner). Applies to cards/lists/field-rows too. `#15i,15i′`
+- **Crop tight** to the meaningful context — no large empty regions; a clean mid-component right edge is fine for a focused crop. `#15c`
+- **Close the sidebar** for focused shots (`avo.sidebar.open=0` cookie + `page.reload()` so content reflows full-width) and drop `.main-content` `border-left`. NEVER clip at the sidebar edge (x≈256) — leaves a stray divider line. `#12`
+- **Floating UI** (filters/popovers/dropdowns/flatpickr): viewport 1440, crop to trigger+panel, `display:"half"` so it shows at real CSS size (small+centered, 1:1). Do NOT enlarge via narrow viewport. `#9c,15g`
+- **Inline-text shots** (table column labels, help, field values): keep captured CSS width ≲ ~900px (narrower viewport ~820–960 + fewer columns) so text lands near 1×. `#9a,10a`
+- **Tables as a whole:** show full width + pagination (`?per_page=6`), clip to the wrapping **panel** bottom (`.card`), not the inner pagination element. `#10,8,20`
+- **Single-column/option table shot:** RESHAPE — minimal resource, ~3 columns, small `per_page`, narrow viewport. Don't crop a slice out of a 6-column table. `#10a`
+- **Grids:** every tile fully visible; control column count via viewport width so N items fill complete rows (probe column count at several widths). `#15k,15l`
+- **Popover over busy content:** `visibility:hidden` the incidental clutter underneath so the overlay gets even mat — BUT keep it live/visible when the overlay is ABOUT that content. `#15j,15j′`
+
+## Display width (`display:` in spec)
+- `display:"full"` → markdown `width`/`height` = **full PNG pixel dims**; image fills the ~688px content column. Use for structure-is-the-point shots. `#9`
+- `display:"half"` → dims = **half** the PNG (real CSS size); image small + centered. Use for floating UI and focused widgets. `#9,9c`
+
+## Marking a single small control
+- If the subject is ONE small control/icon/indicator, you **MUST mark it** — framing alone fails review. `#15b′`
+- Prefer the app's **native `:focus-visible` ring**: open the overlay, then `.focus()` the focusable trigger. `#15b,15p`
+- Fallback **drawn highlight** only if no focus style: `marks:[{selector|box, type:"highlight", style:"focus"}]` (thin 2px ring), hug the target text tightly. For a GROUP use a probed `box` union rect, not the full-width container. `#15d,15d′`
+
+## Border hygiene (verify before done)
+- Element/`selector` captures bake in the wrapper's own hairline — neutralize structural borders (`.card:not(.relative), .card__body, .field-wrapper, .description-list { border-color: transparent }`) so only the meaningful inner border survives. `#15u`
+- **Sample all four outer edges** of the PNG and confirm they read as **mat** (`#fff` light / `#1b1b1f` dark), not a uniform grey line. `magick x.png -crop 2xH+0+0 +repage -format 'min:%[min] mean:%[mean]\n' info:` `#15u`
+- **Judge border-completeness / sliced-edge on the DARK PNG** — a near-white card border is invisible on white, so a cut edge only shows in dark. Dark is authoritative. `#15r′`
+- Isolated-fragment captures: force page bg to the docs mat (`html,body,.main-content { background:#fff }` / `#1b1b1f` dark) so it blends into the frame — don't expose Avo's `#fafafa` body / `#171717` main-content. Verify a bg pixel. `#19,19a`
+
+## Editorial / placement
+- Image goes **directly after the code snippet** it illustrates, **under the heading** whose prose references it. `#11,15o`
+- PNG (not JPG); same filename in the `4_0/` folder. `#15`
+- Doc code examples must be **dark-mode aware** (`dark:` variants) so the documented code stays legible in dark. `#15m`
+- The demo's Tailwind **purges unused utility classes** — reproduce the look via inline style / injected CSS for the shot; keep canonical class names in the doc. Verify the class actually rendered. `#15n`
+
+## Apply
+- `node apply.mjs <id>` copies the PNG pair + rewrites the placeholder tag (unstaged). Matches on the EXACT prompt. `#17`
+- **Re-shoot of an already-shipped image:** `apply.mjs` won't fire (no placeholder) — copy `out/<id>.png` + `-dark.png` over the existing assets by hand and update the existing `<Image>` `width`/`height`/`alt`. `#17a`
+- **GIFs** are manual (PNG-only tooling): ship `x.gif` + `x-dark.gif`, wire the `<Image>` by hand, flag any orphaned old PNGs. `#17b`
+
+## GIFs (only when `kind="gif"`)
+- Author in `GIF_SPECS` (not `SPECS`); fixed probed `clip` every frame; `record-gif.mjs` per theme. `#3`
+- Capture at **DPR 2**, output `width` = clip's CSS width (downscale-only, never upscale → pixelation). `#3`
+- Do the same framing prep (closeSidebar, matBg, hideKbd) at the top of `steps`. `#3`
+- Chart canvas slices aren't DOM-selectable — hover geometrically by mid-angle. `#3a`
+
+---
+**When in doubt or the shot is unusual** (developer overlays, canvas charts, native `<select>` popups,
+width/border edge cases not covered above), **read the full lesson in `RULES.md` by its `#ref`.**
+This checklist is the common path, not a replacement for the rulebook.

--- a/tools/screenshots/PROCESS.md
+++ b/tools/screenshots/PROCESS.md
@@ -91,8 +91,8 @@ color scheme. Then per spec:
 node annotate.mjs <specId>
 ```
 
-Reads `out/<id>.png` + `out/<id>.boxes.json` and draws in one house style (Avo blue
-`#2563eb`) with ImageMagick → `out/<id>.annotated.png`:
+Reads `out/<id>.png` + `out/<id>.boxes.json` and draws in one house style (docs red
+`#ef4444`) with ImageMagick → `out/<id>.annotated.png`:
 - **highlight** → rounded-rect outline around the element
 - **badge** → numbered accent circle at its corner
 - **arrow** → accent arrow pointing at it from n/s/e/w

--- a/tools/screenshots/RULES.md
+++ b/tools/screenshots/RULES.md
@@ -95,12 +95,13 @@ markdown: `<Image src="…/x.png" dark-src="…/x-dark.png" … />`. Dark = doub
 
 ## Lessons — demo app techniques (all reversible)
 
-6. **Resource files + controllers hot-reload** in dev → temp-edit a resource, capture,
-   `git checkout` to revert. New resource? add `Avo::XController < Avo::ResourcesController`
-   (routing is dynamic, controller hot-loads) — no server restart.
-7. **Initializer config does NOT hot-reload.** For a global like
-   `config.buttons_on_form_footers`, set `Avo.configuration.buttons_on_form_footers = true`
-   inside a **reloadable resource file's** class body at capture time, then revert.
+6. **Resource files + controllers hot-reload** in dev → just edit a resource and capture (no
+   restart, no revert — see #18). New resource? add `Avo::XController < Avo::ResourcesController`
+   (routing is dynamic, controller hot-loads).
+7. **Initializer config does NOT hot-reload.** Two options for a global like
+   `config.buttons_on_form_footers`: set it in the initializer and restart the overmind `web`
+   process, OR set `Avo.configuration.buttons_on_form_footers = true` inside a **reloadable resource
+   file's** class body at capture time (no restart).
 8. **`?per_page=6` (or 5)** keeps a table short so the full table + pagination fit a
    compact capture. It's a URL param — no config change needed.
 9. **Display width = full vs half pixel dims.** `Image.vue` compares `width` to the content
@@ -116,12 +117,14 @@ markdown: `<Image src="…/x.png" dark-src="…/x-dark.png" … />`. Dark = doub
     on-screen text size ≈ `688 ÷ (captured CSS width)`. A full-width index table is ~1125px
     CSS at the default 1440 viewport (measured) → its text renders at ~0.6× — *crisp but too
     small to read*. #9's "crisp because the source is larger" is about **sharpness**, not
-    legibility; the two are different. When the shot's value is *reading* text (column labels,
-    help strings, field values, a renamed header), keep the **captured CSS width ≲ ~900px** so
-    text lands near 1×. The index table is responsive and **tracks the viewport** (measured:
-    1440→1125px, 820→777px), so the primary lever is a **narrower viewport**
+    legibility; the two are different. When the shot's value is *reading inline text* (table
+    column labels, help strings, field values, a renamed header), keep the **captured CSS width
+    ≲ ~900px** so text lands near 1×. The index table is responsive and **tracks the viewport**
+    (measured: 1440→1125px, 820→777px), so the primary lever is a **narrower viewport**
     (`viewport: { width: 820–960 }`), combined with fewer columns (see #10a). Reserve full
     ~1400px-wide captures for shots where the *structure*, not the text, is the point.
+    **This narrow-viewport lever does NOT apply to floating UI** (filter panels, popovers,
+    dropdowns, tippy overlays) — those use #9c instead.
 9b. **A single-field FORM-CARD shot must use a NARROW viewport (~720–900), never the default
     1440 — otherwise it ships zoomed-out as a slim letterbox strip.** On a New/Edit form the
     layout is label-left / input-right across the FULL form width, so at viewport 1440 one
@@ -135,6 +138,24 @@ markdown: `<Image src="…/x.png" dark-src="…/x-dark.png" … />`. Dark = doub
     root cause — a focused single-thing shot left at 1440. (2026-06-23: `field-options-help`
     shipped at viewport 1440 → 1960×204 (~9.6:1) slim strip at ~0.7× text; re-shot at viewport
     720 → card ~703px CSS, label stacked above input, 1440×284 (~5:1), displays ~1×.)
+9c. **Floating UI (filters, popovers, dropdowns) = real app size at the standard viewport.**
+    A filter panel, dynamic-filter card, flatpickr popover, tippy overlay, or similar **floating**
+    element must appear in docs at the **same CSS size it has in a full-width browser** — not
+    blown up by a narrow viewport or by wiring `display:"full"` on a sub-column-sized crop.
+    This matches how the rest of the docs look (dynamic-filters, metric cards, control bars):
+    the component is **small and centered** in the column at 1:1, not edge-to-edge and oversized.
+    **Workflow:**
+    1. **Viewport 1440×900–1100** (sidebar closed per #12) — the standard docs viewport; layout
+       matches what users see at 100% screen width.
+    2. **Crop** to trigger + open panel/popover (#15a) with ≤10px symmetric pad (#15e/15f) — still
+       scope the *frame*, but do not shrink the viewport to enlarge the subject inside it.
+    3. **`display: "half"`** in the spec → markdown `width`/`height` = retina PNG dims ÷ 2 = the
+       component's real CSS size; `Image.vue` centers it at 1:1 (#15g). Same as dynamic-filters.
+    4. **GIFs:** capture at DPR 2 with a probed `clip`, set output `width` to the clip's **CSS
+       width** (not an upscaled display width) so the animation also lands at 1:1.
+    **Anti-pattern (what made basic-filters look "zoomed in"):** viewport 1200 + tight panel crop
+    + `display:"full"` with width ≈ the PNG pixel size but < the content column → the panel fills
+    ~90% of the column at ~2× its real app size. Fix: 1440 viewport + `display:"half"`.
 
 ## Lessons — editorial rules (from review feedback)
 
@@ -247,7 +268,7 @@ markdown: `<Image src="…/x.png" dark-src="…/x-dark.png" … />`. Dark = doub
     When the thing to mark isn't a single focusable element (so 15b's native ring can't
     apply) and has no single narrow wrapper — e.g. the four scope tabs, whose only common
     ancestor `.tabs` is deceptively full content-width — use the drawn `highlight` mark
-    (`#2563eb`). Do NOT point it at the full-width container (the box becomes a wide thin bar
+    (`#ef4444`). Do NOT point it at the full-width container (the box becomes a wide thin bar
     across empty space). Instead use the harness's coordinate mark
     `marks: [{ box: { x, y, width, height }, type: "highlight" }]` (viewport CSS-px; probe the
     union rect of the first→last item) so the box hugs exactly the group, full edges inside
@@ -256,9 +277,9 @@ markdown: `<Image src="…/x.png" dark-src="…/x-dark.png" … />`. Dark = doub
 15d′. **A drawn highlight must mimic the native focus ring, not a chunky box — use
     `style: "focus"`.** Whenever you fall back to a drawn `highlight` mark (per 15b/15b′ for a
     non-focusable element, or 15d for a group), add `style: "focus"` to the mark. annotate then
-    renders a thin 2px stroke in `#60a5fa` (Avo `--color-info` / blue-400, the same color as the
-    real `:focus-visible` outline) with a tight ~2px pad and 3px radius — so the drawn mark reads
-    like the app's own ring, not a fat hand-drawn rectangle. The legacy chunky box (`#2563eb`,
+    renders a thin 2px stroke in `#f87171` (red-400) with a tight ~2px pad and 3px radius — so
+    the drawn mark reads like a crisp callout, not a fat hand-drawn rectangle. The legacy chunky
+    box (`#ef4444`, red-500,
     6px pad, 8px radius) is the default only for backward compatibility; new shots should always
     pass `style: "focus"`. Per-mark overrides exist if needed (`pad`, `stroke`, `radius`, `color`,
     unscaled px). The mark's `selector`/`box` must hug the target TEXT tightly — annotate pads
@@ -296,6 +317,8 @@ markdown: `<Image src="…/x.png" dark-src="…/x-dark.png" … />`. Dark = doub
     mismatch, **measure** a shared element in both
     (`magick a.png -fuzz 18% -transparent 'rgb(r,g,b)' -alpha extract -threshold 1 -trim info:`)
     — if identical, it's a relative-width illusion; leave it.
+    **Also applies to floating UI** (filter panels, popovers, flatpickr) — see #9c; dynamic-filters
+    is the reference implementation.
 
 15h. **Measure with in-capture `marks`, not a standalone probe.** A separate probe can be in
     a different layout state than `capture.mjs` (sidebar open vs closed shifts right-aligned
@@ -568,9 +591,13 @@ markdown: `<Image src="…/x.png" dark-src="…/x-dark.png" … />`. Dark = doub
     is framed like any image. `apply.mjs` is PNG-only and will NOT handle a GIF — copy the two
     `.gif`s into `4_0/…` and edit the tag by hand (17a). Converting a static PNG to a GIF orphans
     the old `x.png`/`x-dark.png` — flag them for the user to delete.
-18. **Leave the repo clean.** Revert every temp edit (`git checkout` tracked,
-    `git clean -f <path>` untracked). Never revert the user's own uncommitted changes
-    (whatever they already had modified).
+18. **Don't track the demo — move fast.** `main.avodemo.com` is disposable scratch space for
+    capturing shots: edit whatever you need (resources, controllers, models, initializer, seeds),
+    reuse whatever already fits, and create from scratch when nothing does. You do NOT need to
+    preserve or restore its state — no `git status` pre-check, no off-limits files, no reverting.
+    Do what the shot needs and leave the demo as-is. (Demo only — never commit/push there, and
+    never touch the docs repo beyond the intended doc + asset changes.) Initializer edits need an
+    overmind `web` restart; resource/controller files hot-reload.
 19. **When you isolate an element on a "clean" background, match the capture bg to the
     docs frame — don't expose the app's `<body>` colour.** To shoot just a fragment
     (e.g. the developer backtrace overlay) you hide the page (`body * { visibility:

--- a/tools/screenshots/annotate.mjs
+++ b/tools/screenshots/annotate.mjs
@@ -11,6 +11,7 @@
 
 import { execFile } from "node:child_process";
 import { readFile } from "node:fs/promises";
+import { realpathSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
@@ -19,94 +20,119 @@ const run = promisify(execFile);
 const HERE = dirname(fileURLToPath(import.meta.url));
 const OUT = join(HERE, "out");
 
-const ACCENT = "#2563eb"; // Avo blue
-const FOCUS_RING = "#60a5fa"; // Avo --color-info (blue-400) — matches the native :focus-visible ring
+export const ACCENT = "#ef4444"; // docs annotation red (Tailwind red-500)
+export const FOCUS_RING = "#f87171"; // lighter red for thin focus-style highlights (red-400)
 const FONT = process.env.ANNOTATE_FONT || "/System/Library/Fonts/Supplemental/Arial Bold.ttf";
-const id = process.argv[2];
-if (!id) { console.error("Usage: node annotate.mjs <specId>"); process.exit(1); }
-const SUFFIX = process.env.ANNOTATE_DARK ? "-dark" : ""; // annotate the -dark capture
 
-const { dpr, marks } = JSON.parse(await readFile(join(OUT, `${id}${SUFFIX}.boxes.json`), "utf8"));
-const s = (dpr || 2);              // scale stroke/badge sizes with DPR
-const sw = 3 * s;                  // stroke width
-const pad = 6 * s;                 // highlight padding around element
-const draw = [];
-
-for (const m of marks) {
-  const x1 = Math.round(m.x - pad), y1 = Math.round(m.y - pad);
-  const x2 = Math.round(m.x + m.width + pad), y2 = Math.round(m.y + m.height + pad);
-  if (m.type === "highlight") {
-    // `style: "focus"` mimics Avo's native :focus-visible ring — a thin (2px) blue-400
-    // outline hugging the element with a ~2px gap. Default keeps the legacy chunky box.
-    const focus = m.style === "focus";
-    const hpad = (m.pad ?? (focus ? 2 : 6)) * s;
-    const hsw = (m.stroke ?? (focus ? 2 : 3)) * s;
-    const hradius = (m.radius ?? (focus ? 3 : 8)) * s;
-    const hcolor = m.color ?? (focus ? FOCUS_RING : ACCENT);
-    const fx1 = Math.round(m.x - hpad), fy1 = Math.round(m.y - hpad);
-    const fx2 = Math.round(m.x + m.width + hpad), fy2 = Math.round(m.y + m.height + hpad);
-    draw.push({ rect: `roundrectangle ${fx1},${fy1} ${fx2},${fy2} ${hradius},${hradius}`, color: hcolor, strokeWidth: hsw });
-  } else if (m.type === "badge") {
-    const r = 16 * s, cx = x1, cy = y1;
-    // circle then number drawn separately via -annotate
-    draw.push({ circle: [cx, cy, r], label: m.label, fontSize: 22 * s });
-  } else if (m.type === "arrow") {
-    // arrow comes FROM `from` (n/s/e/w) and points at the element. Default: n.
-    const dir = m.from || "n";
-    const L = 80 * s, gap = pad;
-    const cx = Math.round(m.x + m.width / 2), cy = Math.round(m.y + m.height / 2);
-    const left = Math.round(m.x), right = Math.round(m.x + m.width);
-    const top = Math.round(m.y), bot = Math.round(m.y + m.height);
-    let tip, tail;
-    if (dir === "n") { tip = [cx, top - gap]; tail = [cx, top - gap - L]; }
-    else if (dir === "s") { tip = [cx, bot + gap]; tail = [cx, bot + gap + L]; }
-    else if (dir === "w") { tip = [left - gap, cy]; tail = [left - gap - L, cy]; }
-    else { tip = [right + gap, cy]; tail = [right + gap + L, cy]; } // e
-    draw.push({ arrow: [...tail, ...tip] });
-  }
-}
-
-const src = join(OUT, `${id}${SUFFIX}.png`);
-const dst = join(OUT, `${id}${SUFFIX}.annotated.png`);
-const args = [src, "-strokewidth", String(sw), "-fill", "none", "-stroke", ACCENT];
-
-// rectangles first — each carries its own stroke color/width
-for (const d of draw) {
-  if (d.rect) args.push("-stroke", d.color, "-strokewidth", String(d.strokeWidth), "-draw", d.rect);
-}
-// restore defaults for arrows/badges below
-args.push("-stroke", ACCENT, "-strokewidth", String(sw));
-
-// arrows + badges
-for (const d of draw) {
-  if (d.arrow) {
-    const [x0, y0, x1, y1] = d.arrow; // tail -> tip
-    args.push("-draw", `line ${x0},${y0} ${x1},${y1}`);
-    const a = 9 * s;
-    // arrowhead at the tip, oriented along (tip - tail)
-    let head;
-    if (x0 === x1) {
-      head = y1 > y0 // pointing down vs up
-        ? `${x1},${y1} ${x1 - a},${y1 - a} ${x1 + a},${y1 - a}`
-        : `${x1},${y1} ${x1 - a},${y1 + a} ${x1 + a},${y1 + a}`;
-    } else {
-      head = x1 > x0 // pointing right vs left
-        ? `${x1},${y1} ${x1 - a},${y1 - a} ${x1 - a},${y1 + a}`
-        : `${x1},${y1} ${x1 + a},${y1 - a} ${x1 + a},${y1 + a}`;
+/** Record mark boxes relative to a clip/origin origin (used by record-gif.mjs). */
+export async function computeMarkBoxes(page, marks, origin, dpr = 2) {
+  const boxes = [];
+  for (const mark of marks || []) {
+    const box = mark.box
+      ? mark.box
+      : await page.locator(mark.selector).first().boundingBox();
+    if (!box) {
+      console.warn(`  ! mark selector not found: ${mark.selector}`);
+      continue;
     }
-    args.push("-fill", ACCENT, "-stroke", ACCENT, "-draw", `polygon ${head}`, "-fill", "none");
+    boxes.push({
+      ...mark,
+      x: (box.x - (origin.x || 0)) * dpr,
+      y: (box.y - (origin.y || 0)) * dpr,
+      width: box.width * dpr,
+      height: box.height * dpr,
+    });
   }
-  if (d.circle) {
-    const [cx, cy, r] = d.circle;
-    args.push("-fill", ACCENT, "-stroke", "white",
-      "-draw", `circle ${cx},${cy} ${cx + r},${cy}`,
-      "-fill", "white", "-stroke", "none", "-font", FONT,
-      "-pointsize", String(d.fontSize), "-gravity", "None",
-      "-annotate", `+${cx - 7 * s}+${cy + 8 * s}`, String(d.label),
-      "-fill", "none", "-stroke", ACCENT);
-  }
+  return { dpr, marks: boxes };
 }
 
-args.push(dst);
-await run("magick", args);
-console.log(`✓ annotated → out/${id}.annotated.png (${marks.length} marks)`);
+/** Build ImageMagick args to draw marks onto src → dst. */
+export function magickAnnotateArgs(src, dst, { dpr, marks }) {
+  const s = dpr || 2;
+  const sw = 3 * s;
+  const pad = 6 * s;
+  const draw = [];
+
+  for (const m of marks) {
+    const x1 = Math.round(m.x - pad), y1 = Math.round(m.y - pad);
+    if (m.type === "highlight") {
+      const focus = m.style === "focus";
+      const hpad = (m.pad ?? (focus ? 2 : 6)) * s;
+      const hsw = (m.stroke ?? (focus ? 2 : 3)) * s;
+      const hradius = (m.radius ?? (focus ? 3 : 8)) * s;
+      const hcolor = m.color ?? (focus ? FOCUS_RING : ACCENT);
+      const fx1 = Math.round(m.x - hpad), fy1 = Math.round(m.y - hpad);
+      const fx2 = Math.round(m.x + m.width + hpad), fy2 = Math.round(m.y + m.height + hpad);
+      draw.push({ rect: `roundrectangle ${fx1},${fy1} ${fx2},${fy2} ${hradius},${hradius}`, color: hcolor, strokeWidth: hsw });
+    } else if (m.type === "badge") {
+      const r = 16 * s, cx = x1, cy = y1;
+      draw.push({ circle: [cx, cy, r], label: m.label, fontSize: 22 * s });
+    } else if (m.type === "arrow") {
+      const dir = m.from || "n";
+      const L = 80 * s, gap = pad;
+      const cx = Math.round(m.x + m.width / 2), cy = Math.round(m.y + m.height / 2);
+      const left = Math.round(m.x), right = Math.round(m.x + m.width);
+      const top = Math.round(m.y), bot = Math.round(m.y + m.height);
+      let tip, tail;
+      if (dir === "n") { tip = [cx, top - gap]; tail = [cx, top - gap - L]; }
+      else if (dir === "s") { tip = [cx, bot + gap]; tail = [cx, bot + gap + L]; }
+      else if (dir === "w") { tip = [left - gap, cy]; tail = [left - gap - L, cy]; }
+      else { tip = [right + gap, cy]; tail = [right + gap + L, cy]; }
+      draw.push({ arrow: [...tail, ...tip] });
+    }
+  }
+
+  const args = [src, "-strokewidth", String(sw), "-fill", "none", "-stroke", ACCENT];
+  for (const d of draw) {
+    if (d.rect) args.push("-stroke", d.color, "-strokewidth", String(d.strokeWidth), "-draw", d.rect);
+  }
+  args.push("-stroke", ACCENT, "-strokewidth", String(sw));
+  for (const d of draw) {
+    if (d.arrow) {
+      const [x0, y0, x1, y1] = d.arrow;
+      args.push("-draw", `line ${x0},${y0} ${x1},${y1}`);
+      const a = 9 * s;
+      let head;
+      if (x0 === x1) {
+        head = y1 > y0
+          ? `${x1},${y1} ${x1 - a},${y1 - a} ${x1 + a},${y1 - a}`
+          : `${x1},${y1} ${x1 - a},${y1 + a} ${x1 + a},${y1 + a}`;
+      } else {
+        head = x1 > x0
+          ? `${x1},${y1} ${x1 - a},${y1 - a} ${x1 - a},${y1 + a}`
+          : `${x1},${y1} ${x1 + a},${y1 - a} ${x1 + a},${y1 + a}`;
+      }
+      args.push("-fill", ACCENT, "-stroke", ACCENT, "-draw", `polygon ${head}`, "-fill", "none");
+    }
+    if (d.circle) {
+      const [cx, cy, r] = d.circle;
+      args.push("-fill", ACCENT, "-stroke", "white",
+        "-draw", `circle ${cx},${cy} ${cx + r},${cy}`,
+        "-fill", "white", "-stroke", "none", "-font", FONT,
+        "-pointsize", String(d.fontSize), "-gravity", "None",
+        "-annotate", `+${cx - 7 * s}+${cy + 8 * s}`, String(d.label),
+        "-fill", "none", "-stroke", ACCENT);
+    }
+  }
+  args.push(dst);
+  return args;
+}
+
+export async function annotateImage(src, dst, meta) {
+  await run("magick", magickAnnotateArgs(src, dst, meta));
+}
+
+// ---- CLI -------------------------------------------------------------------
+const invokedDirectly =
+  process.argv[1] && realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  const id = process.argv[2];
+  if (!id) { console.error("Usage: node annotate.mjs <specId>"); process.exit(1); }
+  const SUFFIX = process.env.ANNOTATE_DARK ? "-dark" : "";
+  const { dpr, marks } = JSON.parse(await readFile(join(OUT, `${id}${SUFFIX}.boxes.json`), "utf8"));
+  const src = join(OUT, `${id}${SUFFIX}.png`);
+  const dst = join(OUT, `${id}${SUFFIX}.annotated.png`);
+  await annotateImage(src, dst, { dpr, marks });
+  console.log(`✓ annotated → out/${id}${SUFFIX}.annotated.png (${marks.length} marks)`);
+}

--- a/tools/screenshots/prepare.mjs
+++ b/tools/screenshots/prepare.mjs
@@ -129,6 +129,50 @@ export const hideSummarizableIcons = async (page) => {
   });
 };
 
+// --- avo-advanced dynamic-filters primitives -------------------------------
+// The dynamic-filters bar (above the index table) carries an "Add filter" dropdown.
+// Picking a field appends a filter PILL (the trigger) and opens its filter-card POPOVER —
+// a <dialog> with the field's condition <select>, a value input and an Apply button. These
+// primitives drive that flow so a spec can shoot any one filter type's card in context.
+
+// Open the "Add filter" dropdown and pick a field by its exact menu label (e.g. "Is active",
+// "First name", "Created at"). Leaves the new filter pill + its open popover on screen.
+export const addDynamicFilter = (label) => async (page) => {
+  await page.locator('[data-avo-filters-target="add-filter-button"]').first().click();
+  await page.waitForTimeout(500);
+  await page
+    .locator('a[href*="filter_param_id"]')
+    .filter({ hasText: new RegExp(`^\\s*${label}\\s*$`) })
+    .first()
+    .click();
+  await page.waitForTimeout(1300);
+};
+
+// Expand the filter card's condition <select> into an inline listbox (size=N) so every
+// condition option is visible at once — the legitimate "render the real native select as a
+// list" technique (same as openSelect; a native popup is OS-drawn and can't be screenshot).
+export const expandFilterConditions = async (page) => {
+  await page.evaluate(() => {
+    const s = document.querySelector('#condition_selector, select[data-control="condition"]');
+    if (s) {
+      s.setAttribute("size", String(s.options.length));
+      s.style.width = "auto";
+    }
+  });
+  await page.waitForTimeout(400);
+};
+
+// Open the date/date_time/time filter's flatpickr calendar inside the open popover.
+export const openFilterCalendar = async (page) => {
+  await page.evaluate(() => {
+    const inp = document.querySelector(
+      'dialog.dropdown-popover[open] input.flatpickr-input, dialog.dropdown-popover[open] input[data-control="value"], .filters__panel input.flatpickr-input, .filters__panel input[data-control="value"]',
+    );
+    if (inp && inp._flatpickr) inp._flatpickr.open();
+  });
+  await page.waitForTimeout(600);
+};
+
 // Hide index-table columns by Avo field id (header + body cells).
 export const hideIndexColumns = (...fieldIds) => async (page) => {
   const selectors = fieldIds.flatMap((id) => [

--- a/tools/screenshots/record-gif.mjs
+++ b/tools/screenshots/record-gif.mjs
@@ -13,8 +13,10 @@
 //   clip      { x, y, width, height }        the crop every frame uses
 //   width     output GIF width in px         (default 900; source is captured larger)
 //   delay     centiseconds per frame         (default 18)
-//   steps     async (page, snap) => {}       drive the UI; call snap(hold) to emit frames
-//                                            (hold = duplicate frames = pause on that state)
+//   marks?    same as capture.mjs — default marks for every snap(hold) unless overridden
+//   steps     async (page, snap) => {}       drive the UI; call snap(hold[, marks]) to emit frames
+//                                            marks: array → red-annotate that batch only;
+//                                            false → no annotation; omit → use spec.marks
 //   out?      "docs/public/assets/img/4_0/<page>/<name>.gif"  (destination; copy is manual)
 //
 // Usage:
@@ -29,6 +31,7 @@ import { realpathSync } from "node:fs";
 import { promisify } from "node:util";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { annotateImage, computeMarkBoxes } from "./annotate.mjs";
 
 const run = promisify(execFile);
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -73,10 +76,25 @@ export async function recordGif(spec) {
   await page.waitForTimeout(spec.settle ?? 700);
 
   let i = 0;
-  // snap(hold): emit `hold` identical frames (each frame = one GIF tick) to pause on a state.
-  const snap = async (hold = 1) => {
-    for (let h = 0; h < hold; h++)
-      await page.screenshot({ path: join(frames, String(i++).padStart(3, "0") + ".png"), clip: spec.clip });
+  let defaultMarkMeta = null;
+  // snap(hold[, marks[, clip]]): emit `hold` identical frames. Optional per-batch marks and clip.
+  const snap = async (hold = 1, marksForSnap = undefined, clipOverride = undefined) => {
+    const clip = clipOverride ?? spec.clip;
+    let meta = null;
+    if (marksForSnap === false) {
+      meta = null;
+    } else if (Array.isArray(marksForSnap) && marksForSnap.length) {
+      meta = await computeMarkBoxes(page, marksForSnap, clip, DPR);
+    } else if (marksForSnap === undefined && spec.marks?.length) {
+      if (!defaultMarkMeta) defaultMarkMeta = await computeMarkBoxes(page, spec.marks, spec.clip, DPR);
+      meta = defaultMarkMeta;
+    }
+    for (let h = 0; h < hold; h++) {
+      const framePath = join(frames, String(i++).padStart(3, "0") + ".png");
+      await page.screenshot({ path: framePath, clip });
+      if (meta?.marks?.length)
+        await annotateImage(framePath, framePath, meta);
+    }
   };
 
   await spec.steps(page, snap);
@@ -90,7 +108,7 @@ export async function recordGif(spec) {
     "-resize", `${spec.width ?? 900}x>`,
     // No dithering: the 256-colour GIF palette otherwise speckles flat areas (the dark mat behind
     // a popover) into visible grain that reads as a "blurred"/noisy background (RULES 3).
-    "-dither", "None", "-layers", "Optimize",
+    "-dither", "None", "-layers", "Optimize", "-coalesce",
     gifOut,
   ]);
   console.log(`✓ GIF → out/${spec.id}${SUFFIX}.gif (${i} frames)`);

--- a/tools/screenshots/specs.mjs
+++ b/tools/screenshots/specs.mjs
@@ -19,7 +19,49 @@
 //
 // See RULES.md for every framing rule and prepare.mjs for the prepare-step primitives.
 
-import { compose, closeSidebar, matBg, hideKbd, hideRecords, hideIndexColumns, neutralizeBorders, hover, focus, wait, injectCSS, openSelect, click, hideSummarizableIcons, scrollTo } from "./prepare.mjs";
+import { compose, closeSidebar, matBg, hideKbd, hideRecords, hideIndexColumns, neutralizeBorders, hover, focus, wait, injectCSS, openSelect, click, hideSummarizableIcons, scrollTo, addDynamicFilter, expandFilterConditions, openFilterCalendar, hideUnder } from "./prepare.mjs";
+
+// dynamic-filters (avo-advanced) — add ONE filter via the DSL "Add filter" dropdown; frame the
+// filters bar + open filter-card popover over a 6-row index table (sidebar closed, mat bg).
+// Popover gap: the fix in avo-dynamic_filters swaps the filter panel's `-mt-1` (which pulls the
+// card UP, overlapping the trigger) for `.dynamic-filter-dropdown-popover` → top: calc(100% + 2px),
+// a 2px gap below the trigger. dfPopoverGapFix mirrors that when the demo runs a packaged gem
+// WITHOUT the fix: beta.13's panel has no such class — the `<dialog class="dropdown-popover … -mt-1">`
+// carries the offset — so we also target the filter dialog directly (scoped via the menu class) and
+// neutralize `-mt-1`. Covers both the patched (class present) and unpatched (beta.13) gems.
+const dfPopoverGapFix = injectCSS(`
+  .dynamic-filter-dropdown-popover,
+  dialog.dropdown-popover:has(.dynamic-filter-dropdown-menu) {
+    top: calc(100% + 2px) !important;
+    margin-top: 0 !important;
+  }
+`);
+
+const dfHideSelectColumn = injectCSS(`
+  th[data-control="item-select-th"], td[data-control="item-select-td"] { display: none !important; }
+`);
+
+// Index tables: max 4 columns — id, name (first_name on Users), status, active where present.
+const dfHideUsersColumns = hideIndexColumns(
+  "email", "last_name", "is_admin", "user_status", "progress", "birthday", "is_writer", "cv", "roles",
+);
+const dfHideTeamsColumns = hideIndexColumns("preview", "logo", "created_at", "members_count", "admin");
+const dfHideCoursesColumns = hideIndexColumns("has_skills", "skills", "country", "city", "links");
+
+const dfUsersPrepare = (label, ...extra) => compose(
+  closeSidebar, matBg, hideKbd, dfPopoverGapFix, dfHideSelectColumn, dfHideUsersColumns, addDynamicFilter(label), ...extra,
+);
+const dfTeamsPrepare = (label, ...extra) => compose(
+  closeSidebar, matBg, hideKbd, dfPopoverGapFix, dfHideSelectColumn, dfHideTeamsColumns, addDynamicFilter(label), ...extra,
+);
+const dfCoursesPrepare = (label, ...extra) => compose(
+  closeSidebar, matBg, hideKbd, dfPopoverGapFix, dfHideSelectColumn, dfHideCoursesColumns, addDynamicFilter(label), ...extra,
+);
+
+// Clips for dynamic-filter docs: filters row → table (6 per page) → pagination.
+const DF_CLIP_USERS = { x: 14, y: 600, width: 1412, height: 435 };
+const DF_CLIP_SIMPLE = { x: 14, y: 210, width: 1412, height: 410 };
+const DF_CLIP_DATE_CAL = { x: 14, y: 210, width: 1412, height: 521 };
 
 // ---- factories — stamp out repeated specs for a page (adapt the `out` subpath) -------
 
@@ -79,6 +121,29 @@ export const EXAMPLES = [
 // The live catalog — the resolve agent appends resolved specs here; capture.mjs / apply.mjs
 // read it. Starts empty on a fresh checkout.
 export const SPECS = [
+  // resource-tool-partial (resource-tools.md) — a custom resource tool rendered as a panel on a
+  // record Show view, showing the default generated partial ("Post info" title, the "waiting to be
+  // updated" body with the two file-path codes, the primary "Dummy link" button). The demo's User
+  // resource registers `Avo::ResourceTools::UserTool` (visible on Show); the `_user_tool.html.erb`
+  // partial is temp-rewritten to the doc's generated default (title "Post info", paths
+  // post_info.html.erb / post_info.rb — RULES 13, matching the doc snippet) for the capture, then
+  // reverted with `git checkout`. The tool renders as `div.flex.flex-col > div.panel` (unique on the
+  // page). Sidebar closed + mat bg (RULES 12/19a); hideKbd. Whole panel via selector + symmetric
+  // ≤10px pad so all four borders + the controls bar are in shot (RULES 15e/10b).
+  {
+    id: "resource-tool-partial",
+    path: "/avo/resources/users/1",
+    viewport: { width: 1200, height: 1700 },
+    settle: 900,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: "div.flex.flex-col > div.panel",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/resource-tools/resource-tool-partial.png",
+    display: "full",
+    alt: "An Avo custom resource tool rendered as a panel on a record Show view, titled “Post info” with a primary Dummy link button.",
+    source: { file: "docs/4.0/resource-tools.md", prompt: "a custom resource tool partial rendered as a panel on a record Show view" },
+  },
+
   // field-options "Change field name" — a boolean field whose Index column header shows the
   // custom label set via `name:` ("Availability"). RESHAPED to a single-column shot (RULES
   // 9a/10a): temp-hid the Skills/Country/City/Links index fields so only ID, Name and the renamed
@@ -87,7 +152,7 @@ export const SPECS = [
   // to match the doc snippet (RULES 13). Sidebar closed + mat bg (RULES 12/19a). The "Availability"
   // header is a non-sortable `<div>` (not focusable), so the native ring (15b) can't apply — mark
   // the header TEXT extent with a drawn highlight styled like Avo's native :focus-visible ring
-  // (`style: "focus"` → thin 2px #60a5fa stroke, 2px pad, 3px radius). The header `<div>` is the
+  // thin 2px #f87171 (red-400) stroke, 2px pad, 3px radius). The header `<div>` is the
   // full 222px column width (text left-aligned), so a `selector` ring on it would span the whole
   // empty column — instead an explicit `box` in viewport CSS-px = the GLYPH extent measured via a
   // DOM Range (RULES #5), probed live (probe-hdr.mjs) at this exact viewport + sidebar-closed
@@ -1597,11 +1662,1988 @@ export const SPECS = [
       prompt: "Avo tab switcher with a tab label and its description tooltip visible on hover",
     },
   },
+
+  // belongs_to — Comments index: ID + User columns with belongs_to link (Overview). Whole table card
+  // (RULES 4/10/10a/10b); excerpt + commentable hidden via hideIndexColumns; view_type=table.
+  {
+    id: "belongs-to-index",
+    path: "/avo/resources/comments?view_type=table&per_page=4",
+    viewport: { width: 900, height: 700 },
+    settle: 800,
+    prepare: compose(
+      closeSidebar,
+      matBg,
+      hideKbd,
+      hideIndexColumns("excerpt", "commentable"),
+      injectCSS('th[data-control="item-select-th"], td[data-control="item-select-td"] { display: none !important; }'),
+    ),
+    selector: ".card.relative.w-full",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/associations/belongs-to-index.png",
+    display: "full",
+    alt: "Comments index table with ID and User columns, the User cell showing a belongs_to link to the associated record.",
+    source: { file: "docs/4.0/associations/belongs_to.md", prompt: "belongs_to link on index view" },
+  },
+
+  // belongs_to — Post show: User belongs_to link in its OWN dedicated panel/card (RULES 15z).
+  // Temp edit (reverted after capture): Post resource gets `panel do card do field :user, only_on: :show
+  // end end`; original `:user` hidden on show. Capture whole card with symmetric ≤10px pad (15e/15r).
+  {
+    id: "belongs-to-show",
+    path: "/avo/resources/posts/10",
+    viewport: { width: 720, height: 700 },
+    settle: 800,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: '.card:has([data-field-id="user"])',
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/associations/belongs-to-show.png",
+    display: "full",
+    alt: "Post show view with a User belongs_to field linking to the associated user record inside a complete card.",
+    source: { file: "docs/4.0/associations/belongs_to.md", prompt: "belongs_to field on show view" },
+  },
+
+  // belongs_to — Post edit: User belongs_to dropdown in its OWN dedicated panel/card (RULES 15z/9b).
+  // Temp edit (reverted after capture): Post resource gets `panel do card do field :user, only_on:
+  // [:edit, :new] end end`; original `:user` hidden on edit/new. Narrow viewport ~720px.
+  {
+    id: "belongs-to-edit",
+    path: "/avo/resources/posts/10/edit",
+    viewport: { width: 720, height: 800 },
+    settle: 800,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: '.card:has([data-field-id="user"])',
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/associations/belongs-to-edit.png",
+    display: "full",
+    alt: "Post edit form with the User belongs_to dropdown showing available records inside a complete card.",
+    source: { file: "docs/4.0/associations/belongs_to.md", prompt: "belongs_to dropdown on edit form" },
+  },
+
+  // belongs_to — Review new: polymorphic reviewable with polymorphic_help + help matching doc snippet
+  // (RULES 13/15z/15y). Temp review.rb wraps field in dedicated panel/card on :new only; body/user
+  // hidden on new. Both type + record dropdowns and both help strings visible (closed state).
+  {
+    id: "belongs-to-polymorphic-help",
+    path: "/avo/resources/reviews/new",
+    viewport: { width: 720, height: 900 },
+    settle: 800,
+    prepare: async (page) => {
+      await compose(closeSidebar, matBg, hideKbd)(page);
+      await page.selectOption("#review_reviewable_type", "Post");
+      await wait(600)(page);
+    },
+    selector: '.card:has([data-field-id="reviewable"])',
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/associations/polymorphic-help.png",
+    display: "full",
+    alt: "New review form with a polymorphic Reviewable belongs_to field showing the type dropdown, record dropdown, polymorphic_help and help text inside a complete card.",
+    source: { file: "docs/4.0/associations/belongs_to.md", prompt: "polymorphic belongs_to with polymorphic_help and help on new form" },
+  },
+
+  // basic-filters — filter types overview (RULES 9c/15a/15e): 1440 viewport + display:"half"
+  // → real app CSS size, centered (same pattern as dynamic-filters). Temp: PostStatus on Post.
+  {
+    id: "basic-filters-types",
+    path: "/avo/resources/posts?view_type=table&per_page=6",
+    viewport: { width: 1440, height: 900 },
+    settle: 800,
+    prepare: async (page) => {
+      await compose(closeSidebar, matBg, hideKbd)(page);
+      await page.locator('[data-button="resource-filters"]').click();
+      await wait(400)(page);
+      await focus('[data-button="resource-filters"]')(page);
+    },
+    clipFrom: '[data-button="resource-filters"]',
+    selector: ".filters__panel",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/filters/types.png",
+    display: "half",
+    alt: "Avo Filters button with the open panel showing boolean, select, and multiple select filter types on the Posts index.",
+    source: { file: "docs/4.0/basic-filters.md", prompt: "Avo filter types panel on index" },
+  },
+
+  // basic-filters — multiple select (RULES 9c/15a): Posts index with ONLY the Status filter
+  // (matches the PostStatus code sample: name "Status", Admins / Non admins). Temp: post.rb.
+  {
+    id: "basic-filters-multiple-select",
+    path: "/avo/resources/posts?view_type=table&per_page=6",
+    viewport: { width: 1440, height: 900 },
+    settle: 800,
+    prepare: async (page) => {
+      await compose(closeSidebar, matBg, hideKbd)(page);
+      await page.locator('[data-button="resource-filters"]').click();
+      await wait(400)(page);
+      await focus('[data-button="resource-filters"]')(page);
+    },
+    clipFrom: '[data-button="resource-filters"]',
+    selector: ".filters__panel",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/filters/multiple-select.png",
+    display: "half",
+    alt: "Avo multiple select filter named Status showing Admins and Non admins options with a Filter by Status button.",
+    source: { file: "docs/4.0/basic-filters.md", prompt: "multiple select filter" },
+  },
+
+  // basic-filters — date_time :date (RULES 9c/15a/15v). Patch birthday.rb via patch-birthday.mjs date.
+  {
+    id: "basic-filters-datetime-date",
+    path: "/avo/resources/users?per_page=6",
+    viewport: { width: 1440, height: 900 },
+    settle: 800,
+    prepare: async (page) => {
+      await compose(closeSidebar, matBg, hideKbd)(page);
+      await page.locator('[data-button="resource-filters"]').click();
+      await wait(400)(page);
+      const birthdayInput = page.locator('.filters__panel input[placeholder="Filter by birthday"]');
+      await birthdayInput.scrollIntoViewIfNeeded();
+      await birthdayInput.click();
+      await wait(500)(page);
+      await page.locator(".flatpickr-calendar.open .flatpickr-day:not(.prevMonthDay):not(.nextMonthDay)").filter({ hasText: /^13$/ }).first().click();
+      await wait(300)(page);
+      await focus('.filters__panel input[placeholder="Filter by birthday"]')(page);
+      await wait(200)(page);
+    },
+    clipFrom: '.filters__panel input[placeholder="Filter by birthday"]',
+    selector: ".flatpickr-calendar.open",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/filters/datetime-date.png",
+    display: "half",
+    alt: "Avo date time filter with type date showing the Birthday filter and flatpickr calendar with a date selected.",
+    source: { file: "docs/4.0/basic-filters.md", prompt: "date time filter date type" },
+  },
+
+  // basic-filters — date_time :time. Patch birthday.rb via patch-birthday.mjs time.
+  // Clicking the input closes the filters panel; open flatpickr via API so the Birthday
+  // field and time picker stay visible together (same framing as :date / :date_time).
+  {
+    id: "basic-filters-datetime-time",
+    path: "/avo/resources/users?per_page=6",
+    viewport: { width: 1440, height: 900 },
+    settle: 800,
+    prepare: async (page) => {
+      await compose(closeSidebar, matBg, hideKbd)(page);
+      await page.locator('[data-button="resource-filters"]').click();
+      await wait(400)(page);
+      const birthdayInput = page.locator('.filters__panel input[placeholder="Filter by birthday"]');
+      await birthdayInput.scrollIntoViewIfNeeded();
+      await wait(300)(page);
+      await openFilterCalendar(page);
+      await focus('.filters__panel input[placeholder="Filter by birthday"]')(page);
+      await wait(200)(page);
+    },
+    clipFrom: '.filters-section:has(.filters-date-input)',
+    selector: ".flatpickr-calendar.open",
+    pad: { x: 10, top: 50, bottom: 50 },
+    out: "docs/public/assets/img/4_0/filters/datetime-time.png",
+    display: "half",
+    alt: "Avo date time filter with type time: the Birthday filter input and flatpickr time picker.",
+    source: { file: "docs/4.0/basic-filters.md", prompt: "date time filter time type" },
+  },
+
+  // basic-filters — date_time :date_time. Patch birthday.rb via patch-birthday.mjs date_time.
+  {
+    id: "basic-filters-datetime-datetime",
+    path: "/avo/resources/users?per_page=6",
+    viewport: { width: 1440, height: 900 },
+    settle: 800,
+    prepare: async (page) => {
+      await compose(closeSidebar, matBg, hideKbd)(page);
+      await page.locator('[data-button="resource-filters"]').click();
+      await wait(400)(page);
+      const birthdayInput = page.locator('.filters__panel input[placeholder="Filter by birthday"]');
+      await birthdayInput.scrollIntoViewIfNeeded();
+      await birthdayInput.click();
+      await wait(500)(page);
+    },
+    clipFrom: '.filters__panel input[placeholder="Filter by birthday"]',
+    selector: ".flatpickr-calendar.open",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/filters/datetime-datetime.png",
+    display: "half",
+    alt: "Avo date time filter with type date_time showing the Birthday filter and combined date/time picker.",
+    source: { file: "docs/4.0/basic-filters.md", prompt: "date time filter date_time type" },
+  },
+
+  // basic-filters — date_time range mode. Patch birthday.rb via patch-birthday.mjs range.
+  {
+    id: "basic-filters-datetime-range",
+    path: "/avo/resources/users?per_page=6",
+    viewport: { width: 1440, height: 900 },
+    settle: 800,
+    prepare: async (page) => {
+      await compose(closeSidebar, matBg, hideKbd)(page);
+      await page.locator('[data-button="resource-filters"]').click();
+      await wait(400)(page);
+      const input = page.locator('.filters__panel input[placeholder="Filter by birthday"]');
+      await input.scrollIntoViewIfNeeded();
+      await input.click();
+      await wait(500)(page);
+      const day = page.locator(".flatpickr-calendar.open .flatpickr-day:not(.prevMonthDay):not(.nextMonthDay)");
+      await day.filter({ hasText: /^13$/ }).first().click();
+      await wait(200)(page);
+      await day.filter({ hasText: /^16$/ }).first().click();
+      await wait(300)(page);
+      await input.click();
+      await wait(500)(page);
+    },
+    clipFrom: '.filters__panel input[placeholder="Filter by birthday"]',
+    selector: ".flatpickr-calendar.open",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/filters/datetime-range.png",
+    display: "half",
+    alt: "Avo date time filter in range mode showing the Birthday filter and a selected date range in flatpickr.",
+    source: { file: "docs/4.0/basic-filters.md", prompt: "date time filter range mode" },
+  },
+
+  // basic-filters — date_time single mode. Patch birthday.rb via patch-birthday.mjs single.
+  {
+    id: "basic-filters-datetime-single",
+    path: "/avo/resources/users?per_page=6",
+    viewport: { width: 1440, height: 900 },
+    settle: 800,
+    prepare: async (page) => {
+      await compose(closeSidebar, matBg, hideKbd)(page);
+      await page.locator('[data-button="resource-filters"]').click();
+      await wait(400)(page);
+      const input = page.locator('.filters__panel input[placeholder="Filter by birthday"]');
+      await input.scrollIntoViewIfNeeded();
+      await input.click();
+      await wait(500)(page);
+      await page.locator(".flatpickr-calendar.open .flatpickr-day:not(.prevMonthDay):not(.nextMonthDay)").filter({ hasText: /^13$/ }).first().click();
+      await wait(300)(page);
+      await input.click();
+      await wait(500)(page);
+    },
+    clipFrom: '.filters__panel input[placeholder="Filter by birthday"]',
+    selector: ".flatpickr-calendar.open",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/filters/datetime-single.png",
+    display: "half",
+    alt: "Avo date time filter in single mode showing the Birthday filter and one selected date in flatpickr.",
+    source: { file: "docs/4.0/basic-filters.md", prompt: "date time filter single mode" },
+  },
+
+  // basic-filters — dynamic options static PNG (RULES 9c/15a). Temp: CourseCity keys + empty_message.
+  {
+    id: "basic-filters-dynamic-options",
+    path: "/avo/resources/courses?view_type=table&per_page=6",
+    viewport: { width: 1440, height: 900 },
+    settle: 800,
+    prepare: async (page) => {
+      await compose(closeSidebar, matBg, hideKbd)(page);
+      await page.locator('[data-button="resource-filters"]').click();
+      await wait(400)(page);
+      await page.getByRole("checkbox", { name: "USA" }).check();
+      await page.waitForSelector('.filters__panel label:has-text("New York")', { timeout: 10000 });
+      await wait(500)(page);
+      await focus('[data-button="resource-filters"]')(page);
+    },
+    clipFrom: '[data-button="resource-filters"]',
+    selector: ".filters__panel",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/filters/dynamic-options.png",
+    display: "half",
+    alt: "Avo Filters button with Course country and city filters where selecting USA populates US cities.",
+    source: { file: "docs/4.0/basic-filters.md", prompt: "dynamic filter options country city" },
+  },
+
+  // actions/execution — all four action feedback alert types stacked (succeed, inform, warn, error).
+  // Temp demo: DemoAlertTypes action on Fish show (reverted after capture).
+  {
+    id: "alert-response",
+    path: "/avo/resources/fish?per_page=6",
+    viewport: { width: 1440, height: 900 },
+    settle: 800,
+    prepare: async (page) => {
+      await compose(closeSidebar, matBg, hideKbd)(page);
+      await page.locator("a.button.button--color-fuchsia").filter({ hasText: "Dummy action" }).click();
+      await page.waitForSelector('#modal_frame [role="dialog"]', { timeout: 10000 });
+      await page.locator("#modal_frame").getByRole("button", { name: /Run/i }).click();
+      await page.waitForSelector("#alerts .alert--success", { timeout: 15000 });
+      await wait(500)(page);
+    },
+    clipFrom: "#alerts .alert--success",
+    selector: "#alerts .alert--danger",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/alert/alert-response.png",
+    display: "half",
+    alt: "Avo action feedback notifications: success, info, warning, and error alerts stacked.",
+    source: { file: "docs/4.0/actions/execution.md", prompt: "action feedback alert types succeed inform warn error" },
+  },
+
+  // dynamic-filters (avo-advanced) — filters bar + open card over a 6-row index table.
+  // per_page=6; sidebar closed + mat bg. See DF_CLIP_* constants and probe-df-context.mjs.
+
+  // Boolean (users → "Is active"): default card, Is true condition + Apply.
+  {
+    id: "dynamic-filters-boolean",
+    path: "/avo/resources/users?per_page=6",
+    viewport: { width: 1024, height: 1320 },
+    settle: 800,
+    prepare: dfUsersPrepare("Is active"),
+    // Zoomed-in (~1.5×) at a narrowed viewport so the WHOLE table (all columns + pagination) fits at
+    // the same component scale. Clip = filters bar → table → pagination, sidebar closed, small mat pad.
+    // x:12 keeps a left mat gap so the "Add filter" button + table left border aren't flush-cut.
+    clip: { x: 12, y: 607, width: 1000, height: 426 },
+    display: "full",
+    out: "docs/public/assets/img/4_0/dynamic-filters/boolean.png",
+    alt: "Avo Users index with six rows per page: the Is active dynamic filter pill and open card showing the Is true condition and Apply button over the table.",
+  },
+  // Boolean conditions expanded: Is true / Is false / Is null / Is not null.
+  {
+    id: "dynamic-filters-boolean-conditions",
+    path: "/avo/resources/users?per_page=6",
+    viewport: { width: 1024, height: 1320 },
+    settle: 800,
+    prepare: dfUsersPrepare("Is active", expandFilterConditions),
+    clip: { x: 12, y: 607, width: 1000, height: 426 },
+    display: "full",
+    out: "docs/public/assets/img/4_0/dynamic-filters/boolean2.png",
+    alt: "Avo Users index with the Is active dynamic filter: condition list expanded over the table showing Is true, Is false, Is null and Is not null.",
+  },
+
+  // Date (teams → "Created at"): flatpickr calendar + time picker open.
+  {
+    id: "dynamic-filters-date-calendar",
+    path: "/avo/resources/teams?per_page=6",
+    viewport: { width: 1024, height: 1320 },
+    settle: 800,
+    prepare: dfTeamsPrepare("Created at", openFilterCalendar),
+    clip: { x: 12, y: 242, width: 1000, height: 526 },
+    display: "full",
+    out: "docs/public/assets/img/4_0/dynamic-filters/date3.png",
+    alt: "Avo Teams index with six rows per page: the Created at dynamic filter with flatpickr calendar and time picker open over the table.",
+  },
+  // Date conditions expanded: Is / Is not / Is on or before / Is on or after / Is within.
+  {
+    id: "dynamic-filters-date-conditions",
+    path: "/avo/resources/teams?per_page=6",
+    viewport: { width: 1024, height: 1320 },
+    settle: 800,
+    prepare: dfTeamsPrepare("Created at", expandFilterConditions),
+    clip: { x: 12, y: 242, width: 1000, height: 408 },
+    display: "full",
+    out: "docs/public/assets/img/4_0/dynamic-filters/date2.png",
+    alt: "Avo Teams index with the Created at dynamic filter: condition list expanded over the table.",
+  },
+
+  // Number (teams → "ID"): default card, = condition + value input + Apply.
+  {
+    id: "dynamic-filters-number",
+    path: "/avo/resources/teams?per_page=6",
+    viewport: { width: 1024, height: 1320 },
+    settle: 800,
+    prepare: dfTeamsPrepare("ID"),
+    clip: { x: 12, y: 242, width: 1000, height: 408 },
+    display: "full",
+    out: "docs/public/assets/img/4_0/dynamic-filters/number.png",
+    alt: "Avo Teams index with six rows per page: the ID dynamic filter pill and open card over the table.",
+  },
+  // Number conditions expanded: =, !=, >, >=, <, <=, Is within.
+  {
+    id: "dynamic-filters-number-conditions",
+    path: "/avo/resources/teams?per_page=6",
+    viewport: { width: 1024, height: 1320 },
+    settle: 800,
+    prepare: dfTeamsPrepare("ID", expandFilterConditions),
+    clip: { x: 12, y: 242, width: 1000, height: 408 },
+    display: "full",
+    out: "docs/public/assets/img/4_0/dynamic-filters/number2.png",
+    alt: "Avo Teams index with the ID dynamic filter: condition operators expanded over the table.",
+  },
+
+  // Select (courses → "Country"): default card, Is condition + value picker + Apply.
+  {
+    id: "dynamic-filters-select",
+    path: "/avo/resources/courses?per_page=6",
+    viewport: { width: 1024, height: 1320 },
+    settle: 800,
+    prepare: dfCoursesPrepare("Country"),
+    clip: { x: 12, y: 242, width: 1000, height: 408 },
+    display: "full",
+    out: "docs/public/assets/img/4_0/dynamic-filters/select.png",
+    alt: "Avo Courses index with six rows per page: the Country dynamic filter pill and open card over the table.",
+  },
+  // Select conditions expanded: Is / Is not / Is null / Is not null.
+  {
+    id: "dynamic-filters-select-conditions",
+    path: "/avo/resources/courses?per_page=6",
+    viewport: { width: 1024, height: 1320 },
+    settle: 800,
+    prepare: dfCoursesPrepare("Country", expandFilterConditions),
+    clip: { x: 12, y: 242, width: 1000, height: 408 },
+    display: "full",
+    out: "docs/public/assets/img/4_0/dynamic-filters/select2.png",
+    alt: "Avo Courses index with the Country dynamic filter: condition list expanded over the table.",
+  },
+
+  // Text (users → "First name"): default card, Contains condition + value input + Apply.
+  {
+    id: "dynamic-filters-text",
+    path: "/avo/resources/users?per_page=6",
+    viewport: { width: 1024, height: 1320 },
+    settle: 800,
+    prepare: dfUsersPrepare("First name"),
+    clip: { x: 12, y: 607, width: 1000, height: 426 },
+    display: "full",
+    out: "docs/public/assets/img/4_0/dynamic-filters/text.png",
+    alt: "Avo Users index with six rows per page: the First name dynamic filter pill and open card over the table.",
+  },
+  // Text conditions expanded: Contains, Does not contain, Is, Is not, Starts with, Ends with, …
+  {
+    id: "dynamic-filters-text-conditions",
+    path: "/avo/resources/users?per_page=6",
+    viewport: { width: 1024, height: 1320 },
+    settle: 800,
+    prepare: dfUsersPrepare("First name", expandFilterConditions),
+    clip: { x: 12, y: 607, width: 1000, height: 426 },
+    display: "full",
+    out: "docs/public/assets/img/4_0/dynamic-filters/text2.png",
+    alt: "Avo Users index with the First name dynamic filter: text conditions expanded over the table.",
+  },
+
+  // Tags (courses → "Skills"): default card, Are condition + tag input + Apply.
+  {
+    id: "dynamic-filters-tags",
+    path: "/avo/resources/courses?per_page=6",
+    viewport: { width: 1024, height: 1320 },
+    settle: 800,
+    prepare: dfCoursesPrepare("Skills"),
+    clip: { x: 12, y: 242, width: 1000, height: 408 },
+    display: "full",
+    out: "docs/public/assets/img/4_0/dynamic-filters/tags.png",
+    alt: "Avo Courses index with six rows per page: the Skills dynamic filter pill and open card over the table.",
+  },
+  // Tags conditions expanded: Are, Contain, Overlap.
+  {
+    id: "dynamic-filters-tags-conditions",
+    path: "/avo/resources/courses?per_page=6",
+    viewport: { width: 1440, height: 900 },
+    settle: 800,
+    prepare: dfCoursesPrepare("Skills", expandFilterConditions),
+    clip: DF_CLIP_SIMPLE,
+    display: "full",
+    out: "docs/public/assets/img/4_0/dynamic-filters/tags2.png",
+    alt: "Avo Courses index with the Skills dynamic filter: tag conditions expanded over the table.",
+  },
+
+  // has_one — Team#1 (Apple) show: the `admin` has_one association panel, titled "Admin", showing the
+  // UNFOLDED child user record (ID + USER INFORMATION fields) with the Actions/Detach controls — the
+  // "peek at the Show view of the associated record" the doc describes (`field :admin, as: :has_one`).
+  // The panel is normally HIDDEN in the demo because `explicit_authorization = true` gates association
+  // panels behind `view_admin?` (undefined → false); a TEMP edit to team.rb sets
+  // `Avo.configuration.explicit_authorization = false` (reverted after capture) so every panel renders.
+  // Whole association turbo-frame captured (RULES 10/15z — complete panel with title + child = full
+  // context). Sidebar closed + mat bg (RULES 12/19a); hideKbd; symmetric 10px pad (15e/15f).
+  {
+    id: "has-one-panel",
+    path: "/avo/resources/teams/1",
+    viewport: { width: 1200, height: 1600 },
+    settle: 1200,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: "#has_one_field_show_admin",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/associations/has-one-panel.png",
+    display: "full",
+    alt: "An Avo Team show view with the admin has_one association panel titled Admin, showing the unfolded child user record with its Id and user information fields plus the Detach control.",
+    source: { file: "docs/4.0/associations/has_one.md", prompt: "has_one association panel on show view" },
+  },
+
+  // has_many `linkable` (has_many.md) — static screenshot for now: Team#1 (Apple) show page with
+  // breadcrumbs, record header, and the Memberships panel embedded below; red highlight on the
+  // linkable open-in-new-tab icon. Temp edit: team.rb `linkable: true` (reverted after).
+  // TODO(screenshot→gif): swap for has-many-linkable.gif — see GIF_SPECS `has-many-linkable-gif`.
+  {
+    id: "has-many-linkable",
+    path: "/avo/resources/teams/1",
+    viewport: { width: 1120, height: 1120 },
+    settle: 1200,
+    prepare: compose(
+      closeSidebar, matBg, hideKbd,
+      injectCSS(`a[href^="cursor://"] { display: none !important; }`),
+      async (page) => {
+        await page.evaluate(() => document.getElementById("has_many_field_show_memberships")?.scrollIntoView({ block: "start" }));
+        await page.locator("#has_many_field_show_memberships[complete]").waitFor({ timeout: 15000 });
+        await page.waitForTimeout(600);
+        await page.evaluate(() => window.scrollTo(0, 0));
+        await wait(700)(page);
+      },
+    ),
+    // Full content width (sidebar closed, RULES 12/19a) with the record header (breadcrumbs +
+    // title + Edit button, right≈1096, UNCUT) and the Memberships panel below (x25→1096,
+    // bottom≈1043). Clip = union bbox of breadcrumbs ∪ Edit ∪ memberships panel + symmetric
+    // ~10px pad (RULES 15e): x7→1114, y50→1053. All four edges land on the mat-forced .main-content.
+    clip: { x: 7, y: 50, width: 1107, height: 1003 },
+    marks: [{ selector: '#has_many_field_show_memberships a[has-data-tippy="Open in a new tab"]', type: "highlight", style: "focus" }],
+    out: "docs/public/assets/img/4_0/associations/has-many-linkable.png",
+    display: "full",
+    alt: "An Avo Team show page with the Memberships has_many association panel embedded below the record fields; the linkable open-in-new-tab icon beside the panel title is highlighted.",
+    source: { file: "docs/4.0/associations/has_many.md", prompt: "linkable association title opens the same view on a new page" },
+  },
+
+  // associations (custom label) (`/memberships?view=show`):
+  // the dedicated has_many view whose TITLE is a CUSTOM LABEL ("Members" via field_translations —
+  // the i18n localization the doc recommends for `team_members`). TEMP edit to avo.en.yml adds
+  // `field_translations.memberships → Members` (reverted after capture). Capture the WHOLE
+  // association page panel (title + action bar + table + pagination) — NOT the app top-navbar,
+  // breadcrumbs, or sidebar (RULES 12/19a). Sidebar closed + mat bg; hideKbd; symmetric 10px pad
+  // (15e/15f/15r). Annotate the custom title (prompt).
+  {
+    id: "associations-custom-label",
+    path: "/avo/resources/teams/1/memberships?view=show",
+    viewport: { width: 1100, height: 800 },
+    settle: 1200,
+    prepare: compose(
+      closeSidebar, matBg, hideKbd,
+      injectCSS(`a[href^="cursor://"] { display: none !important; }
+        .top-navbar, .breadcrumbs, .breadcrumbs__container { display: none !important; }
+        .main-content { padding-top: 0 !important; }`),
+      wait(600),
+    ),
+    selector: ".main-content .panel.w-full",
+    pad: { x: 10, y: 10 },
+    marks: [{ selector: '.main-content .panel.w-full .header__title [data-slot="text-value"]', type: "highlight", style: "focus" }],
+    out: "docs/public/assets/img/4_0/associations/associations-custom-label.png",
+    display: "full",
+    alt: "An Avo has_many association page titled Members (a custom label via field localization) showing the full index table with attach and create actions, without the app header or sidebar.",
+    source: { file: "docs/4.0/associations.md", prompt: "entier page without the header and sidebar and anotate the title" },
+  },
+
+  // ===================== cards.md + dashboards.md =====================
+  // The demo's `Dashy` dashboard (app/avo/dashboards/dashy.rb) hosts every card type the Cards
+  // page documents. Each card lazy-loads in its own turbo-frame, so the prepare scrolls the page
+  // bottom→top to trigger all the lazy frames, then a long settle lets every card finish before
+  // the shot. A single-card shot frames that card's `.card` wrapper (border + rounded corners
+  // intact, RULES 15r fully-around) with a symmetric ≤10px pad; sidebar closed + mat bg
+  // (RULES 12/19a). The dashboard-overview shot keeps the sidebar (Cards/dashboard context is
+  // explicit, RULES 12) and captures the whole grid.
+
+  // scroll the lazy dashboard frames into view (bottom then back to top) + settle so all cards load
+  // before the shot. Used by every dashboard spec below.
+  // (defined inline per-spec via `prepare` — see dashLoad)
+
+  // dashboards-overview (dashboards.md) — the Dashy dashboard as it appears in the browser
+  // viewport (NOT fullPage — fullPage stretches the fixed sidebar past the content and leaves
+  // empty space below the user profile). Sidebar kept for navigation context (RULES 12). Lazy
+  // cards are scrolled into view first; capture is viewport-only at 1440×900 — shows metrics +
+  // charts through the column/pie/bar row; the Custom partials divider + map cards below are
+  // intentionally cut off (they don't fit one screen).
+  {
+    id: "dashboards-overview",
+    path: "/avo/dashboards/dashy",
+    viewport: { width: 1440, height: 900 },
+    settle: 2500,
+    prepare: async (page) => {
+      await hideKbd(page);
+      await page.addStyleTag({ content: "a[href^='cursor://']{display:none!important}" });
+      for (let y = 0; y <= 2000; y += 500) { await page.evaluate((yy) => window.scrollTo(0, yy), y); await page.waitForTimeout(350); }
+      await page.evaluate(() => window.scrollTo(0, 0));
+      await page.waitForTimeout(1200);
+    },
+    out: "docs/public/assets/img/4_0/dashboards/dashboard.png",
+    display: "full",
+    alt: "An Avo dashboard named Dashy with the sidebar visible, showing a viewport of its card grid — metrics, charts (area, scatter, line, column, pie, bar), Percent done and Amount raised.",
+    source: { file: "docs/4.0/dashboards.md", prompt: "a dashboard overview page with its cards" },
+  },
+
+  // cards-metric — the metric card (Users count). A MetricCard renders a big number with a
+  // header (label + ranges dropdown). Frame the single card wrapper, sidebar closed + mat bg.
+  {
+    id: "cards-metric",
+    path: "/avo/dashboards/dashy",
+    viewport: { width: 1100, height: 900 },
+    settle: 1800,
+    prepare: async (page) => {
+      await closeSidebar(page); await matBg(page); await hideKbd(page);
+      await page.addStyleTag({ content: "a[href^='cursor://']{display:none!important}" });
+      await page.evaluate(() => window.scrollTo(0, 0)); await page.waitForTimeout(800);
+    },
+    selector: '.card:has([data-card-id="users_metric"])',
+    pad: { x: 4, y: 8 },
+    out: "docs/public/assets/img/4_0/cards/metric.png",
+    display: "half",
+    alt: "An Avo metric card titled “Users count” showing a large number with a range dropdown in its header.",
+    source: { file: "docs/4.0/cards.md", prompt: "a metric card showing a big number" },
+  },
+
+  // cards-chartkick — the chartkick area chart card (User signups). Frame the single card.
+  {
+    id: "cards-chartkick",
+    path: "/avo/dashboards/dashy",
+    viewport: { width: 1100, height: 900 },
+    settle: 2000,
+    prepare: async (page) => {
+      await closeSidebar(page); await matBg(page); await hideKbd(page);
+      await page.addStyleTag({ content: "a[href^='cursor://']{display:none!important}" });
+      await page.evaluate(() => window.scrollTo(0, 0)); await page.waitForTimeout(1000);
+    },
+    selector: '.card:has([data-card-id="user_signups"])',
+    pad: { x: 4, y: 8 },
+    out: "docs/public/assets/img/4_0/cards/chartkick.png",
+    display: "full",
+    alt: "An Avo chartkick card titled “User signups” rendering an area chart of signups over time.",
+    source: { file: "docs/4.0/cards.md", prompt: "a chartkick chart card" },
+  },
+
+  // cards-map — the MapCard partial card with `display_header = false`, so the embedded Google
+  // Maps iframe fills the whole card flush to its borders (the "Hide the header" example). Tall
+  // card (rows=4). The avo-dashboards beta still paints a `.card__header` strip with the label
+  // even when `display_header = false`, so to surface the DOCUMENTED state (header hidden, content
+  // flush) we hide that header strip via CSS for the map card only and let the iframe fill the
+  // card body to the top. Frame the single card wrapper, sidebar closed + mat bg.
+  {
+    id: "cards-map",
+    path: "/avo/dashboards/dashy",
+    viewport: { width: 1100, height: 1450 },
+    settle: 2200,
+    prepare: async (page) => {
+      await closeSidebar(page); await matBg(page); await hideKbd(page);
+      await page.addStyleTag({ content: "a[href^='cursor://']{display:none!important} .card:has([data-card-id='map_card']) .card__header{display:none!important}" });
+      for (let y = 0; y <= 1600; y += 400) { await page.evaluate((yy) => window.scrollTo(0, yy), y); await page.waitForTimeout(300); }
+      await page.evaluate(() => window.scrollTo(0, 0)); await page.waitForTimeout(1500);
+    },
+    selector: '.card:has([data-card-id="map_card"])',
+    pad: { x: 8, y: 8 },
+    out: "docs/public/assets/img/4_0/cards/map.png",
+    display: "full",
+    alt: "An Avo partial card embedding a Google Maps view of Manhattan, rendered flush to the card edges because the card header is hidden.",
+    source: { file: "docs/4.0/cards.md", prompt: "a map card filling the whole card with the header hidden" },
+  },
+
+  // cards-custom-partial — the PartialCard rendering custom HTML content (rows=4, cols=1), with
+  // its header + description ("This card has been loaded from a custom partial.") and the partial
+  // body. Frame the single card wrapper, sidebar closed + mat bg.
+  {
+    id: "cards-custom-partial",
+    path: "/avo/dashboards/dashy",
+    viewport: { width: 1100, height: 1450 },
+    settle: 2200,
+    prepare: async (page) => {
+      await closeSidebar(page); await matBg(page); await hideKbd(page);
+      await page.addStyleTag({ content: "a[href^='cursor://']{display:none!important}" });
+      for (let y = 0; y <= 1600; y += 400) { await page.evaluate((yy) => window.scrollTo(0, yy), y); await page.waitForTimeout(300); }
+      await page.evaluate(() => window.scrollTo(0, 0)); await page.waitForTimeout(1500);
+    },
+    selector: '.card:has([data-card-id="users_custom_card"])',
+    pad: { x: 8, y: 8 },
+    out: "docs/public/assets/img/4_0/cards/custom-partial.png",
+    display: "half",
+    alt: "A tall Avo partial card whose body is custom HTML loaded from a partial, with the description “This card has been loaded from a custom partial.”",
+    source: { file: "docs/4.0/cards.md", prompt: "a custom partial card with custom content" },
+  },
+
+  // cards-amount-raised-without-format — the AmountRaised metric card as it renders WITHOUT a
+  // `self.format` (the demo's app/avo/cards/amount_raised.rb has `prefix = "$"` and `result 9001`
+  // and NO format), so the value shows the raw number with the $ prefix. Sibling of the
+  // with-format shot. Frame the single card wrapper, sidebar closed + mat bg.
+  {
+    id: "cards-amount-raised-without-format",
+    path: "/avo/dashboards/dashy",
+    viewport: { width: 1100, height: 900 },
+    settle: 1800,
+    prepare: async (page) => {
+      await closeSidebar(page); await matBg(page); await hideKbd(page);
+      await page.addStyleTag({ content: "a[href^='cursor://']{display:none!important}" });
+      await page.evaluate(() => window.scrollTo(0, 0)); await page.waitForTimeout(900);
+    },
+    selector: '.card:has([data-card-id="amount_raised"])',
+    pad: { x: 4, y: 8 },
+    out: "docs/public/assets/img/4_0/cards/amount-raised-without-format.png",
+    display: "half",
+    alt: "An Avo metric card titled “Amount raised” showing the value with a $ prefix and no formatting applied.",
+    source: { file: "docs/4.0/cards.md", prompt: "amount raised metric card without format" },
+  },
+
+  // cards-amount-raised-with-format — the AmountRaised metric card WITH `self.format = -> {
+  // number_to_social value, start_at: 1_000 }` (temp-added to app/avo/cards/amount_raised.rb,
+  // matching the doc snippet exactly — RULES 13), so the value 9001 renders as the compact
+  // social form ("9K") with the $ prefix. Sibling of the without-format shot — SAME crop, same
+  // card. Temp edit reverted after capture. Frame the single card wrapper, sidebar closed + mat bg.
+  {
+    id: "cards-amount-raised-with-format",
+    path: "/avo/dashboards/dashy",
+    viewport: { width: 1100, height: 900 },
+    settle: 1800,
+    prepare: async (page) => {
+      await closeSidebar(page); await matBg(page); await hideKbd(page);
+      await page.addStyleTag({ content: "a[href^='cursor://']{display:none!important}" });
+      await page.evaluate(() => window.scrollTo(0, 0)); await page.waitForTimeout(900);
+    },
+    selector: '.card:has([data-card-id="amount_raised"])',
+    pad: { x: 4, y: 8 },
+    out: "docs/public/assets/img/4_0/cards/amount-raised-with-format.png",
+    display: "half",
+    alt: "An Avo metric card titled “Amount raised” showing the value formatted via number_to_social as a compact “9K” with a $ prefix.",
+    source: { file: "docs/4.0/cards.md", prompt: "amount raised metric card with number_to_social format" },
+  },
+
+  // cards-prefix-suffix — a metric card that decorates its value with BOTH a `~` prefix and a
+  // `%` suffix (the "Decorate the data using prefix and suffix" example). Temp edit (reverted
+  // after capture): the demo's Users count card (app/avo/cards/example_metric.rb) gets
+  // `self.prefix = "~"` and `self.suffix = "%"` uncommented, matching the doc snippet
+  // `self.prefix = '~'` / `self.suffix = '%'` (RULES 13). Frame the single card wrapper, sidebar
+  // closed + mat bg.
+  {
+    id: "cards-prefix-suffix",
+    path: "/avo/dashboards/dashy",
+    viewport: { width: 1100, height: 900 },
+    settle: 1800,
+    prepare: async (page) => {
+      await closeSidebar(page); await matBg(page); await hideKbd(page);
+      await page.addStyleTag({ content: "a[href^='cursor://']{display:none!important}" });
+      await page.evaluate(() => window.scrollTo(0, 0)); await page.waitForTimeout(900);
+    },
+    selector: '.card:has([data-card-id="users_metric"])',
+    pad: { x: 4, y: 8 },
+    out: "docs/public/assets/img/4_0/cards/prefix-suffix.png",
+    display: "half",
+    alt: "An Avo metric card whose value is decorated with a ~ prefix and a % suffix.",
+    source: { file: "docs/4.0/cards.md", prompt: "metric card with a prefix and suffix decorating the value" },
+  },
+
+  // cards-divider — the labelled divider ("Custom partials") that separates two groups of cards on
+  // the dashboard. Shown IN CONTEXT (RULES 15a/10b): the full row of three chart cards ABOVE, the
+  // divider line + label, then the custom-partial and map cards BELOW in full (both complete, all
+  // borders). Clip probed sidebar-closed @ 1100px: chart-row top y=676 (−8 mat), bottom y=1383
+  // (map + partial card wrappers, +8 mat), full grid width x 16→1084. Sidebar closed + mat bg.
+  {
+    id: "cards-divider",
+    path: "/avo/dashboards/dashy",
+    viewport: { width: 1100, height: 1500 },
+    settle: 2000,
+    prepare: async (page) => {
+      await closeSidebar(page); await matBg(page); await hideKbd(page);
+      await page.addStyleTag({ content: "a[href^='cursor://']{display:none!important}" });
+      for (let y = 0; y <= 1600; y += 400) { await page.evaluate((yy) => window.scrollTo(0, yy), y); await page.waitForTimeout(300); }
+      await page.evaluate(() => window.scrollTo(0, 0)); await page.waitForTimeout(1200);
+    },
+    clip: { x: 16, y: 668, width: 1068, height: 723 },
+    out: "docs/public/assets/img/4_0/cards/divider.png",
+    display: "full",
+    alt: "An Avo dashboard divider labelled “Custom partials” separating a row of chart cards above from the custom partial and map cards below, each shown in full.",
+    source: { file: "docs/4.0/cards.md", prompt: "a labelled divider separating dashboard cards" },
+  },
+
+  // ── menu-editor ──────────────────────────────────────────────────────────
+  // Sidebar-menu shots. The custom main_menu / profile_menu are surfaced by a temp override
+  // (Avo.configuration.main_menu = ... inside review.rb) per PROCESS.md. The sidebar column is
+  // ~256px CSS wide; we capture the left column (navbar logo + sidebar menu) via a clip, then
+  // DISPLAY at half the DPR-2 pixel dims (small/centered, RULES 9 — references are ~250px wide).
+
+  // 1) Custom main menu — Resources section, Company group, Projects highlighted with two
+  //    subitem links, Teams, Team memberships, Reviews.
+  {
+    id: "menu-editor-main",
+    path: "/avo/resources/projects",
+    viewport: { width: 1440, height: 900 },
+    settle: 600,
+    prepare: hideKbd,
+    clip: { x: 0, y: 0, width: 256, height: 312 },
+    out: "docs/public/assets/img/4_0/menu-editor/v4/main.png",
+    display: "half",
+    alt: "Avo custom main menu with a Resources section, a Company group, the Projects resource highlighted with First project / Second project sub-links, Teams, Team memberships and Reviews.",
+  },
+
+  // 2) all_ helpers — App section with all_resources (alphabetical resource list).
+  {
+    id: "menu-editor-all-helpers",
+    path: "/avo/resources/projects",
+    viewport: { width: 1440, height: 900 },
+    settle: 600,
+    prepare: hideKbd,
+    clip: { x: 0, y: 0, width: 256, height: 312 },
+    out: "docs/public/assets/img/4_0/menu-editor/v4/all-helpers.png",
+    display: "half",
+    alt: "Avo menu built with the all_resources helper, listing every resource alphabetically in the sidebar.",
+  },
+
+  // 3) Collapsable section + group (expanded).
+  {
+    id: "menu-editor-collapsable",
+    path: "/avo/resources/projects",
+    viewport: { width: 1440, height: 900 },
+    settle: 600,
+    prepare: hideKbd,
+    clip: { x: 4, y: 50, width: 248, height: 138 },
+    out: "docs/public/assets/img/4_0/menu-editor/collapsable.jpg",
+    display: "half",
+    alt: "A collapsable Avo sidebar section with an expanded group showing its resource links.",
+  },
+
+  // 4) Collapsed section/group state.
+  {
+    id: "menu-editor-collapsed",
+    path: "/avo/resources/projects",
+    viewport: { width: 1440, height: 900 },
+    settle: 600,
+    prepare: hideKbd,
+    clip: { x: 4, y: 50, width: 248, height: 66 },
+    out: "docs/public/assets/img/4_0/menu-editor/collapsed.jpg",
+    display: "half",
+    alt: "A collapsed Avo sidebar section/group with its child items hidden.",
+  },
+
+  // 5) Profile menu — open dropdown (Profile + Sign out) over the avatar trigger (RULES 15a).
+  {
+    id: "menu-editor-profile-menu",
+    path: "/avo/resources/projects",
+    viewport: { width: 1440, height: 900 },
+    settle: 600,
+    prepare: compose(hideKbd, hideUnder(".main-content"), hideUnder(".sidebar__body"), click(".sidebar-profile .button--style-text"), wait(600)),
+    clip: { x: 6, y: 776, width: 316, height: 120 },
+    out: "docs/public/assets/img/4_0/menu-editor/profile-menu.png",
+    display: "half",
+    alt: "The Avo profile dropdown menu open above the user avatar, showing a Profile link and a red Sign out link.",
+  },
+
+  // as-link-to-resource (customization.md "## ID links to resource") — with id_links_to_resource the
+  // index ID column renders each id as a LINK to that record's Show. Reshaped to a focused ID + Name
+  // table (RULES 10a/10b): a TEMP-minimal Teams resource (other index columns hidden via hide_on:
+  // :index, id given link_to_record: true), a narrow 860 viewport so ID + Name read at ~1× (RULES
+  // 9a), per_page=5 so the whole table card + pagination fit. Sidebar closed + mat bg (RULES 12/19a);
+  // hideKbd. Capture the whole table card with ≤10px symmetric pad — real native edges + pagination
+  // (RULES 4/10), the blue ID links are the subject. Temp team.rb edit reverted after capture.
+  {
+    id: "as-link-to-resource",
+    path: "/avo/resources/teams?per_page=5",
+    viewport: { width: 860, height: 900 },
+    settle: 900,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: '.card[data-component-name="avo/view_types/table_component"]',
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/customization/as-link-to-resource.png",
+    display: "full",
+    alt: "An Avo index where each row's ID is rendered as a blue link to that record's show view, with a Name column.",
+  },
+
+  // associations-lookup-list-limit (customization.md "### `lookup_list_limit`") — the
+  // "There are more records available." message Avo appends to a belongs_to options list when the
+  // lookup hits `lookup_list_limit`. Surfaced on the New Membership form: its `user` belongs_to is
+  // `searchable: false`, so it renders a native <select> listing User options; with a TEMP
+  // `lookup_list_limit: 5` (set in membership.rb's class body) and 55 users, the list shows 5 names +
+  // the disabled "There are more records available." option. The native popup can't be screenshot, so
+  // openSelect expands the REAL select to size=N inline (RULES 15a/openSelect) — the message shows in
+  // the field's form context. Sidebar closed + mat bg (RULES 12/19a); hideKbd. Capture the whole New
+  // form card (panel) with ≤10px symmetric pad so the User field + open list read inside the form
+  // (RULES 10b). Full dims (old shot was wide). Temp config reverted after capture.
+  {
+    id: "associations-lookup-list-limit",
+    path: "/avo/resources/memberships/new",
+    viewport: { width: 900, height: 1000 },
+    settle: 900,
+    prepare: compose(
+      closeSidebar,
+      matBg,
+      hideKbd,
+      openSelect("#team_membership_user_id"),
+      wait(400),
+    ),
+    // form card x17-884 y186-464 (probed, sidebar closed) + ≤10px symmetric mat; the expanded select
+    // (to y377) sits inside, so the whole New form card with the open list reads as one (RULES 10b/4).
+    clip: { x: 7, y: 176, width: 887, height: 298 },
+    // Red box around the disabled "There are more records available." option. The option's own
+    // bounding box (page y≈355, 17px tall) abuts "Allan Labadie" above, so a selector box top would
+    // graze it — use an explicit viewport box inset ~3px at the top to clear Allan (viewport CSS-px;
+    // capture.mjs offsets by the clip origin). openSelect expands the native <select> inline.
+    marks: [{ box: { x: 254, y: 358, width: 221, height: 13 }, type: "highlight", pad: 1 }],
+    out: "docs/public/assets/img/4_0/customization/associations-lookup-list-limit.png",
+    display: "full",
+    alt: "An Avo new form where a belongs_to user select lists five records followed by a disabled 'There are more records available.' message when the lookup list limit is reached.",
+  },
+
+  // custom-fields progress-show (custom-fields.md "## Generate a new field" → after registering
+  // `field :progress, as: :progress_bar`) — the progress_bar field rendered on the SHOW view. The
+  // built-in Avo progress_bar (which this tutorial recreates) renders a real progress bar + the
+  // value. Captured from a clean temp resource (ProgressShotDemo, a Project subclass) where the
+  // `:progress` field is wrapped in its OWN `panel do card do … end end` (RULES 15z) so it sits in a
+  // dedicated content-sized card; the field reads "Progress" + "98%" (record id=1). Sidebar closed +
+  // mat bg (RULES 12/19a); hideKbd. Whole card via selector `.card` (the progress card is the only/
+  // first .card on the page) + ≤10px symmetric pad. Narrow 900 viewport so it displays ~1× (RULES 9a).
+  {
+    id: "progress-show",
+    path: "/avo/resources/progress_shot_demos/1",
+    viewport: { width: 680, height: 760 },
+    settle: 800,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: ".card",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/custom-fields/progress-show.png",
+    display: "full",
+    alt: "A progress_bar custom field on an Avo Show view, rendering a green progress bar with the value 98% above it.",
+    source: { file: "docs/4.0/custom-fields.md", prompt: "the progress custom field on the show view" },
+  },
+
+  // custom-fields progress-index (custom-fields.md "## Customize the views") — the progress_bar
+  // field rendered as a small bar (w-24) in the INDEX cell, with the value+suffix above it
+  // (`display_value: true, value_suffix: "%"`). RESHAPED to a focused ~3-column table (ID, Name,
+  // Progress) with a few MIDDLE rows (RULES 10a/9a/15i): the temp ProgressShotDemo resource exposes
+  // only id, name and progress on index; small per_page so a real pager shows. Sidebar closed + mat
+  // bg (RULES 12/19a); hideKbd. Narrow viewport so columns are tight + text near 1×. Whole table card
+  // via selector + ≤10px symmetric pad (RULES 10/20).
+  {
+    id: "progress-index",
+    path: "/avo/resources/progress_shot_demos?per_page=4",
+    viewport: { width: 760, height: 760 },
+    settle: 900,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: ".card",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/custom-fields/progress-index.png",
+    display: "full",
+    alt: "An Avo index table with ID, Name and Progress columns, where Progress renders a small progress bar with the value and a percent suffix above it.",
+    source: { file: "docs/4.0/custom-fields.md", prompt: "the progress custom field on the index view" },
+  },
+
+  // custom-fields progress-edit (custom-fields.md "## Customize the views" → the Edit range input) —
+  // the progress_bar field on the EDIT form as a range input with the value+suffix shown above it.
+  // Captured from the temp ProgressShotDemo edit form (id=1) where `:progress` is wrapped in its OWN
+  // panel/card (RULES 15z/15y — Form view shows the full range control); `step: 10, display_value:
+  // true, value_suffix: "%"`. NARROW viewport (~820) so the single-field form card displays ~1× with
+  // the label stacked above the input (RULES 9b). Sidebar closed + mat bg (RULES 12/19a); hideKbd.
+  // Whole card via selector `.card` (the progress card) + ≤10px symmetric pad.
+  {
+    id: "progress-edit",
+    path: "/avo/resources/progress_shot_demos/1/edit",
+    viewport: { width: 640, height: 760 },
+    settle: 800,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: ".card",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/custom-fields/progress-edit.png",
+    display: "full",
+    alt: "A progress_bar custom field on an Avo Edit form, rendered as a range slider with the current value and percent suffix shown above it.",
+    source: { file: "docs/4.0/custom-fields.md", prompt: "the progress custom field on the edit view" },
+  },
+
+  // guide-bulk_destroy (guides/bulk_destroy_action_using_customizable_controls.md) — the bulk-destroy
+  // action surfaced as a customizable INDEX control (the red trash button top-right) plus its open
+  // confirmation modal. The demo's base_resource registers `Avo::Actions::BulkDestroy` as an
+  // `index_control` on Products/Posts/Users/etc (icon trash, color red, style outline) exactly per the
+  // guide. We use Products (table view) because its first four records have clean titles (Apple Watch,
+  // MacBook Pro, iPhone, iPod): select those four rows, then click the red destroy control → the action
+  // modal opens listing "Are you sure you want to delete these 4 records?", the scrollable record list,
+  // and the "This action cannot be undone." warning with Cancel / Run — the exact UI the guide
+  // describes. Red group box around the header select-all + four checked row checkboxes; red focus
+  // ring on the bulk-destroy trigger (native blue focus ring stripped via injectCSS). Sidebar closed +
+  // mat bg (RULES 12/19a); hideKbd. clip frames the red control row → table card → modal.
+  {
+    id: "guide-bulk_destroy-bulk_destroy_image",
+    path: "/avo/resources/products?per_page=6&view_type=table",
+    viewport: { width: 1280, height: 900 },
+    settle: 900,
+    prepare: compose(
+      closeSidebar,
+      matBg,
+      hideKbd,
+      injectCSS(`a.button--color-red:focus, a.button--color-red:focus-visible,
+        a[class*="color-r"]:focus, a[class*="color-r"]:focus-visible {
+        outline: none !important; box-shadow: none !important;
+      }`),
+      async (page) => {
+        await page.waitForTimeout(300);
+        // select the four named rows (tbody indices 2..5 = Apple Watch, MacBook Pro, iPhone, iPod)
+        const rows = page.locator('tbody tr input[type="checkbox"]');
+        const n = await rows.count();
+        for (let i = 2; i < n; i++) await rows.nth(i).click();
+        await page.waitForTimeout(300);
+        // click the red customizable bulk-destroy control → opens the confirmation modal
+        await page.locator('a.button--color-red, a[class*="color-r"]').first().click();
+        await page.waitForSelector('text=This action cannot be undone', { timeout: 8000 }).catch(() => {});
+        await page.waitForTimeout(900);
+        await page.evaluate(() => document.activeElement?.blur?.());
+      },
+    ),
+    clip: { x: 12, y: 106, width: 1256, height: 500 },
+    marks: [
+      { box: { x: 41, y: 235, width: 17, height: 293 }, type: "highlight", color: "#ef4444" },
+      { selector: 'a.button--color-red, a[class*="color-r"]', type: "highlight", style: "focus", color: "#ef4444" },
+    ],
+    out: "docs/public/assets/img/4_0/guides/bulk_destroy/bulk_destroy_image.png",
+    display: "full",
+    alt: "An Avo Products index with four records selected and the customizable bulk-destroy control (red trash button) clicked, opening a confirmation modal that lists the records to be deleted and warns the action cannot be undone.",
+    source: { file: "docs/4.0/guides/bulk_destroy_action_using_customizable_controls.md", prompt: "a bulk-destroy action surfaced via customizable controls on an index (selected rows + the destroy control)" },
+  },
+
+  // guide-display-scope-record-count (guides/display-scope-record-count.md) — the scopes tab bar
+  // showing a record-count badge on the Active scope. Temp-edit `Active` scope `name` to the guide's
+  // callable + gray pill (RULES 13). Full-width scopes bar + index toolbar + table header for
+  // natural context (not the old tight 366×64 strip). Red highlight on the count badge (RULES 15d).
+  // Sidebar closed + mat bg (RULES 12/19a); hideKbd. Temp scope edit reverted after capture.
+  {
+    id: "guide-display-scope-record-count-scopes",
+    path: "/avo/resources/users?per_page=6",
+    viewport: { width: 900, height: 900 },
+    settle: 900,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    clip: { x: 7, y: 488, width: 887, height: 198 },
+    marks: [{ selector: "span.bg-gray-500", type: "highlight", color: "#ef4444" }],
+    out: "docs/public/assets/img/4_0/guides/display-scope-record-count/scopes.png",
+    display: "full",
+    alt: "An Avo Users index with the scopes tab bar — All, Admins, Non admins, Active — where the Active scope shows a small gray badge with the record count, highlighted in red.",
+    source: { file: "docs/4.0/guides/display-scope-record-count.md", prompt: "the scopes bar showing record counts next to each scope name" },
+  },
+
+  // guide-conditionally-render-styled-rows (guides/conditionally-render-styled-rows.md) — an index
+  // whose ROWS are conditionally styled (colored background) via the guide's `:has()` CSS trick. The
+  // guide attaches a `soft-deleted` class to the `:id` field wrapper of the records to mark (even ids
+  // in the example) then targets `tr[…table_row_component]:has(.soft-deleted)` with a red background.
+  // We reproduce it on the Projects index: temp-edit Project#fields' `:id` field with the guide's
+  // EXACT `html -> { index { wrapper { classes { record.id.even? ? 'soft-deleted' } } } }` block
+  // (RULES 13), and inject the guide's row-background CSS in prepare (a raw `#fef2f2`, which the demo's
+  // Tailwind purge can't strip since it's literal CSS — RULES 15n; plus a dark-mode red so the dark
+  // shot stays legible — RULES 15m). The even-id rows (36/34/32) then render with a light-red
+  // background, the odd rows plain — exactly the conditional row styling. Table-as-a-whole shot so the
+  // full table + pagination read together (RULES 10); whole `.card` via selector + symmetric ≤10px
+  // pad. Sidebar closed + mat bg (RULES 12/19a); hideKbd. Temp resource edit reverted after captures.
+  {
+    id: "guide-conditionally-render-styled-rows-conditionally-render-styled-rows",
+    path: "/avo/resources/projects?per_page=6&view_type=table",
+    viewport: { width: 1280, height: 950 },
+    settle: 900,
+    prepare: async (page) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await page.addStyleTag({ content: `
+        tr[data-component-name="avo/index/table_row_component"]:has(.soft-deleted){ background:#fef2f2 !important; }
+        @media (prefers-color-scheme: dark){ tr[data-component-name="avo/index/table_row_component"]:has(.soft-deleted){ background:#3f1d1d !important; } }
+      ` });
+      await page.waitForTimeout(300);
+    },
+    selector: ".card",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/guides/conditionally-render-styled-rows/conditionally-render-styled-rows.png",
+    display: "full",
+    alt: "An Avo Projects index where the even-id rows are rendered with a light-red background via a conditional CSS class, while the odd-id rows stay plain.",
+    source: { file: "docs/4.0/guides/conditionally-render-styled-rows.md", prompt: "an index whose rows are conditionally styled (colored row backgrounds)" },
+  },
+  // format-ruby-object-to-json (guides/format-ruby-object-to-json.md) — the `meta` code field on a
+  // Project Show, BEFORE the pretty-print formatter: the JSON renders on one wrapped line, hard to
+  // read. Temp Project resource shows only id + `field :meta, as: :code, language: "javascript"`;
+  // project 2's meta temp-seeded to a 3-item todo array. Whole Show `.card` (id + meta rows) via
+  // selector + symmetric pad; sidebar closed + mat bg (RULES 12/19a); hideKbd.
+  {
+    id: "guide-format-ruby-object-to-json-before",
+    path: "/avo/resources/projects/2",
+    viewport: { width: 1280, height: 950 },
+    settle: 800,
+    prepare: async (page) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+    },
+    selector: ".card",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/guides/format-ruby-object-to-json/before.png",
+    display: "full",
+    alt: "A Project Show page with the meta JSON rendered as a code field on a single hard-to-read wrapped line.",
+    source: { file: "docs/4.0/guides/format-ruby-object-to-json.md", prompt: "the meta code field before formatting — raw one-line JSON" },
+  },
+  // use-markdown-in-help-attributes (guides/use-markdown-in-help-attributes.md) — a field on a form
+  // whose `help:` text is RENDERED MARKDOWN (headings, a bold paragraph, a fenced code block, an
+  // inline code span and a bullet list). Temp Project resource renders a single `markdown` field in
+  // its own panel/card (RULES 15z) with `help: markdown_help(<<~MARKDOWN …)`; the resource carries
+  // the guide's Redcarpet renderer + `markdown_help` helper so the help is genuinely compiled from
+  // markdown (not faked). Captured on the New form (the field + its rendered help below the editor).
+  // Whole `.card` via selector + symmetric pad; sidebar closed + mat bg (RULES 12/19a); hideKbd.
+  {
+    id: "guide-use-markdown-in-help-attributes-result",
+    path: "/avo/resources/projects/new",
+    viewport: { width: 900, height: 1400 },
+    settle: 900,
+    prepare: async (page) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      // The demo's Tailwind purges the help list's `list-disc` (RULES 15n) and marksmith's editor
+      // CSS resets list markers; restore the bullets so the rendered <ul> matches the doc's output.
+      await page.addStyleTag({ content: `
+        .help ul, [class*="help"] ul, section ul.list-disc { list-style: disc !important; }
+        section ul.list-disc li, .help ul li { display: list-item !important; }
+      ` });
+    },
+    selector: ".card",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/guides/use-markdown-in-help-attributes/result.png",
+    display: "full",
+    alt: "A markdown field on a New form whose help text is rendered markdown — headings (Dog, Cat, bird), a bold paragraph, a code block, an inline code span and a bullet list.",
+    source: { file: "docs/4.0/guides/use-markdown-in-help-attributes.md", prompt: "a field whose help attribute is rendered markdown" },
+  },
+  // safely-override-resource-components (guides/safely-override-resource-components.md) — SHOT 1:
+  // after wiring a custom index component (extends Avo::Views::ResourceIndexComponent) onto the Movie
+  // resource via `self.components`, the Movies index renders the component's placeholder template
+  // ("Add Avo::Views::ResourceCustomIndexComponent template here") instead of the table. Temp
+  // component (rb + erb placeholder) + Movie `self.components` wiring. Content area (breadcrumb + the
+  // placeholder line) with sidebar closed + mat bg (RULES 12/19a); hideKbd.
+  {
+    id: "guide-safely-override-resource-components-custom-index-component-1",
+    // Re-captured at 200% zoom (RULES 9a legibility) to match sibling shot 2. The viewport is held
+    // at 1800 (NOT widened) and `.main-content { zoom: 2 }` magnifies the content → effective layout
+    // 1800/2 = 900, so the content is painted 2× inside the same-width frame and reads LARGER on the
+    // full-width image. (Widening the viewport with the zoom cancels the effect — effective width
+    // stays constant and the on-page size doesn't change.) Clip probed from the zoomed layout:
+    // breadcrumb top − 10px down to the placeholder line bottom + 10px (short shot — no table),
+    // ~10px symmetric side mat.
+    path: "/avo/resources/movies",
+    viewport: { width: 1800, height: 1300 },
+    settle: 800,
+    prepare: async (page) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await injectCSS(".main-content { zoom: 2; }")(page);
+    },
+    clip: { x: 22, y: 86, width: 1756, height: 148 },
+    out: "docs/public/assets/img/4_0/guides/safely-override-resource-components/custom_index_component_1.png",
+    display: "full",
+    alt: "The Movies index rendering the custom index component's placeholder text instead of a table, after wiring it via self.components.",
+    source: { file: "docs/4.0/guides/safely-override-resource-components.md", prompt: "the Movies index showing the custom component placeholder text" },
+  },
+  // safely-override-resource-components — SHOT 2: the custom component now wraps the original index
+  // component and adds a blue "MovieFest 2025 • Discover what's trending…" message banner ABOVE the
+  // table. Temp component template renders the banner + `render Avo::Views::ResourceIndexComponent
+  // .new(**@kwargs)`. Content area = the message banner + the full Movies table + pagination
+  // (RULES 10); sidebar closed + mat bg (RULES 12/19a); hideKbd.
+  {
+    id: "guide-safely-override-resource-components-custom-index-component-2",
+    // Re-captured at 200% zoom (RULES 9a legibility). The viewport is held at 1800 (NOT widened) and
+    // `.main-content { zoom: 2 }` magnifies the content → effective layout 1800/2 = 900, so the banner
+    // + table are painted 2× inside the same-width frame and read LARGER on the full-width image.
+    // (Widening the viewport with the zoom cancels the effect.) The table still keeps all columns
+    // (ID/Name/Release date/Fun fact) at effective 900. Clip probed from the zoomed layout: top =
+    // banner top − 10px, bottom = the table panel/pagination bottom + 10px (RULES 10/20), x/width =
+    // banner span + ~10px symmetric mat.
+    path: "/avo/resources/movies",
+    viewport: { width: 1800, height: 1300 },
+    settle: 900,
+    prepare: async (page) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await injectCSS(".main-content { zoom: 2; }")(page);
+    },
+    clip: { x: 38, y: 166, width: 1724, height: 706 },
+    out: "docs/public/assets/img/4_0/guides/safely-override-resource-components/custom_index_component_2.png",
+    display: "full",
+    alt: "The Movies index with a blue MovieFest 2025 message banner rendered above the table by the custom index component.",
+    source: { file: "docs/4.0/guides/safely-override-resource-components.md", prompt: "the Movies index with a custom message banner above the table" },
+  },
+  // tabs-counter-indicator (guides/tabs-counter-indicator.md) — a tabs switcher whose labels carry a
+  // counter badge (count of associated records). Temp TabsDemo resource wraps the Teams/People tab
+  // titles with the doc's `name_with_counter(name, count)` helper (sanitized HTML badge); record 41
+  // temp-seeded to teams=2 / people=1 so the badges read "2" and "1" exactly like the legacy shot.
+  // Teams tab made active (focus) so its badge stands out. Whole `.tabs` switcher row via selector +
+  // symmetric pad; sidebar closed + mat bg (RULES 12/19a); hideKbd.
+  {
+    id: "guide-tabs-counter-indicator-tabs-counter",
+    path: "/avo/resources/tabs_demos/41",
+    viewport: { width: 1280, height: 950 },
+    settle: 800,
+    prepare: async (page) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      // activate the Teams tab (the .tabs row's Teams link) so its counter badge is highlighted
+      const teams = page.locator('.tabs:visible a', { hasText: 'Teams' }).first();
+      try { await teams.click({ timeout: 4000 }); await page.waitForTimeout(600); } catch (e) {}
+    },
+    // tight clip to the tab labels (RULES 15c) — the .tabs row is wider than its content,
+    // so clip from the row's left to just past the last (Projects) tab, full row height + pad.
+    clip: { x: 156, y: 322, width: 522, height: 64 },
+    out: "docs/public/assets/img/4_0/guides/tabs-counter-indicator/tabs_counter.png",
+    display: "half",
+    alt: "An Avo tabs switcher where the Teams and People tab labels each show a small grey counter badge with the number of associated records.",
+    source: { file: "docs/4.0/guides/tabs-counter-indicator.md", prompt: "a tabs switcher whose labels show a record-count badge" },
+  },
+  // format-ruby-object-to-json — AFTER: same `meta` code field, now passed through
+  // `JSON.pretty_generate(record.meta.as_json)` so it renders multi-line, indented and readable.
+  // Temp Project resource uses the `do … end` computed code field; same project 2 seed + framing.
+  {
+    id: "guide-format-ruby-object-to-json-after",
+    path: "/avo/resources/projects/2",
+    viewport: { width: 1280, height: 1100 },
+    settle: 800,
+    prepare: async (page) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+    },
+    selector: ".card",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/guides/format-ruby-object-to-json/after.png",
+    display: "full",
+    alt: "The same Project Show page with the meta JSON pretty-printed in the code field — multi-line, indented and easy to read.",
+    source: { file: "docs/4.0/guides/format-ruby-object-to-json.md", prompt: "the meta code field after formatting — pretty-printed multi-line JSON" },
+  },
+
+  // ---- common/ association-panel shared partials (TEMP edit: user.rb adds a direct
+  // `:comments` has_many panel on Show with reloadable/name/scope/description options, and sets
+  // explicit_authorization=false so association panels render; reverted after capture).
+  // Each captures the whole comments association turbo-frame (RULES 10/15z) on User#1's Show.
+
+  // associations_description_option_common.md — the `description` option: the text shown under
+  // the association title. TEMP edit: user.rb sets name/description on `:comments`; user_policy.rb
+  // adds `view_comments?` (explicit_authorization); reverted after capture.
+  {
+    id: "common-description-option",
+    path: "/avo/resources/users/1",
+    viewport: { width: 1100, height: 1400 },
+    settle: 1200,
+    prepare: compose(
+      closeSidebar, matBg, hideKbd,
+      injectCSS(`#has_many_field_show_comments .header__description { width: fit-content; display: inline-block; }`),
+      async (page) => {
+        await page.evaluate(() => document.getElementById("has_many_field_show_comments")?.scrollIntoView({ block: "center" }));
+        await page.locator("#has_many_field_show_comments[complete]").waitFor({ timeout: 20000 });
+        await wait(600)(page);
+      },
+    ),
+    selector: "#has_many_field_show_comments",
+    pad: { x: 10, y: 10 },
+    marks: [{ selector: "#has_many_field_show_comments .header__description", type: "highlight", style: "focus", pad: 1 }],
+    out: "docs/public/assets/img/4_0/common/associations/description-option.png",
+    display: "full",
+    alt: "A has_many association panel with the description text shown under the association title",
+    source: { file: "docs/4.0/common/associations_description_option_common.md", prompt: "association panel with a description under its title" },
+  },
+
+  // reloadable.md — the reload icon next to the association title. Header strip only; red highlight
+  // on the reload control (not the native blue focus ring — stripped via injectCSS). TEMP edit:
+  // user.rb sets reloadable/name/description on `:comments`; user_policy.rb adds view_comments?;
+  // reverted after capture.
+  {
+    id: "common-reloadable",
+    path: "/avo/resources/users/1",
+    viewport: { width: 1100, height: 1400 },
+    settle: 1200,
+    prepare: compose(
+      closeSidebar, matBg, hideKbd,
+      injectCSS(`#has_many_field_show_comments [data-controller="panel-refresh"],
+        #has_many_field_show_comments [data-action*="panel-refresh#refresh"] {
+          outline: none !important; box-shadow: none !important;
+        }`),
+      async (page) => {
+        await page.evaluate(() => document.getElementById("has_many_field_show_comments")?.scrollIntoView({ block: "center" }));
+        await page.locator("#has_many_field_show_comments[complete]").waitFor({ timeout: 20000 });
+        await wait(600)(page);
+      },
+    ),
+    selector: "#has_many_field_show_comments .header",
+    pad: { x: 10, y: 10 },
+    marks: [{
+      selector: '#has_many_field_show_comments [data-action*="panel-refresh#refresh"]',
+      type: "highlight",
+      color: "#ef4444",
+      pad: 2,
+      stroke: 2,
+      radius: 3,
+    }],
+    out: "docs/public/assets/img/4_0/common/reloadable.png",
+    display: "full",
+    alt: "An association panel header with the reload icon (highlighted) next to the association title",
+    source: { file: "docs/4.0/common/reloadable.md", prompt: "the reload icon next to an association panel title" },
+  },
+
+  // scopes_common.md — a has_many association panel with a scope applied (the scoped list of
+  // associated records). Whole panel: title + scoped rows + pagination.
+  {
+    id: "common-scope",
+    path: "/avo/resources/users/1",
+    viewport: { width: 1100, height: 1400 },
+    settle: 1200,
+    prepare: compose(
+      closeSidebar, matBg, hideKbd,
+      async (page) => {
+        await page.locator("#has_many_field_show_comments[complete]").waitFor({ timeout: 15000 });
+        await wait(600)(page);
+      },
+    ),
+    selector: "#has_many_field_show_comments",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/common/associations/scope.png",
+    display: "full",
+    alt: "An Avo has_many association panel showing a scoped list of associated records.",
+    source: { file: "docs/4.0/common/scopes_common.md", prompt: "has_many association panel with a scope applied" },
+  },
+
+  // show_hide_buttons_common.md — header controls (Actions, Attach, Create) + per-row controls
+  // (show, edit, delete) governed by authorization. Two red highlights: `.header__controls`
+  // and the row-controls column (union box probed at 1100×1400). Commentable column hidden.
+  // TEMP edit: user.rb name/description on `:comments`; user_policy.rb association policy
+  // methods; comment.rb adds Dummy action for header Actions; reverted after capture.
+  {
+    id: "common-authorization",
+    path: "/avo/resources/users/1",
+    viewport: { width: 1100, height: 1400 },
+    settle: 1200,
+    prepare: compose(
+      closeSidebar, matBg, hideKbd, hideIndexColumns("commentable"),
+      async (page) => {
+        await page.evaluate(() => document.getElementById("has_many_field_show_comments")?.scrollIntoView({ block: "center" }));
+        await page.locator("#has_many_field_show_comments[complete]").waitFor({ timeout: 20000 });
+        await wait(600)(page);
+      },
+    ),
+    selector: "#has_many_field_show_comments",
+    pad: { x: 10, y: 10 },
+    marks: [
+      { selector: "#has_many_field_show_comments .header__controls", type: "highlight", color: "#ef4444", pad: 2, stroke: 2 },
+      { box: { x: 957, y: 1020, width: 113, height: 189 }, type: "highlight", color: "#ef4444", pad: 2, stroke: 2 },
+    ],
+    out: "docs/public/assets/img/4_0/common/associations/authorization.png",
+    display: "full",
+    alt: "An Avo has_many association panel whose header Actions, Attach, and Create buttons and per-row show, edit, and delete controls are governed by authorization policies.",
+    source: { file: "docs/4.0/common/show_hide_buttons_common.md", prompt: "association panel action buttons governed by authorization" },
+  },
+
+  // associations_name_option_common.md — the `name` option: the association panel TITLE uses a
+  // custom name. Whole panel.
+  {
+    id: "common-name-option",
+    path: "/avo/resources/users/1",
+    viewport: { width: 1100, height: 1400 },
+    settle: 1200,
+    prepare: compose(
+      closeSidebar, matBg, hideKbd,
+      async (page) => {
+        await page.evaluate(() => document.getElementById("has_many_field_show_comments")?.scrollIntoView({ block: "center" }));
+        await page.locator("#has_many_field_show_comments[complete]").waitFor({ timeout: 15000 });
+        await wait(600)(page);
+      },
+    ),
+    selector: "#has_many_field_show_comments",
+    pad: { x: 10, y: 10 },
+    marks: [{ selector: '#has_many_field_show_comments .header__title [data-slot="text-value"]', type: "highlight", style: "focus" }],
+    out: "docs/public/assets/img/4_0/common/associations/name-option.png",
+    display: "full",
+    alt: "An Avo has_many association panel whose title uses a custom name option.",
+    source: { file: "docs/4.0/common/associations_name_option_common.md", prompt: "association panel whose title uses the name option" },
+  },
+
+  // ---- faq.md "Render new lines for textarea fields" — textarea preserves newlines on Show
+  // by default (whitespace-pre-line in the show component). TEMP edit: comment.rb wraps `body`
+  // in its own card (RULES 15z); comment #282 has a 3-line body. Switch format_using between
+  // captures (see notes). Narrow viewport so the card hugs + displays ~1× (RULES 9b/15z).
+
+  // edit.png — Body textarea on Edit with multi-line content.
+  // comment.rb: panel/card, `field :body, as: :textarea, stacked: true` (no format_using).
+  {
+    id: "faq-newline-edit",
+    path: "/avo/resources/comments/282/edit",
+    viewport: { width: 760, height: 900 },
+    settle: 700,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: ".card:has(textarea)",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/faq/newline/edit.png",
+    display: "full",
+    alt: "A textarea Body field on the Edit form showing multi-line content with a trailing empty line after the last sentence.",
+    source: { file: "docs/4.0/faq.md", prompt: "textarea field with newlines on the edit form" },
+  },
+
+  // show.png — same value on Show; trailing newlines render via an extra <br> in the show component.
+  // comment.rb: panel/card, stacked body only (no format_using). Record #282 ends with a newline.
+  {
+    id: "faq-newline-show",
+    path: "/avo/resources/comments/282",
+    viewport: { width: 760, height: 900 },
+    settle: 700,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: ".card:has([data-field-type='textarea'])",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/faq/newline/show.png",
+    display: "full",
+    alt: "The same Body value on the Show view, including the trailing empty line after the last sentence.",
+    source: { file: "docs/4.0/faq.md", prompt: "textarea value on show with line breaks preserved by default" },
+  },
+
+  // simple_format.png — Show with `format_using: -> { simple_format value }` for paragraph spacing.
+  // comment.rb body field gets that format_using before this capture.
+  {
+    id: "faq-newline-simple-format",
+    path: "/avo/resources/comments/282",
+    viewport: { width: 760, height: 900 },
+    settle: 700,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: ".card:has([data-field-type='textarea'])",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/faq/newline/simple_format.png",
+    display: "full",
+    alt: "A Show view Body field rendered with simple_format, turning blank lines into spaced paragraphs.",
+    source: { file: "docs/4.0/faq.md", prompt: "textarea value on show formatted with simple_format" },
+  },
+
+  // ===========================================================================
+  // html.md — "Where are the attributes added?" — 8 ANATOMY shots.
+  // Each documents which part of a field WRAPPER an `html:` attribute attaches to, per view.
+  // Frame the field in its real container (the Course resource: Name / Has skills / Country /
+  // City rows) and draw a focus-style box (RULES 15d′) on the named element:
+  //   wrapper  → the whole .field-wrapper (one full row)
+  //   label    → .field-wrapper__label (the "Name" label area)
+  //   content  → .field-wrapper__content (slot=value — the value/input area)
+  //   input    → the <input> itself (edit only)
+  // Course 150's name is "Design 515". Sidebar closed + mat bg (RULES 12/19a).
+  // wrapper shots frame the whole card (full context); label/content/input frame the card too
+  // for consistency — the box position distinguishes the part. Index frames the table card and
+  // boxes a middle name CELL (RULES 15i — not first/last row).
+
+  // 1) Index field wrapper — the name CELL on the Courses index table.
+  {
+    id: "html-index-field-wrapper",
+    path: "/avo/resources/courses?per_page=5",
+    viewport: { width: 1440, height: 1000 },
+    settle: 800,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: ".card.relative",
+    pad: { x: 10, y: 10 },
+    marks: [{ selector: 'table tbody tr:nth-child(3) td[data-field-id="name"]', type: "highlight", style: "focus" }],
+    out: "docs/public/assets/img/4_0/html/index-field-wrapper.png",
+    display: "full",
+    alt: "The Avo Courses index table with one Name cell highlighted — the index field wrapper.",
+    source: { file: "docs/4.0/html.md", prompt: "Index field wrapper" },
+  },
+
+  // 2) Show field wrapper — the whole name row on the Course Show card.
+  {
+    id: "html-show-field-wrapper",
+    path: "/avo/resources/courses/150",
+    viewport: { width: 1440, height: 900 },
+    settle: 700,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: ".card",
+    pad: { x: 10, y: 10 },
+    marks: [{ selector: '[data-field-id="name"]', type: "highlight", style: "focus" }],
+    out: "docs/public/assets/img/4_0/html/show-field-wrapper.png",
+    display: "full",
+    alt: "An Avo Show card with the Name field wrapper highlighted.",
+    source: { file: "docs/4.0/html.md", prompt: "Show field wrapper" },
+  },
+
+  // 3) Show label target — the label area of the name field on Show.
+  {
+    id: "html-show-label-target",
+    path: "/avo/resources/courses/150",
+    viewport: { width: 1440, height: 900 },
+    settle: 700,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: ".card",
+    pad: { x: 10, y: 10 },
+    marks: [{ selector: '[data-field-id="name"] .field-wrapper__label', type: "highlight", style: "focus" }],
+    out: "docs/public/assets/img/4_0/html/show-label-target.png",
+    display: "full",
+    alt: "An Avo Show card with the Name field's label area highlighted.",
+    source: { file: "docs/4.0/html.md", prompt: "Show label target" },
+  },
+
+  // 4) Show content target — the value/content area of the name field on Show.
+  {
+    id: "html-show-content-target",
+    path: "/avo/resources/courses/150",
+    viewport: { width: 1440, height: 900 },
+    settle: 700,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: ".card",
+    pad: { x: 10, y: 10 },
+    marks: [{ selector: '[data-field-id="name"] .field-wrapper__content', type: "highlight", style: "focus" }],
+    out: "docs/public/assets/img/4_0/html/show-content-target.png",
+    display: "full",
+    alt: "An Avo Show card with the Name field's content (value) area highlighted.",
+    source: { file: "docs/4.0/html.md", prompt: "Show content target" },
+  },
+
+  // 5) Edit field wrapper — the whole name row on the Course Edit form card.
+  {
+    id: "html-edit-field-wrapper",
+    path: "/avo/resources/courses/150/edit",
+    viewport: { width: 1440, height: 900 },
+    settle: 800,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: ".card",
+    pad: { x: 10, y: 10 },
+    marks: [{ selector: '[data-field-id="name"]', type: "highlight", style: "focus" }],
+    out: "docs/public/assets/img/4_0/html/edit-field-wrapper.png",
+    display: "full",
+    alt: "An Avo Edit form card with the Name field wrapper highlighted.",
+    source: { file: "docs/4.0/html.md", prompt: "Edit field wrapper" },
+  },
+
+  // 6) Edit label target — the label area of the name field on Edit.
+  {
+    id: "html-edit-label-target",
+    path: "/avo/resources/courses/150/edit",
+    viewport: { width: 1440, height: 900 },
+    settle: 800,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: ".card",
+    pad: { x: 10, y: 10 },
+    marks: [{ selector: '[data-field-id="name"] .field-wrapper__label', type: "highlight", style: "focus" }],
+    out: "docs/public/assets/img/4_0/html/edit-label-target.png",
+    display: "full",
+    alt: "An Avo Edit form card with the Name field's label area highlighted.",
+    source: { file: "docs/4.0/html.md", prompt: "Edit label target" },
+  },
+
+  // 7) Edit content target — the content (value) area of the name field on Edit.
+  {
+    id: "html-edit-content-target",
+    path: "/avo/resources/courses/150/edit",
+    viewport: { width: 1440, height: 900 },
+    settle: 800,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: ".card",
+    pad: { x: 10, y: 10 },
+    marks: [{ selector: '[data-field-id="name"] .field-wrapper__content', type: "highlight", style: "focus" }],
+    out: "docs/public/assets/img/4_0/html/edit-content-target.png",
+    display: "full",
+    alt: "An Avo Edit form card with the Name field's content area highlighted.",
+    source: { file: "docs/4.0/html.md", prompt: "Edit content target" },
+  },
+
+  // 8) Edit input target — the <input> element of the name field on Edit.
+  {
+    id: "html-edit-input-target",
+    path: "/avo/resources/courses/150/edit",
+    viewport: { width: 1440, height: 900 },
+    settle: 800,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: ".card",
+    pad: { x: 10, y: 10 },
+    marks: [{ selector: '[data-field-id="name"] input', type: "highlight", style: "focus" }],
+    out: "docs/public/assets/img/4_0/html/edit-input-target.png",
+    display: "full",
+    alt: "An Avo Edit form card with the Name field's input element highlighted.",
+    source: { file: "docs/4.0/html.md", prompt: "Edit input target" },
+  },
+
+  // ===========================================================================
+  // field-wrappers.md — 4 ANATOMY shots of the field wrapper itself.
+  // index/show/edit wrappers (same Course rows), and a stacked field (label above value — Event name).
+
+  // 1) index_field_wrapper — the Courses index table card (no highlight mark).
+  {
+    id: "field-wrappers-index_field_wrapper",
+    path: "/avo/resources/courses?per_page=5",
+    viewport: { width: 1440, height: 1000 },
+    settle: 800,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: ".card.relative",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/field-wrappers/index_field_wrapper.png",
+    display: "full",
+    alt: "The Avo Courses index table showing index field wrappers in each cell.",
+    source: { file: "docs/4.0/field-wrappers.md", prompt: "index field wrapper" },
+  },
+
+  // 2) show_field_wrapper — Course Show card (id, name, availability, country). TEMP edit: course.rb
+  // trims fields to four rows. No highlight mark.
+  {
+    id: "field-wrappers-show_field_wrapper",
+    path: "/avo/resources/courses/150",
+    viewport: { width: 1440, height: 900 },
+    settle: 700,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: ".card",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/field-wrappers/show_field_wrapper.png",
+    display: "full",
+    alt: "An Avo Show card with field wrappers for id, name, availability, and country.",
+    source: { file: "docs/4.0/field-wrappers.md", prompt: "show field wrapper" },
+  },
+
+  // 3) edit_field_wrapper — Course Edit form card (id, name, availability, country). TEMP edit: course.rb
+  // trims fields to four rows. No highlight mark.
+  {
+    id: "field-wrappers-edit_field_wrapper",
+    path: "/avo/resources/courses/150/edit",
+    viewport: { width: 1440, height: 900 },
+    settle: 800,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: ".card",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/field-wrappers/edit_field_wrapper.png",
+    display: "full",
+    alt: "An Avo Edit form card with field wrappers for id, name, availability, and country.",
+    source: { file: "docs/4.0/field-wrappers.md", prompt: "edit field wrapper" },
+  },
+
+  // 4) stacked_field — `stacked: true` on Event#name (label above input). TEMP edit: event.rb
+  // wraps name in its own panel/card (RULES 15z). Capture the whole card incl. bottom border/padding.
+  {
+    id: "field-wrappers-stacked_field",
+    path: "/avo/resources/events/1/edit",
+    viewport: { width: 760, height: 900 },
+    settle: 800,
+    prepare: compose(closeSidebar, matBg, hideKbd),
+    selector: ".card:has([data-field-id=\"name\"])",
+    pad: { x: 10, y: 10 },
+    out: "docs/public/assets/img/4_0/field-wrappers/stacked_field.png",
+    display: "full",
+    alt: "A stacked field wrapper: the label is displayed above the input in a column layout.",
+    source: { file: "docs/4.0/field-wrappers.md", prompt: "a field with stacked layout — label above input" },
+  },
+
+  // customization — config.sidebar_toggle_visible = false. SPECIAL CASE: this is the ONE shot that
+  // KEEPS the sidebar open and visible (do NOT closeSidebar). The config is applied LIVE on the demo.
+  // On a desktop-width viewport (lg: breakpoint) the navbar's collapse/expand toggle next to the logo
+  // gets `lg:hidden` (verified: the [data-sidebar-toggle-icon] button is 0×0 / lg:hidden on desktop),
+  // and the sidebar stays permanently open. We capture the WHOLE viewport — sidebar + navbar + content
+  // — so the reader sees there is no toggle button next to the logo. Full-viewport screenshot (no
+  // selector/clip). matBg + hideKbd only.
+  {
+    id: "customization-sidebar-toggle-hidden",
+    path: "/avo/resources/users?per_page=6",
+    viewport: { width: 1440, height: 1180 },
+    settle: 800,
+    prepare: compose(matBg, hideKbd),
+    out: "docs/public/assets/img/4_0/customization/sidebar-toggle-hidden.png",
+    display: "full",
+    alt: "An Avo resource index on desktop with the sidebar permanently open and no toggle button in the navbar, because sidebar_toggle_visible is set to false.",
+    source: { file: "docs/4.0/customization.md", prompt: "Full Avo resource index page with config.sidebar_toggle_visible = false: the sidebar is open on the left and the navbar at the top has NO collapse/expand toggle button next to the logo. Capture the entire page (sidebar + navbar + content) at a desktop width." },
+  },
 ];
 
 // ---- GIF specs — animated demos; record-gif.mjs drives each spec's steps(page, snap) -------
 // Same idea as SPECS, for GIFs. Append a spec here when a shot must animate. Starts empty.
 export const GIF_SPECS = [
+  // resource-search (search/resource-search.md "## Resource search") — the per-resource search box
+  // on Projects index: empty table → focus search → type "an" → table filters to matching rows.
+  // Clip = `.panel__body` + 10px symmetric pad, sized to the UNFILTERED (tallest) state so the
+  // shrink to 3 rows reads as real filtering, not a cropped frame. NOT the navbar global search.
+  {
+    id: "resource-search",
+    path: "/avo/resources/projects?per_page=8",
+    viewport: { width: 1100, height: 1000 },
+    settle: 900,
+    clip: { x: 14, y: 184, width: 1072, height: 579 },
+    width: 2144,
+    delay: 20,
+    steps: async (page, snap) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await page.waitForTimeout(400);
+
+      const input = page.locator(
+        '[data-controller~="resource-search"] input[type="search"], [data-controller~="resource-search"] input[placeholder="Search"]',
+      ).first();
+
+      await snap(10, false); // full table, empty search
+
+      await input.click();
+      await page.waitForTimeout(300);
+      await snap(6, false); // search focused, still unfiltered
+
+      await input.type("a", { delay: 70 });
+      await page.waitForTimeout(700);
+      await snap(8, false); // partial filter after "a"
+
+      await input.type("n", { delay: 70 });
+      await page.waitForTimeout(900);
+      await snap(14, false); // "an" — 3 matching records
+    },
+    out: "docs/public/assets/img/4_0/search/resource-search.gif",
+    display: "full",
+    alt: "An Avo Projects index where typing into the per-resource search box filters the table to matching records.",
+    source: { file: "docs/4.0/search/resource-search.md", prompt: "the per-resource search box on a resource index mid-search showing filtered results" },
+  },
+
+  // fields/markdown.md — the Marksmith markdown editor in action, framed as a WHOLE card (RULES
+  // 15z/10b). Temp edit: project.rb wraps `:description, as: :markdown` in its OWN `panel do card
+  // do … end end`, so Avo renders a real, content-sized card hugging just that field — header/label,
+  // Write/Preview tabs, formatting toolbar, textarea and footer, all four borders visible. Captured
+  // on the Project New form (interactive: the Write/Preview tabs work). Narrow viewport WIDTH (760)
+  // so the field stacks its label above the editor and the card is ~743px CSS wide (RULES 9b) — not
+  // a slim label-left strip. A 1200px bottom spacer (injected in steps) gives the page generous
+  // scroll headroom: the markdown card is near the document end, so without headroom the page hits
+  // max-scroll and pin() can't seat the card top where we want (its top then rides up under the
+  // navbar and the clip slices the card's TOP border in the empty-Write state, which is the tallest
+  // because the textarea's min-height makes the card tallest there). With the spacer the page can
+  // always scroll the card top to clip-top + ~10px (probed: vTop=58, clamped=false in every state),
+  // so the top border + rounded top corners are never cut. Sidebar closed + mat bg (RULES 12/19a);
+  // hideKbd. The fixed clip (y=48, just under the ~48px fixed navbar) frames the whole card + ~10px
+  // symmetric mat: top mat 10px (card top 58); the tallest state (empty/typed Write, card bottom
+  // ~430) gets ~10px bottom mat, the shorter Preview a little more — never cut. Animation: clear the
+  // prefilled markdown, type it live (heading, bold, a list), Preview → rendered HTML, back to Write.
+  {
+    id: "markdown-field",
+    path: "/avo/resources/projects/new",
+    viewport: { width: 760, height: 1000 },
+    settle: 900,
+    clip: { x: 0, y: 48, width: 760, height: 392 },
+    width: 760,
+    delay: 16,
+    steps: async (page, snap) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await page.waitForTimeout(400);
+
+      // Hide every OTHER form field-wrapper on the page so only the markdown card shows. The New
+      // form stacks Started / Users required above and File / Meta below the markdown card; if any
+      // peek into the clip they read as bleed, not mat. Hiding them (visibility:hidden keeps layout
+      // so the card's document position is stable) leaves clean mat above and below the card in
+      // every frame, so a generous clip height can fully contain the TALLEST state (Preview, whose
+      // rendered HTML is taller than the empty Write textarea) without catching a neighbour field.
+      await page.addStyleTag({ content: `
+        .field-wrapper:not(:has(.marksmith)) { visibility: hidden !important; }
+        /* The breadcrumb bar is position:sticky (viewport ~52–88px, z-index 40) — it overlaps the
+           top of the clip and renders OVER the card's top border + "Description" label, fading and
+           slicing them. Hide it so the card's top mat is clean. (The fixed navbar above it is already
+           excluded by the clip starting at y=48.) */
+        nav.breadcrumbs, .breadcrumbs { display: none !important; }
+        /* Bottom spacer: the markdown card is near the document end, so add scroll headroom below it
+           so the page never hits max-scroll before pin() can seat the card top at clip-top + ~10px
+           (1200px probed to leave the scroll un-clamped in every state). */
+        body::after { content: ''; display: block; height: 1200px; }
+      ` });
+      await page.waitForTimeout(200);
+
+      // Pin the markdown card so its TOP edge lands at a fixed viewport y (TARGET_TOP = clip-top 48
+      // + 10px mat = 58), DETERMINISTICALLY: scroll, then read the card's real viewport top and
+      // correct for any residual delta (a fixed navbar / sticky offset otherwise makes a single
+      // `top - N` land a few px off, slicing the card's top border). Typing / focusing the textarea
+      // auto-scrolls the page, so re-pin before every snap. The 1200px bottom spacer guarantees the
+      // page can scroll far enough (un-clamped) for the correction to actually take effect.
+      const TARGET_TOP = 58; // = clip.y (48) + 10px top mat
+      const pin = async () => {
+        await page.evaluate((target) => {
+          const card = document.querySelector(".card:has(.marksmith)");
+          // iterate: scroll so card top → target, re-measure, correct residual delta
+          for (let i = 0; i < 4; i++) {
+            const top = card.getBoundingClientRect().top;
+            const delta = top - target;
+            if (Math.abs(delta) <= 1) break;
+            window.scrollBy(0, delta);
+          }
+        }, TARGET_TOP);
+        await page.waitForTimeout(120);
+      };
+      await pin();
+
+      const ta = page.locator(".marksmith-textarea").first();
+      // start clean so the typing reads clearly (the field has a prefilled `default:`)
+      await ta.fill("");
+      await page.waitForTimeout(300);
+      await pin();
+      await snap(6); // empty editor, Write tab active — whole card in frame
+
+      await ta.click();
+      await page.keyboard.type("# Release notes\n\n", { delay: 35 });
+      await pin();
+      await snap(2);
+      await page.keyboard.type("We shipped a **brand new** Markdown editor.\n\n", { delay: 28 });
+      await pin();
+      await snap(2);
+      // list-continuation auto-inserts "- " after Enter, so only type the first marker
+      await page.keyboard.type("- Live preview", { delay: 30 });
+      await page.keyboard.press("Enter");
+      await page.keyboard.type("File uploads", { delay: 30 });
+      await page.keyboard.press("Enter");
+      await page.keyboard.type("Media library", { delay: 30 });
+      await page.waitForTimeout(300);
+      await pin();
+      await snap(9); // hold on the typed markdown source
+
+      // toggle to Preview → rendered HTML
+      await page.locator(".marksmith-preview-tab").first().click();
+      await page.waitForTimeout(900);
+      await pin();
+      await snap(12); // hold on the rendered preview
+
+      // back to Write
+      await page.locator(".marksmith-write-tab").first().click();
+      await page.waitForTimeout(600);
+      await pin();
+      await snap(6);
+    },
+    out: "docs/public/assets/img/4_0/fields/markdown/markdown-field.gif",
+    alt: "The Avo Markdown field shown in its own card: typing Markdown in the Marksmith editor, then toggling the Preview tab to see the rendered HTML.",
+    source: { file: "docs/4.0/fields/markdown.md", prompt: "the Marksmith markdown editor inside its own card — type markdown then toggle Preview" },
+  },
+
+  // nested-records-when-creating (guides/nested-records-when-creating.md) — creating nested has_many
+  // records inline on the New form. The demo's Fish resource already wires the guide's setup: a
+  // `tool Avo::ResourceTools::NestedFishReviews, only_on: :new` renders a "Reviews" panel with an
+  // "Add another review" button; clicking it appends a review sub-form (a Trix body + a belongs_to
+  // user select) via the stimulus-rails-nested-form controller. GIF: Fish New form, the empty
+  // Reviews panel → click "Add another review" → one review form appears → click again → a second
+  // appears. Sidebar closed + mat bg (RULES 12/19a); hideKbd. Clip frames the nested Reviews panel
+  // as it grows. Viewport tall enough to fit two review forms without the 2nd one clipping.
+  {
+    id: "guide-nested-records-when-creating-nested-records-demo",
+    path: "/avo/resources/fish/new",
+    viewport: { width: 1180, height: 1340 },
+    settle: 1000,
+    clip: { x: 15, y: 290, width: 1150, height: 648 },
+    width: 920,
+    delay: 24,
+    steps: async (page, snap) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      // The Fish New form stacks other tool panels (FishInformation) and the has_many reviews
+      // table right below the nested Reviews panel; hide everything except the Reviews panel so the
+      // growing panel sits on clean mat (RULES 15j) and nothing bleeds into the bottom of the clip.
+      await page.addStyleTag({ content: `
+        [data-controller="nested-form"] { background: transparent; }
+      ` });
+      await page.evaluate(() => {
+        const nf = document.querySelector('[data-controller="nested-form"]');
+        const reviewsPanel = nf.closest('.panel') || nf.querySelector('.panel') || nf;
+        // hide every panel that starts BELOW the reviews panel's top, so the growing reviews
+        // panel sits on clean mat and nothing bleeds into the bottom of the clip.
+        const top = reviewsPanel.getBoundingClientRect().top;
+        document.querySelectorAll('.panel').forEach((p) => {
+          if (p === reviewsPanel || reviewsPanel.contains(p) || p.contains(reviewsPanel)) return;
+          if (p.getBoundingClientRect().top >= top + 5) p.style.visibility = 'hidden';
+        });
+      });
+      await page.waitForTimeout(500);
+
+      const addBtn = page.locator('[data-action="click->nested-form#add"]').first();
+      await page.waitForTimeout(300);
+      await snap(8); // hold on the empty Reviews panel + the "Add another review" button
+
+      await addBtn.click();
+      await page.waitForTimeout(900); // Trix editor + user select render
+      await snap(9); // one review sub-form appeared (body + user)
+
+      // type a short review body into the first Trix editor to show it's a real, fillable form
+      const trix = page.locator('trix-editor').first();
+      if (await trix.count()) {
+        await trix.click();
+        await page.keyboard.type('Great little fish!', { delay: 45 });
+        await page.waitForTimeout(400);
+        await snap(7);
+      }
+
+      await addBtn.click();
+      await page.waitForTimeout(900);
+      await snap(11); // a second review sub-form appended — hold longer at the end
+    },
+    out: "docs/public/assets/img/4_0/guides/nested-records-when-creating/nested-records-demo.gif",
+    alt: "Creating nested review records inline on the Fish New form: clicking Add another review appends review sub-forms, each with a body editor and a user picker.",
+    source: { file: "docs/4.0/guides/nested-records-when-creating.md", prompt: "creating nested has_many records inline on a New form" },
+  },
+
+  // action-link (actions/guides-and-tutorials.md "### `link_arguments`") — an Action rendered/
+  // triggered as a LINK. The demo's City resource has a "name (click to edit)" field on the Index
+  // whose cell is `link_to record.name, *Avo::Actions::Update.link_arguments(...)` — clicking it
+  // opens the Update action MODAL (data-turbo-frame="modal_frame") with a prefilled `name` field;
+  // running it updates the row. GIF: Cities TABLE index (view_type=table avoids the map, which needs
+  // MAPBOX), hover+focus the "New York" name link (native ring marks the trigger, RULES 15a/15b),
+  // click it → the action modal slides in with the name field, edit it, then Run → success toast +
+  // the row's name updates. Sidebar closed + mat bg (RULES 12/19a); hideKbd. Clip frames the table
+  // card + the modal that opens over it.
+  {
+    id: "action-link",
+    path: "/avo/resources/cities?per_page=6&view_type=table",
+    viewport: { width: 1120, height: 820 },
+    settle: 1000,
+    clip: { x: 8, y: 52, width: 1104, height: 509 }, // probed: breadcrumb y60, panel bottom 551; 8px mat top, 10px mat bottom
+    width: 1104,
+    delay: 24,
+    steps: async (page, snap) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await page.waitForTimeout(400);
+
+      const link = page.locator('[data-field-id="name"] a[data-turbo-frame="modal_frame"]').first();
+      await link.scrollIntoViewIfNeeded();
+      await link.hover();
+      await link.focus(); // native :focus-visible ring marks the link trigger
+      await snap(8); // hold ~2s on the index with the name link focused (the "action as a link")
+
+      await link.click();
+      // wait for the action modal to load inside the modal_frame
+      await page.waitForSelector('#modal_frame form, [data-turbo-frame="modal_frame"] form, dialog form', { timeout: 8000 }).catch(() => {});
+      await page.waitForTimeout(900);
+      await snap(8); // hold on the open action modal with the prefilled name field
+
+      // Edit the name then run the action.
+      const input = page.locator('#modal_frame input[type="text"], dialog input[type="text"]').first();
+      if (await input.count()) {
+        await input.click();
+        await input.fill("");
+        await input.type("New York City", { delay: 55 });
+        await page.waitForTimeout(300);
+        await snap(7); // hold on the edited value
+      }
+      const run = page.locator('#modal_frame button[type="submit"], dialog button[type="submit"], [data-turbo-frame="modal_frame"] button[type="submit"]').first();
+      if (await run.count()) {
+        await run.click();
+        await page.waitForTimeout(1400); // action runs, modal closes, row updates + toast
+        await snap(10); // hold on the success / updated row
+      }
+    },
+    out: "docs/public/assets/img/4_0/actions/action-link.gif",
+    alt: "An Avo Cities index where a record's name is a clickable link; clicking it opens an Update action modal with a prefilled name field, which when run updates the row.",
+    source: { file: "docs/4.0/actions/guides-and-tutorials.md", prompt: "an Action rendered/triggered as a link" },
+  },
+
+  // select-all (select-all.md "## How does it work?") — selecting ALL records on an index including
+  // the "select all across pages" affordance. Projects index (36 records, per_page=6). GIF:
+  // unselected → header checkbox checked (red group box around header + row checkboxes) → banner
+  // with "Select all matching" highlighted (red focus ring) → click → "36 records selected from all
+  // pages". Dark-mode fix: the count spans use text-gray-700 which vanishes on bg-secondary —
+  // injectCSS overrides in dark.
+  {
+    id: "select-all",
+    path: "/avo/resources/projects?per_page=6",
+    viewport: { width: 1160, height: 760 },
+    settle: 1000,
+    clip: { x: 4, y: 102, width: 1152, height: 600 },
+    width: 1152,
+    delay: 26,
+    steps: async (page, snap) => {
+      const checkboxColumnBox = () =>
+        page.evaluate(() => {
+          const boxes = [
+            ...document.querySelectorAll(
+              'input[name="Select all"][data-item-select-all-target="checkbox"], table tbody input[type="checkbox"]',
+            ),
+          ].map((el) => el.getBoundingClientRect());
+          const x1 = Math.min(...boxes.map((b) => b.x));
+          const y1 = Math.min(...boxes.map((b) => b.y));
+          const x2 = Math.max(...boxes.map((b) => b.x + b.width));
+          const y2 = Math.max(...boxes.map((b) => b.y + b.height));
+          return { x: Math.round(x1), y: Math.round(y1), width: Math.round(x2 - x1), height: Math.round(y2 - y1) };
+        });
+
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await injectCSS(`
+        @media (prefers-color-scheme: dark) {
+          [data-item-select-all-target="unselectedMessage"] .text-gray-700,
+          [data-item-select-all-target="selectedMessage"] .text-gray-700 {
+            color: var(--color-content, oklch(0.95 0 0)) !important;
+          }
+        }
+      `)(page);
+      await page.waitForTimeout(400);
+
+      await snap(8, false); // index, nothing selected
+
+      const header = page.locator('input[name="Select all"][data-item-select-all-target="checkbox"]').first();
+      await header.click();
+      await page.waitForTimeout(500);
+      const columnBox = await checkboxColumnBox();
+      await snap(10, [{ box: columnBox, type: "highlight", color: "#ef4444" }]);
+
+      const selectAll = page.locator('[data-item-select-all-target="unselectedMessage"] a[data-action="click->item-select-all#selectAll"]').first();
+      await snap(8, [{ selector: '[data-item-select-all-target="unselectedMessage"] a[data-action="click->item-select-all#selectAll"]', type: "highlight", style: "focus", color: "#ef4444" }]);
+
+      await selectAll.click();
+      await page.waitForTimeout(700);
+      await snap(12, false); // "36 records selected from all pages"
+    },
+    out: "docs/public/assets/img/4_0/select-all/select-all.gif",
+    alt: "An Avo Projects index where checking the header Select all checkbox selects the page and offers a Select all matching link, which selects all 36 records across every page.",
+    source: { file: "docs/4.0/select-all.md", prompt: "selecting all records on an index including the select all across pages affordance" },
+  },
+
   // money-currency-dropdown ("gif with showing the dropdown selector", placeholder money.md line 19,
   // kind="gif") — the money field's currency selector on the product NEW form, animated: the closed
   // state (amount input beside the currency picker), then the selector expanded to reveal all four
@@ -1807,38 +3849,6 @@ export const GIF_SPECS = [
     source: { file: "docs/4.0/fields/files.md", prompt: "gif to see the difference between grid and list view types" },
   },
 
-  // markdown — Marksmith Write tab with prefilled example markdown, then Preview tab showing rendered
-  // HTML. Temp edit: project.rb wraps :description (name "Body") in its own panel/card with a
-  // `default:` of example markdown on the New form.
-  {
-    id: "markdown-field",
-    path: "/avo/resources/projects/new",
-    viewport: { width: 1000, height: 1400 },
-    settle: 900,
-    clip: { x: 6, y: 892, width: 988, height: 422 },
-    width: 1000,
-    delay: 20,
-    steps: async (page, snap) => {
-      await closeSidebar(page);
-      await matBg(page);
-      await hideKbd(page);
-      await page.waitForTimeout(300);
-      await page.locator(".card:has(.marksmith)").scrollIntoViewIfNeeded();
-      await snap(6); // Write tab with example markdown
-
-      await page.locator(".marksmith-preview-tab").click();
-      await page.waitForTimeout(700);
-      await snap(10); // Preview rendered
-
-      await page.locator(".marksmith-write-tab").click();
-      await page.waitForTimeout(300);
-      await snap(5);
-    },
-    out: "docs/public/assets/img/4_0/fields/markdown/markdown-field.gif",
-    alt: "An Avo New (create) form card showing the Markdown field powered by Marksmith: an animation switching from the Write tab (example markdown with heading, list, blockquote, link and code block) to the Preview tab showing the rendered HTML.",
-    source: { file: "docs/4.0/fields/markdown.md", prompt: "create a gif that will display how markdown is working with some exemples" },
-  },
-
   // preview — hover the preview icon on the Teams index to reveal the preview popover (RULES 15a).
   // Hide the dynamic-filters bar (Add filter / Reset filters). Clip includes the FULL index search
   // + Filters/view-toggle row (y≈187) — the old y=205 top sliced those controls in half. Sized
@@ -1952,6 +3962,945 @@ export const GIF_SPECS = [
     out: "docs/public/assets/img/4_0/fields/tags/create-save.gif",
     alt: "An Avo create form with a tags field: the animation opens the suggestions dropdown, picks one and two, saves the record, and shows the tags on the Show view.",
     source: { file: "docs/4.0/fields/tags.md", prompt: "gif on the create form adding tags from suggestions and saving to see them on show" },
+  },
+
+  // basic-filters-country-city GIF — Courses index: table (ID/Name/Country/City only) + Filters
+  // panel. Annotate Filters button → open panel (empty_message) → annotate USA → tick → cities populate.
+  {
+    id: "basic-filters-country-city",
+    path: "/avo/resources/courses?view_type=table&per_page=5",
+    viewport: { width: 1440, height: 950 },
+    settle: 900,
+    clip: { x: 14, y: 184, width: 1412, height: 412 },
+    width: 1412,
+    delay: 20,
+    steps: async (page, snap) => {
+      const filterBtnMark = [{ selector: '[data-button="resource-filters"]', type: "highlight", style: "focus", color: "#ef4444" }];
+      const usaMark = [{ selector: '.filters__panel label:has-text("USA")', type: "highlight", style: "focus", color: "#ef4444" }];
+
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await page.addStyleTag({
+        content: `table thead th:nth-child(4), table tbody td:nth-child(4),
+          table thead th:nth-child(5), table tbody td:nth-child(5) { display: none !important; }`,
+      });
+      await page.waitForTimeout(300);
+
+      await snap(5, false); // index with table, panel closed
+      await snap(8, filterBtnMark); // highlight Filters button
+      await page.locator('[data-button="resource-filters"]').first().click();
+      await page.waitForTimeout(900);
+      await snap(12, false); // panel open: city filter empty_message over the table
+
+      await snap(8, usaMark); // highlight USA checkbox
+      await page.getByRole("checkbox", { name: "USA" }).check();
+      await page.waitForLoadState("networkidle");
+      await page.waitForSelector('.filters__panel label:has-text("New York"), .filters__panel label:has-text("Los Angeles")', { timeout: 15000 });
+      await page.waitForTimeout(1200);
+      await snap(16, false); // USA checked, US cities populated, first city auto-selected
+    },
+    out: "docs/public/assets/img/4_0/filters/country-city-filters.gif",
+    alt: "An Avo Courses index with the table visible: the Filters button is highlighted, the panel opens showing the city filter empty message, USA is ticked, and US cities populate with the first one auto-selected.",
+    source: { file: "docs/4.0/basic-filters.md", prompt: "single gif: filters panel over table, empty message, tick USA, cities populate" },
+  },
+
+  // TODO(screenshot→gif): parked — replace docs/public/assets/img/4_0/associations/has-many-linkable.png
+  // with .gif once the 4-beat animation reads clearly. Static spec: SPECS `has-many-linkable`.
+  {
+    id: "has-many-linkable-gif",
+    path: "/avo/resources/teams/1",
+    viewport: { width: 1120, height: 760 },
+    settle: 1200,
+    clip: { x: 12, y: 78, width: 1080, height: 600 },
+    width: 1080,
+    delay: 22,
+    steps: async (page, snap) => {
+      const PIN_Y = 90;
+      const CLIP = { x: 12, y: 78, width: 1080, height: 600 };
+      const linkSel = '#has_many_field_show_memberships a[has-data-tippy="Open in a new tab"]';
+      const iconMark = [{ selector: linkSel, type: "highlight", style: "focus" }];
+
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await page.addStyleTag({ content: `a[href^="cursor://"] { display: none !important; }` });
+
+      // Lazy-load the Memberships frame, then scroll back to top so the clip shows Team context.
+      await page.evaluate(() => document.getElementById("has_many_field_show_memberships")?.scrollIntoView({ block: "start" }));
+      await page.locator("#has_many_field_show_memberships[complete]").waitFor({ timeout: 15000 });
+      await page.waitForTimeout(600);
+      await page.evaluate(() => window.scrollTo(0, 0));
+      await page.waitForTimeout(700);
+      await snap(10, false, CLIP); // beat 1: Team show — breadcrumbs, "Apple", Memberships below
+
+      await page.evaluate((py) => {
+        const f = document.getElementById("has_many_field_show_memberships");
+        window.scrollBy(0, f.getBoundingClientRect().top - py);
+      }, PIN_Y);
+      await page.waitForTimeout(700);
+      await snap(6, false, CLIP); // beat 2: scrolled to the Memberships panel on the Team show page
+
+      await snap(7, iconMark, CLIP); // beat 3: red highlight on the linkable icon
+
+      const dest = await page.locator(linkSel).first().getAttribute("href");
+      await page.goto(new URL(dest, page.url()).toString(), { waitUntil: "networkidle" });
+      await page.waitForTimeout(1400);
+      await matBg(page);
+      await hideKbd(page);
+      await page.addStyleTag({ content: `a[href^="cursor://"] { display: none !important; }` });
+      await page.evaluate((py) => { const h = document.querySelector(".header"); if (h) window.scrollBy(0, h.getBoundingClientRect().top - py); }, PIN_Y);
+      await page.waitForTimeout(600);
+      await snap(12, false, CLIP); // beat 4: dedicated Memberships page (breadcrumbs visible)
+    },
+    out: "docs/public/assets/img/4_0/associations/has-many-linkable.gif",
+    alt: "An Avo Team show view: the Memberships has_many association panel whose linkable title icon is clicked, opening the same Memberships table on its own dedicated page.",
+    source: { file: "docs/4.0/associations/has_many.md", prompt: "linkable association title opens the same view on a new page" },
+  },
+
+  // has_many `attach_fields` (has_many.md) — 2-beat GIF from the static PNG pair: Team show with red
+  // highlight on Attach team member → click → modal (Review attach field). Same scroll pin as SPECS.
+  // Temp (revert after): team.rb attach_fields → review text; TeamPolicy view/attach/create_team_members.
+  {
+    id: "has-many-attach-fields-gif",
+    path: "/avo/resources/teams/1",
+    viewport: { width: 1120, height: 760 },
+    settle: 1200,
+    clip: { x: 12, y: 78, width: 1080, height: 600 },
+    width: 1080,
+    delay: 22,
+    steps: async (page, snap) => {
+      const attachSel = '#has_many_field_show_team_members a:has-text("Attach team member")';
+      const modalSel = '.modal__card[data-modal-target="card"]';
+      const attachMark = [{ selector: attachSel, type: "highlight", style: "focus" }];
+
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await page.addStyleTag({ content: `a[href^="cursor://"] { display: none !important; }` });
+
+      await page.evaluate(() => document.getElementById("has_many_field_show_team_members")?.scrollIntoView({ block: "start" }));
+      await page.locator(attachSel).first().waitFor({ state: "visible", timeout: 20000 });
+      await page.evaluate(() => window.scrollTo(0, 0));
+      await page.waitForTimeout(800);
+      await snap(12, attachMark); // beat 1: Team show + Attach highlighted
+
+      await page.locator(attachSel).first().click();
+      await page.locator(modalSel).waitFor({ state: "visible", timeout: 10000 });
+      await page.waitForTimeout(1200);
+      await snap(16, false); // beat 2: attach modal open
+    },
+    out: "docs/public/assets/img/4_0/associations/has-many-attach-fields.gif",
+    alt: "An Avo Team show view: clicking Attach team member on the Team members has_many through association opens a modal with the member dropdown and an extra Review text field from attach_fields.",
+    source: { file: "docs/4.0/associations/has_many.md", prompt: "attach modal showing extra attach_fields on the join table" },
+  },
+
+  // sidebar-toggle-visible (customization.md "## Toggle the sidebar button visibility") — the navbar
+  // toggle button (top-left hamburger) that collapses/expands the sidebar on desktop. This shows the
+  // DEFAULT behaviour (the button IS visible, `sidebar_toggle_visible` left at its default true). GIF
+  // on the Projects index: start with the sidebar OPEN, click the toggle (button[data-action=
+  // "click->sidebar#toggleSidebarForViewport"]) → sidebar collapses + content reflows full-width;
+  // click again → sidebar expands back. matBg + hideKbd; sidebar stays open at start (no closeSidebar —
+  // the open→collapsed→open animation IS the subject). Clip frames the navbar toggle + sidebar +
+  // left content so the collapse/expand reads clearly.
+  {
+    id: "sidebar-toggle-visible",
+    path: "/avo/resources/projects?per_page=6",
+    viewport: { width: 1280, height: 800 },
+    settle: 900,
+    clip: { x: 0, y: 0, width: 820, height: 720 },
+    width: 820,
+    delay: 14,
+    steps: async (page, snap) => {
+      await matBg(page);
+      await hideKbd(page);
+      await page.waitForTimeout(300);
+      const toggle = page.locator('button[data-action="click->sidebar#toggleSidebarForViewport"]').first();
+
+      await snap(10); // hold ~2s on the default state — sidebar open, toggle button visible
+
+      await toggle.click(); // collapse the sidebar
+      await page.waitForTimeout(500);
+      await snap(12); // hold on the collapsed state — content reflowed full-width
+
+      await toggle.click(); // expand it back
+      await page.waitForTimeout(500);
+      await snap(12); // hold on the re-expanded state
+    },
+    out: "docs/public/assets/img/4_0/customization/sidebar-toggle-visible.gif",
+    alt: "An Avo resource index where clicking the navbar toggle button collapses the sidebar and clicking it again expands it.",
+    source: { file: "docs/4.0/customization.md", prompt: "toggling the sidebar visibility with the navbar toggle button" },
+  },
+
+  // click-row-to-view-record (customization.md "`click_row_to_view_record`") — UserPanelsDemo
+  // index (id + name) → red-annotate the name cell → click row → Show with panel/card DSL
+  // (main panel + "User information" panel). click_row_to_view_record is on in demo avo.rb.
+  {
+    id: "click-row-to-view-record",
+    path: "/avo/resources/user_panels_demos?per_page=6",
+    viewport: { width: 1200, height: 900 },
+    settle: 1000,
+    clip: { x: 15, y: 52, width: 1170, height: 478 },
+    width: 1170,
+    delay: 20,
+    steps: async (page, snap) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await injectCSS(
+        'th[data-control="item-select-th"], td[data-control="item-select-td"] { display: none !important; }',
+      )(page);
+      await page.waitForTimeout(400);
+
+      const clip = { x: 15, y: 52, width: 1170, height: 478 };
+      const rowCell = 'table tbody tr:nth-child(3) td[data-field-id="name"]';
+      const clickMark = [{ selector: rowCell, type: "highlight", color: "#ef4444", pad: 4, radius: 6 }];
+
+      await snap(10, false, clip); // index — breadcrumbs + table
+
+      const cell = page.locator(rowCell);
+      await cell.scrollIntoViewIfNeeded();
+      await cell.hover();
+      await page.waitForTimeout(400);
+      await snap(12, clickMark, clip); // hovered row — red ring on the name cell we click
+
+      await cell.click();
+      await page.waitForLoadState("networkidle");
+      await page.waitForTimeout(900);
+      await matBg(page);
+      await hideKbd(page);
+      await snap(14, false, clip); // show — panel + named "User information" card
+    },
+    out: "docs/public/assets/img/4_0/customization/click-row-to-view-record.gif",
+    alt: "An Avo resource index where a row name cell is highlighted, clicked, and navigates to the record show view with panel and card DSL layout.",
+    source: { file: "docs/4.0/customization.md", prompt: "clicking a row navigates to its show view" },
+  },
+
+  // skip-show-view (customization.md "## Skip show view") — with resource_default_view = :edit
+  // (demo avo.rb) creating a course redirects to Edit, not Show. GIF: new form → fill name +
+  // check Availability → annotate Save → click → land on Edit (breadcrumb ends in /edit).
+  {
+    id: "skip-show-view",
+    path: "/avo/resources/courses/new",
+    viewport: { width: 1200, height: 900 },
+    settle: 900,
+    clip: { x: 15, y: 52, width: 1170, height: 412 },
+    width: 1170,
+    delay: 20,
+    steps: async (page, snap) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await page.waitForTimeout(400);
+
+      const clip = { x: 15, y: 52, width: 1170, height: 412 };
+      const saveMark = [{ selector: '[data-resource-edit-target="saveButton"]', type: "highlight", color: "#ef4444", pad: 4, radius: 6 }];
+
+      await snap(10, false, clip); // Create new course — empty form
+
+      await page.locator('[data-field-id="name"] input').fill("Skip Show View");
+      await page.locator('[data-field-id="has_skills"] input[type="checkbox"]').check();
+      await page.waitForTimeout(400);
+      await snap(10, false, clip); // name + Availability filled
+
+      await snap(12, saveMark, clip); // Save button annotated
+
+      await page.locator('[data-resource-edit-target="saveButton"]').click();
+      await page.waitForURL(/\/avo\/resources\/courses\/\d+\/edit/, { timeout: 15000 });
+      await page.waitForLoadState("networkidle");
+      await page.waitForTimeout(1000);
+      await matBg(page);
+      await hideKbd(page);
+      await snap(14, false, clip); // Edit view — skipped Show
+    },
+    out: "docs/public/assets/img/customization/skip_show_view.gif",
+    alt: "An Avo create form for a course: after saving, Avo redirects to the Edit view instead of Show when skip_show_view is enabled.",
+    source: { file: "docs/4.0/customization.md", prompt: "creating a record redirects to edit instead of show when skip_show_view is enabled" },
+  },
+
+  // custom-fields hidden_input_color (custom-fields.md "### Hidden input controller" → the
+  // ColorPickerField example) — a custom color field on the SHOW view using Avo's `hidden-input`
+  // Stimulus controller in the default INLINE field-wrapper layout (label "Color" on the left,
+  // "Show content" link on the right). Clicking reveals the purple swatch pill with the hex value.
+  // Temp files (removed after capture): ProgressShotDemo resource + ColorPickerField matching the
+  // doc snippet exactly. Viewport 900px so the wrapper is side-by-side (760px stacks vertically).
+  // Clip = the Color card sized for the revealed state + symmetric mat (RULES 10b/13).
+  {
+    id: "hidden_input_color",
+    path: "/avo/resources/progress_shot_demos/1",
+    viewport: { width: 900, height: 600 },
+    settle: 1200,
+    clip: { x: 8, y: 144, width: 884, height: 86 },
+    width: 900,
+    delay: 22,
+    steps: async (page, snap) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await page.addStyleTag({ content: "a[href^='cursor://']{display:none!important}" });
+      await page.waitForTimeout(500);
+
+      await snap(10); // inline row — "Color" label left, "Show content" link right
+      await page.locator('[data-controller="hidden-input"] a').first().click();
+      await page.waitForTimeout(350);
+      await snap(16); // swatch pill revealed on the right
+    },
+    out: "docs/public/assets/img/4_0/stimulus/hidden_input_color.gif",
+    alt: "A custom color field on an Avo Show view using the hidden-input controller: the Color label on the left and a Show content link on the right that, when clicked, reveals a colored swatch pill showing the hex value.",
+    source: { file: "docs/4.0/custom-fields.md", prompt: "the hidden input controller revealing a color swatch on show" },
+  },
+
+  // custom-fields hidden_input_trix (custom-fields.md "### Hidden input controller" → the Trix field
+  // example) — the built-in Trix show field uses the `trix-body` Stimulus controller (same hide/show
+  // pattern as `hidden-input`): long HTML starts collapsed with a "More content" link; clicking it
+  // reveals the rich text and swaps to "Less content". Temp edit (reverted after capture): the demo's
+  // TrixDemo resource shows `field :body, as: :trix` on the SHOW view (`only_on: [:show, :edit]`
+  // instead of `:forms`). Record id 1 has enough body HTML to trigger the link. Sidebar closed + mat
+  // bg; clip = the Body card sized for the revealed (taller) state with symmetric mat (RULES 10b/13).
+  {
+    id: "hidden_input_trix",
+    path: "/avo/resources/trix_demos/1",
+    viewport: { width: 1000, height: 900 },
+    settle: 1200,
+    clip: { x: 8, y: 144, width: 984, height: 274 },
+    width: 1000,
+    delay: 22,
+    steps: async (page, snap) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await page.addStyleTag({ content: "a[href^='cursor://']{display:none!important}" });
+      await page.waitForTimeout(500);
+
+      await snap(10); // Body card collapsed — "More content" link visible
+      await page.locator('[data-trix-body-target="moreContentButton"] a').click();
+      await page.waitForTimeout(350);
+      await snap(16); // rich text revealed — "Less content" link visible
+    },
+    out: "docs/public/assets/img/4_0/stimulus/hidden_input_trix.gif",
+    alt: "A Trix field on an Avo Show view with long content collapsed behind a “More content” link that, when clicked, reveals the rich text.",
+    source: { file: "docs/4.0/custom-fields.md", prompt: "the Trix field hiding long content behind a more content link on show" },
+  },
+
+  // ── stimulus-integration.md (Stimulus JS & HTML attributes) ─────────────────────────────
+  // Four GIFs of Stimulus controllers wired into Avo fields on the Course EDIT form. The demo's
+  // Course resource (app/avo/resources/course.rb) already wires `self.stimulus_controllers =
+  // "course-resource toggle-fields"` and the pre-made resource-edit methods on the relevant
+  // fields, so these capture the REAL documented behaviour. Common framing for all four: the
+  // edit form's field card on a narrow viewport (vw 900 → card ~868px CSS, displays ~1×, RULES
+  // 9b); sidebar closed + mat bg (RULES 12/19a); hideKbd. Clip = the whole field card + ~10px
+  // symmetric mat so every edge reads as mat and the component shows whole (RULES 10b/15y).
+
+  // stimulus-country-city — `Custom Stimulus controllers` country→city dependent select. One red
+  // highlight around BOTH Country + City rows; Country + City rows only (sibling fields hidden) with
+  // a console readout below showing the real logged output on each country change (devtools can't be
+  // screenshotted — same pattern as stimulus-debug). Closed single-line <select>s; values change via
+  // selectOption after each country pick repopulates city (react_on: :country). GIF: Japan → USA +
+  // New York → Spain + Barcelona.
+  {
+    id: "stimulus-country-city",
+    path: "/avo/resources/courses/1/edit",
+    viewport: { width: 900, height: 1000 },
+    settle: 1000,
+    clip: { x: 11, y: 201, width: 878, height: 244 },
+    width: 878,
+    delay: 24,
+    steps: async (page, snap) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await page.waitForTimeout(600);
+
+      // Country + City only — hide sibling rows; neutralize card border (RULES 15s).
+      await page.addStyleTag({
+        content:
+          '[data-field-id]:not([data-field-id="country"]):not([data-field-id="city"]) { display: none !important; }' +
+          ".card:not(.relative) { border-color: transparent !important; box-shadow: none !important; }",
+      });
+
+      // Console readout pinned below the City row — echoes genuine console.log lines (see logCountryAndCities).
+      await page.evaluate(() => {
+        const anchor = document.querySelector('[data-field-id="city"]');
+        const box = document.createElement("div");
+        box.id = "debug-console-readout";
+        box.style.cssText =
+          "margin:10px 5px 0;font:12px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;" +
+          "background:#0b0f19;color:#d1d5db;border-radius:8px;padding:10px 12px;" +
+          "max-height:130px;overflow:hidden;border:1px solid rgba(255,255,255,.08);";
+        const head = document.createElement("div");
+        head.textContent = "// browser console";
+        head.style.cssText = "color:#6b7280;margin-bottom:4px;";
+        box.appendChild(head);
+        const log = document.createElement("div");
+        log.id = "debug-console-log";
+        box.appendChild(log);
+        anchor.parentElement.insertBefore(box, anchor.nextSibling);
+        window.__pushConsole = (line) => {
+          const el = document.getElementById("debug-console-log");
+          if (!el) return;
+          const row = document.createElement("div");
+          row.innerHTML =
+            '<span style="color:#34d399">&rsaquo;</span> ' +
+            line.replace(/</g, "&lt;");
+          el.appendChild(row);
+          while (el.childElementCount > 4) el.removeChild(el.firstChild);
+        };
+      });
+
+      page.on("console", (m) => {
+        const t = m.text();
+        if (t.startsWith("onCountryChange") || t.startsWith("Cities:"))
+          page.evaluate((s) => window.__pushConsole(s), t).catch(() => {});
+      });
+
+      const countrySel = '[data-field-id="country"] select';
+      const citySel = '[data-field-id="city"] select';
+      const pairMark = async () => {
+        const box = await page.evaluate(() => {
+          const country = document.querySelector('[data-field-id="country"]');
+          const city = document.querySelector('[data-field-id="city"]');
+          const cr = country.getBoundingClientRect();
+          const cir = city.getBoundingClientRect();
+          return {
+            x: Math.min(cr.x, cir.x),
+            y: cr.y,
+            width: Math.max(cr.width, cir.width),
+            height: cir.bottom - cr.y,
+          };
+        });
+        return [{ box, type: "highlight", style: "focus", color: "#ef4444" }];
+      };
+      const logCountryAndCities = async () => {
+        await page.evaluate(() => {
+          const country = document.querySelector('[data-field-id="country"] select')?.value ?? "";
+          console.log(`onCountryChange → ${country}`);
+          const citySelect = document.querySelector('[data-field-id="city"] select');
+          const cities = citySelect
+            ? [...citySelect.options].map((o) => o.value).filter(Boolean)
+            : [];
+          console.log(`Cities: [${cities.join(", ")}]`);
+        });
+        await page.waitForTimeout(250);
+      };
+
+      await logCountryAndCities();
+      await snap(8, await pairMark()); // Japan, city empty, console shows initial country + cities
+
+      await page.locator(countrySel).selectOption("USA");
+      await page.waitForTimeout(1100);
+      await logCountryAndCities();
+      await snap(10, await pairMark()); // USA selected, city repopulated + console updated
+
+      await page.locator(citySel).selectOption("New York");
+      await page.waitForTimeout(500);
+      await snap(10, await pairMark()); // USA + New York
+
+      await page.locator(countrySel).selectOption("Spain");
+      await page.waitForTimeout(1100);
+      await logCountryAndCities();
+      await snap(10, await pairMark()); // Spain selected, city list swapped + console updated
+
+      await page.locator(citySel).selectOption("Barcelona");
+      await page.waitForTimeout(500);
+      await snap(10, await pairMark()); // Spain + Barcelona
+    },
+    out: "docs/public/assets/img/4_0/stimulus/country-city-select.gif",
+    alt: "An Avo Course edit form with Country and City highlighted together and a browser console readout below: picking USA repopulates the city select and logs the new options, then New York is chosen; switching to Spain swaps the city list and Barcelona is selected.",
+    source: { file: "docs/4.0/stimulus-integration.md", prompt: "selecting a country repopulates a dependent city select" },
+  },
+
+  // stimulus-toggle — `resource-edit#toggle` pre-made method. The `has_skills` boolean carries
+  // `action: "input->resource-edit#toggle"` + `resource_edit_toggle_target_param:
+  // "skills_tags_wrapper"`, so toggling it shows/hides the `skills` field wrapper. GIF: start with
+  // the checkbox on (skills visible) → uncheck (skills row hidden) → check again (skills row back).
+  // Clip sized to the skills-VISIBLE (tallest) state so the hidden state just shows clean mat below.
+  {
+    id: "stimulus-toggle",
+    path: "/avo/resources/courses/1/edit",
+    viewport: { width: 900, height: 1000 },
+    settle: 1000,
+    clip: { x: 6, y: 196, width: 888, height: 274 },
+    width: 888,
+    delay: 26,
+    steps: async (page, snap) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await page.waitForTimeout(600);
+
+      const cb = page.locator('[data-field-id="has_skills"] input[type="checkbox"]').first();
+      await snap(9); // checkbox on → Skills field visible
+
+      await cb.click();
+      await page.waitForTimeout(500);
+      await snap(11); // checkbox off → Skills field hidden
+
+      await cb.click();
+      await page.waitForTimeout(500);
+      await snap(10); // checkbox on again → Skills field back
+    },
+    out: "docs/public/assets/img/4_0/stimulus/toggle-method.gif",
+    alt: "An Avo Course edit form where toggling the Availability boolean uses resource-edit#toggle to show and hide the Skills field.",
+    source: { file: "docs/4.0/stimulus-integration.md", prompt: "a stimulus action toggling another field's visibility" },
+  },
+
+  // stimulus-disable — `resource-edit#disable` pre-made method. Like toggle, but DISABLES the target
+  // field instead of hiding it. Requires a temp edit to the Course resource: switch the `has_skills`
+  // boolean's html action to `input->resource-edit#disable` with
+  // `resource_edit_disable_target_param: "name_text_input"`, per the doc's `### resource-edit#disable`
+  // example. NOTE: the doc example names the COUNTRY select as the target, but Avo v4 applies NO
+  // visible style to a disabled <select> (it only sets the DOM `disabled` attr — verified: identical
+  // color/bg/cursor), so a select target produces a "nothing happens" animation. A disabled TEXT
+  // input DOES grey out in v4 (text color oklch .20 → .53, cursor text → default), so we target the
+  // Name text field — the same genuine resource-edit#disable method, on a field type whose disabled
+  // state v4 actually renders, giving a faithful, legible animation. GIF: checkbox on → Name input
+  // enabled (dark text) → uncheck → Name input disabled (greyed text) → check → enabled again. Temp
+  // edit reverted after capture.
+  {
+    id: "stimulus-disable",
+    path: "/avo/resources/courses/1/edit",
+    viewport: { width: 900, height: 1000 },
+    settle: 1000,
+    clip: { x: 6, y: 196, width: 888, height: 274 },
+    width: 888,
+    delay: 26,
+    steps: async (page, snap) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await page.waitForTimeout(600);
+
+      const cb = page.locator('[data-field-id="has_skills"] input[type="checkbox"]').first();
+      await snap(9); // checkbox on → Name input enabled (dark text)
+
+      await cb.click();
+      await page.waitForTimeout(500);
+      await snap(11); // checkbox off → Name input disabled (greyed text)
+
+      await cb.click();
+      await page.waitForTimeout(500);
+      await snap(10); // checkbox on again → Name input enabled
+    },
+    out: "docs/public/assets/img/4_0/stimulus/disable-method.gif",
+    alt: "An Avo Course edit form where toggling the Availability boolean uses resource-edit#disable to disable and re-enable the Name field, greying it out.",
+    source: { file: "docs/4.0/stimulus-integration.md", prompt: "a stimulus action disabling/enabling a field" },
+  },
+
+  // stimulus-debug — `resource-edit#debugOnInput` pre-made method. The `name` text field carries
+  // `action: "input->resource-edit#debugOnInput"`, which logs the event + value to the browser
+  // console on each keystroke (debugging only). A page screenshot can't show the devtools console,
+  // so we render the controller's REAL emitted output into a small console-styled readout pinned
+  // below the field: we listen to `page.on("console")` and echo each genuine `onInput …` line the
+  // method logs (real data, not a faked component). To keep the shot a clean self-contained
+  // fragment (Name field + console only), the sibling field rows are hidden and the card's own
+  // border neutralized so the docs frame supplies the border (RULES 15s). GIF: type into the Name
+  // field char-by-char; each keystroke appends the real logged line to the console readout.
+  {
+    id: "stimulus-debug",
+    path: "/avo/resources/courses/1/edit",
+    viewport: { width: 900, height: 1000 },
+    settle: 1000,
+    clip: { x: 6, y: 200, width: 888, height: 210 },
+    width: 888,
+    delay: 30,
+    steps: async (page, snap) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await page.waitForTimeout(600);
+
+      // Isolate the Name field: hide the other rows + neutralize the card border so the shot is a
+      // clean Name+console fragment framed by the docs border (RULES 15s), not a sliced card.
+      await page.addStyleTag({
+        content:
+          '[data-field-id]:not([data-field-id="name"]) { display: none !important; }' +
+          ".card:not(.relative) { border-color: transparent !important; box-shadow: none !important; }",
+      });
+
+      // A console-styled readout pinned right under the Name field so the GIF can SHOW the real
+      // console output the debugOnInput method emits (a page screenshot can't capture devtools).
+      await page.evaluate(() => {
+        const anchor = document.querySelector('[data-field-id="name"]');
+        const box = document.createElement("div");
+        box.id = "debug-console-readout";
+        box.style.cssText =
+          "margin:10px 5px 0;font:12px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;" +
+          "background:#0b0f19;color:#d1d5db;border-radius:8px;padding:10px 12px;" +
+          "max-height:130px;overflow:hidden;border:1px solid rgba(255,255,255,.08);";
+        const head = document.createElement("div");
+        head.textContent = "// browser console";
+        head.style.cssText = "color:#6b7280;margin-bottom:4px;";
+        box.appendChild(head);
+        const log = document.createElement("div");
+        log.id = "debug-console-log";
+        box.appendChild(log);
+        anchor.parentElement.insertBefore(box, anchor.nextSibling);
+        window.__pushConsole = (line) => {
+          const el = document.getElementById("debug-console-log");
+          if (!el) return;
+          const row = document.createElement("div");
+          row.innerHTML =
+            '<span style="color:#34d399">&rsaquo;</span> ' +
+            line.replace(/</g, "&lt;");
+          el.appendChild(row);
+          while (el.childElementCount > 5) el.removeChild(el.firstChild);
+        };
+      });
+
+      // Forward the REAL controller console output into the readout.
+      page.on("console", (m) => {
+        const t = m.text();
+        if (t.startsWith("onInput")) page.evaluate((s) => window.__pushConsole(s), t).catch(() => {});
+      });
+
+      const name = page.locator('[data-field-id="name"] input').first();
+      await name.click();
+      await name.fill("");
+      await page.waitForTimeout(300);
+      await snap(6); // empty field + empty console readout
+
+      for (const ch of "Stimulus".split("")) {
+        await name.type(ch, { delay: 30 });
+        await page.waitForTimeout(220); // let the console event round-trip into the readout
+        await snap(3); // each keystroke logs the real onInput event + value
+      }
+      await snap(8); // hold on the final state
+    },
+    out: "docs/public/assets/img/4_0/stimulus/debug-on-input.gif",
+    alt: "An Avo Course edit form Name field wired to resource-edit#debugOnInput; typing logs each input event and value, shown in a console readout below the field.",
+    source: { file: "docs/4.0/stimulus-integration.md", prompt: "a debug controller logging input as you type" },
+  },
+
+  // guide-export-to-csv (guides/export-to-csv.md) — selecting records + running an Export-to-CSV
+  // action. The demo registers `Avo::Actions::ExportCsv` (self.confirmation = true) on the Projects
+  // resource, exactly the guide's action. GIF walks the real flow on the Projects table index: select
+  // three rows (header/row checkboxes) → open the Actions dropdown → the "Export csv" item appears →
+  // click it → the action's confirmation modal slides in ("Are you sure you want to run this action?")
+  // with Cancel / Run → click Run → the CSV downloads and the index returns. (The browser's file-save
+  // is OS-level and not part of the page surface, so the GIF ends on the action having run — RULES'
+  // native-dialog limitation, same as basic-auth; the selectable flow up to Run is the documentable
+  // part.) Sidebar closed + mat bg (RULES 12/19a); hideKbd. clip frames the Actions button → dropdown
+  // → table card → the confirmation modal that opens over it (RULES 15a triggered-in-context).
+  {
+    id: "guide-export-to-csv-export-to-csv",
+    path: "/avo/resources/projects?per_page=6&view_type=table",
+    viewport: { width: 1200, height: 850 },
+    settle: 1000,
+    clip: { x: 12, y: 108, width: 1176, height: 540 },
+    width: 1176,
+    delay: 26,
+    steps: async (page, snap) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await page.waitForTimeout(400);
+
+      await snap(7); // index, nothing selected
+
+      // select three rows
+      const rows = page.locator('tbody tr input[type="checkbox"]');
+      for (let i = 0; i < 3; i++) await rows.nth(i).click();
+      await page.waitForTimeout(400);
+      await snap(8); // three rows selected
+
+      // open the Actions dropdown
+      const actions = page.locator('button:has-text("Actions"), a:has-text("Actions")').first();
+      await actions.click();
+      await page.waitForTimeout(600);
+      await snap(9); // dropdown open showing "Export csv"
+
+      // click the Export csv action → confirmation modal
+      await page.locator('a:has-text("Export csv"), button:has-text("Export csv")').first().click();
+      await page.waitForSelector('text=Are you sure you want to run this action', { timeout: 8000 }).catch(() => {});
+      await page.waitForTimeout(700);
+      await snap(10); // confirmation modal with Cancel / Run
+
+      // run the action
+      const run = page.locator('#modal_frame button[type="submit"], dialog button[type="submit"], [data-turbo-frame="modal_frame"] button[type="submit"]').first();
+      if (await run.count()) {
+        await run.click();
+        await page.waitForTimeout(1400); // action runs (CSV downloads), modal closes, index returns
+      }
+      await snap(10); // hold on the index after the action ran
+    },
+    out: "docs/public/assets/img/4_0/guides/export-to-csv/export-to-csv.gif",
+    alt: "An Avo Projects index where three records are selected, the Actions dropdown is opened, the Export csv action is chosen, and its confirmation modal is run to export the records to a CSV file.",
+    source: { file: "docs/4.0/guides/export-to-csv.md", prompt: "selecting records + running an export-to-CSV action" },
+  },
+
+  // guide-act-as-taggable-on (guides/act-as-taggable-on-integration.md) — a tags field backed by the
+  // acts-as-taggable-on gem, with the add-a-tag interaction. The guide's first line says Avo already
+  // supports acts-as-taggable-on in the `tags` field; the demo's TagsDemo resource has a real
+  // `field :tags, as: :tags, acts_as_taggable_on: :tags` (with suggestions one/two/three). GIF on the
+  // TagsDemo NEW form: focus the tags input → type "one" → the suggestions dropdown appears → press
+  // Enter to add the chip → type "two" → Enter to add a second chip — the live add-a-tag flow. The
+  // field renders in its own real card (with Category/Notes/Reference siblings) so it reads in context
+  // (RULES 10b/15z). A narrow 900px viewport keeps the card content-sized (~867px CSS) so it displays
+  // near 1×. Sidebar closed + mat bg (RULES 12/19a); hideKbd. clip frames the form card + the
+  // suggestions dropdown that opens inside it.
+  // NOTE: the legacy 3.0 GIF showed BROWSING tags as RESOURCES (a taggings/tags resource index), which
+  // the demo doesn't register; per the task this is resolved as the tags-FIELD add-a-tag interaction
+  // (the feature the guide's intro names) instead.
+  {
+    id: "guide-act-as-taggable-on-act-as-taggable-on-integration",
+    path: "/avo/resources/tags_demos/new",
+    viewport: { width: 900, height: 760 },
+    settle: 900,
+    clip: { x: 7, y: 142, width: 887, height: 250 },
+    width: 887,
+    delay: 26,
+    steps: async (page, snap) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await page.waitForTimeout(400);
+
+      await snap(7); // empty tags field with placeholder + help text
+
+      const editable = page.locator('[data-field-id="tags"] .tagify__input').first();
+      await editable.click();
+      await page.waitForTimeout(400);
+      await page.keyboard.type("one", { delay: 110 });
+      await page.waitForTimeout(600);
+      await snap(9); // typed "one" + suggestions dropdown
+
+      await page.keyboard.press("Enter");
+      await page.waitForTimeout(500);
+      await snap(8); // first chip added ("one")
+
+      await page.keyboard.type("two", { delay: 110 });
+      await page.waitForTimeout(500);
+      await snap(7); // typed "two" + suggestion
+      await page.keyboard.press("Enter");
+      await page.waitForTimeout(500);
+      await snap(10); // both chips added ("one", "two")
+    },
+    out: "docs/public/assets/img/4_0/guides/act-as-taggable-on-integration/act-as-taggable-on-integration.gif",
+    alt: "An Avo form with a tags field backed by acts-as-taggable-on; typing a tag shows a suggestions dropdown and pressing Enter adds it as a chip, building up a list of tags.",
+    source: { file: "docs/4.0/guides/act-as-taggable-on-integration.md", prompt: "a tags field backed by acts-as-taggable-on; record the add-a-tag interaction" },
+  },
+
+  // per-page-pagination (customization.md "### Per-page pagination") — Comments index with 4 rows
+  // (?per_page=4) and pagination bar. Temp config in comment.rb sets per_page=4 + per_page_steps=
+  // [4, 12, 24, 48] (RULES 13). injectCSS forces the per-page popover to open upward so all
+  // options stay in frame. GIF: closed picker → open listing 4/12/24/48 → close. Full table
+  // card + pagination (RULES 10/10b/15a); sidebar closed + mat bg (RULES 12/19a); hideKbd.
+  {
+    id: "per-page-pagination",
+    path: "/avo/resources/comments?per_page=4",
+    viewport: { width: 900, height: 900 },
+    settle: 900,
+    clip: { x: 6, y: 224, width: 888, height: 280 },
+    width: 888,
+    delay: 20,
+    steps: async (page, snap) => {
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await injectCSS(
+        `[data-component-name="avo/index/table_component"] [data-item-select-all-target="selectAllBanner"],
+         .item-select-all-banner { display: none !important; }
+         .pagination__per-page .popover-menu__panel {
+           position-area: top span-left !important;
+           position-try-fallbacks: none !important;
+           margin-top: 0 !important;
+           margin-bottom: 0.25rem !important;
+         }`,
+      )(page);
+      await page.waitForTimeout(400);
+
+      const clip = { x: 6, y: 224, width: 888, height: 280 };
+
+      await snap(10, false, clip); // 4 rows, "4 per page" closed
+
+      await page.locator(".pagination__per-page-input").click();
+      await page.waitForTimeout(500);
+      await snap(14, false, clip); // dropdown open above button: 4, 12, 24, 48
+
+      await page.locator(".pagination__per-page-input").click();
+      await page.waitForTimeout(500);
+      await snap(8, false, clip); // closed again
+    },
+    out: "docs/public/assets/img/4_0/customization/per-page-pagination.gif",
+    alt: "An Avo index table with four rows and a pagination bar; the per-page picker opens upward to list 4, 12, 24 and 48, then closes.",
+    source: {
+      file: "docs/4.0/customization.md",
+      prompt: "index table with 4 rows and pagination bar; per-page picker opens listing 4, 12, 24, 48 then closes",
+    },
+  },
+
+  // view-type-table-grid (customization.md "### Default view type") — Posts index with 6 records
+  // per page (?per_page=6). GIF: table view → red-annotate grid toggle → switch to grid →
+  // red-annotate table toggle → switch back to table. Native view-switcher chrome unchanged;
+  // only ImageMagick highlight marks (no hover tooltips). Sidebar closed + mat bg; hideKbd.
+  {
+    id: "view-type-table-grid",
+    path: "/avo/resources/posts?view_type=table&per_page=6",
+    viewport: { width: 900, height: 1100 },
+    settle: 900,
+    clip: { x: 6, y: 170, width: 888, height: 650 },
+    width: 888,
+    delay: 20,
+    steps: async (page, snap) => {
+      const hideBanner = () =>
+        injectCSS(
+          `[data-component-name="avo/index/table_component"] [data-item-select-all-target="selectAllBanner"],
+           .item-select-all-banner { display: none !important; }`,
+        )(page);
+
+      await closeSidebar(page);
+      await matBg(page);
+      await hideKbd(page);
+      await hideBanner();
+      await page.waitForTimeout(400);
+
+      const clip = { x: 6, y: 170, width: 888, height: 650 };
+      const gridToggle = '[data-control="view-type-toggle-grid"]';
+      const tableToggle = '[data-control="view-type-toggle-table"]';
+      const mark = (sel) => [{ selector: sel, type: "highlight", color: "#ef4444", pad: 3, radius: 6 }];
+      const clearHover = async () => {
+        await page.evaluate(() => document.activeElement?.blur());
+        await page.mouse.move(400, 400);
+        await page.waitForTimeout(150);
+      };
+
+      await snap(10, false, clip); // table view, 6 rows
+
+      await clearHover();
+      await snap(10, mark(gridToggle), clip); // grid toggle — red mark only
+
+      await page.locator(gridToggle).click();
+      await page.waitForLoadState("networkidle");
+      await page.waitForTimeout(700);
+      await matBg(page);
+      await hideKbd(page);
+      await hideBanner();
+      await page.waitForTimeout(300);
+      await snap(12, false, clip); // grid view, 6 cards
+
+      await clearHover();
+      await snap(10, mark(tableToggle), clip); // table toggle — red mark only
+
+      await page.locator(tableToggle).click();
+      await page.waitForLoadState("networkidle");
+      await page.waitForTimeout(700);
+      await matBg(page);
+      await hideKbd(page);
+      await hideBanner();
+      await page.waitForTimeout(300);
+      await snap(10, false, clip); // back to table view
+    },
+    out: "docs/public/assets/img/4_0/customization/view-type-table-grid.gif",
+    alt: "An Avo Posts index with six records per page: the view switcher toggles between table rows and grid cards.",
+    source: {
+      file: "docs/4.0/customization.md",
+      prompt: "Posts index with 4 per page; GIF toggling table and grid view with annotated view switcher",
+    },
+  },
+
+  // act-as-taggable-on-integration (guides/act-as-taggable-on-integration.md) — the railsbytes
+  // template adds Tag + Tagging Avo RESOURCES so you can browse the acts-as-taggable-on data as
+  // first-class resources. The guide is about that, NOT the tags form field. Demo edits (v4
+  // adaptation of the v2 template): Avo::Resources::Tag (model ActsAsTaggableOn::Tag, title :name,
+  // fields id/name/taggings_count/created_at + has_many :taggings) and Avo::Resources::Tagging
+  // (model ActsAsTaggableOn::Tagging, fields id/tag belongs_to/taggable polymorphic→Post/created_at)
+  // + Avo::TagsController/Avo::TaggingsController + permissive ActsAsTaggableOn::Tag/TaggingPolicy
+  // (the demo runs explicit_authorization). Seeded 6 realistic tags (rails, ruby, tutorial,
+  // announcement, release, performance) onto Posts → non-zero taggings counts + 34 taggings.
+  // NOTE: this Avo build does NOT render has_many panels inline on Show (verified: Post/Team show
+  // pages drop their has_many panels too), so the "tag's taggings list" can't be shown ON the tag
+  // show page. Tour instead surfaces the taggings as their OWN resource: Tags index → open a tag
+  // (Show details) → Taggings index, where each tagging row links to its tag + the Post it tags.
+  // RED CLICK MARKS (user request): before each navigational hop, an absolutely-positioned red
+  // overlay (red-400 #f87171, 2px stroke, 2px pad, small radius — RULES 15d′, NOT the native blue
+  // ring) is drawn hugging the element being "clicked" (the tag row on the Tags index; a tagging's
+  // Tag link on the Taggings index), held for a few frames, then removed and the page advances. The
+  // overlay is injected DOM so it renders identically in light + dark.
+  // BALANCED CLIP (no dead space): per_page=3 makes both index tables ~218px tall (panel y160→378),
+  // matching the Tag show details card (~205px, y160→365). The fixed clip frames the page title row
+  // (H1+controls, y≈116) down to the table/pager bottom (~378) + ~10px mat — so all three screens
+  // fill the frame with no half-empty band. Sidebar closed + mat bg + hideKbd (RULES 12/19a/15e).
+  // width 2144 / display:"full" → fills the docs content column like resource-search.
+  {
+    id: "taggable-resources-tour",
+    path: "/avo/resources/tags?per_page=3",
+    viewport: { width: 1100, height: 1000 },
+    settle: 1000,
+    clip: { x: 14, y: 104, width: 1072, height: 286 },
+    width: 2144,
+    delay: 20,
+    steps: async (page, snap) => {
+      const BASE = process.env.AVO_BASE_URL || "http://localhost:3020";
+      const frame = async () => {
+        await closeSidebar(page);
+        await matBg(page);
+        await hideKbd(page);
+        await page.waitForTimeout(400);
+      };
+      // Draw a red callout (red-400, 2px stroke, tight pad, small radius — RULES 15d′) hugging the
+      // element matched by `selector`, then remove it. Injected DOM so it renders in light + dark.
+      const showRedMark = async (selector) => {
+        await page.evaluate((sel) => {
+          const el = document.querySelector(sel);
+          if (!el) return;
+          const b = el.getBoundingClientRect();
+          const pad = 2;
+          const box = document.createElement("div");
+          box.id = "__red_click_mark__";
+          Object.assign(box.style, {
+            position: "fixed",
+            left: `${b.left - pad}px`,
+            top: `${b.top - pad}px`,
+            width: `${b.width + pad * 2}px`,
+            height: `${b.height + pad * 2}px`,
+            border: "2px solid #f87171",
+            borderRadius: "4px",
+            boxShadow: "0 0 0 1px rgba(248,113,113,0.35)",
+            pointerEvents: "none",
+            zIndex: "2147483647",
+          });
+          document.body.appendChild(box);
+        }, selector);
+      };
+      const clearRedMark = async () => {
+        await page.evaluate(() => document.getElementById("__red_click_mark__")?.remove());
+      };
+
+      await frame();
+
+      // Beat 1 — the Tags index: tags browsed as a resource (id / name / taggings count / created at).
+      await snap(12, false);
+
+      // Mark the first tag row (the element we "click" to open the tag), hold, then advance to Show.
+      await showRedMark("table tbody tr:first-child");
+      await snap(9, false); // red callout on the tag row
+      await clearRedMark();
+      await page.goto(`${BASE}/avo/resources/tags/10`, { waitUntil: "networkidle" });
+      await frame();
+
+      // Beat 2 — that tag's Show page: its details (id / name / taggings count / created at).
+      await snap(13, false);
+
+      // Beat 3 — the Taggings index: the underlying tagging records, each linking to its tag + Post.
+      await page.goto(`${BASE}/avo/resources/taggings?per_page=3`, { waitUntil: "networkidle" });
+      await frame();
+      await snap(12, false);
+
+      // Mark a tagging's Tag link (the element we "click" to drill back to that tag), hold, advance.
+      await showRedMark("table tbody tr:first-child a[href*='/avo/resources/tags/']");
+      await snap(9, false); // red callout on the tagging's Tag link
+      await clearRedMark();
+      await page.goto(`${BASE}/avo/resources/tags/10`, { waitUntil: "networkidle" });
+      await frame();
+      await snap(13, false); // land on that tag's Show — closes the loop
+    },
+    out: "docs/public/assets/img/4_0/guides/act-as-taggable-on-integration/taggable-resources-tour.gif",
+    display: "full",
+    alt: "Browsing acts-as-taggable-on data as Avo resources: clicking a tag on the Tags index opens its details, and the Taggings index lists the underlying tagging records, each linking back to its tag and the post it tags.",
+    source: {
+      file: "docs/4.0/guides/act-as-taggable-on-integration.md",
+      prompt: "tour the generated Tag + Tagging Avo resources with red click marks — Tags index, a Tag show, the Taggings index",
+    },
   },
 ];
 


### PR DESCRIPTION
Remove 35 one-off scratch probe scripts that were never reusable and ignore probe-*-tmp.mjs going forward. Update the docs-screenshots skill, RULES/PROCESS/CHECKLIST, and the core harness scripts (annotate, prepare, record-gif, specs).