### PR TITLE
Document Avo Status sidebar access for admin and developer users

### DIFF
--- a/docs/4.0/authentication.md
+++ b/docs/4.0/authentication.md
@@ -162,7 +162,7 @@ You can do that check yourself using the `Avo::Current.user_is_admin?`.
 
 #### When does Avo check if the use is an admin (`is_admin?`)
 
-Avo doesn't use this setting momentarily but might in the future.
+Admin users can access the private **Avo Status** page at `/avo_private/status` (under your Avo mount path) and see the status link in the sidebar on production.
 
 </Option>
 
@@ -180,6 +180,8 @@ You can do that check yourself using the `Avo::Current.user_is_developer?`.
 
 Avo uses this role to display long backtraces on non-validation errors.
 Ex: on record save, you might call an API which by some reason errors out. Instead of just getting a generic "Something went wrong" error, the developer user will see the error message and backtrace
+
+Developer users can also access the private **Avo Status** page and see the status link in the sidebar on production (same access as [admin users](#1-admin-user)). In development, the status link is visible to everyone.
 
 <Image src="/assets/img/4_0/authentication/backtrace.png" dark-src="/assets/img/4_0/authentication/backtrace-dark.png" alt="Backtrace alert" width="1060" height="484" />
 


### PR DESCRIPTION
## Summary
- Document that admin and developer users can access `/avo_private/status` and see the Avo Status sidebar link in production
- Note that the status link remains visible to everyone in development

Related: https://linear.app/avo-hq/issue/AVO-1223/add-avo-privatestatus-on-production-for-developer-users
Companion PR: https://github.com/avo-hq/avo/pull/4610

## Test plan
- [ ] Review updated authentication docs page for clarity and correct anchor links