### PR TITLE
Document license key hidden on status page by default

### DIFF
--- a/docs/4.0/customization.md
+++ b/docs/4.0/customization.md
@@ -751,11 +751,11 @@ end
 
 <Option name="`exclude_from_status`">
 
-Defines which status items to exclude from the status page (`/avo_private/status`). This is useful for hiding sensitive information like license keys from the status page.
+Defines which status items to exclude from the status page (`/avo_private/status`). By default, the license key is hidden for security reasons.
 
 ### Default value
 
-`[]`
+`["license_key"]`
 
 ### Possible values
 
@@ -766,18 +766,26 @@ An array of strings or a callable that returns an array of strings representing 
 ```ruby
 # config/initializers/avo.rb
 Avo.configure do |config|
-  config.exclude_from_status = ["license_key"]
+  # Hide additional items from the status page
+  config.exclude_from_status = ["license_key", "ip"]
 
   # OR using a callable
   config.exclude_from_status = -> do
-    ["license_key"]
+    ["license_key", "ip"]
   end
 end
 ```
 
-### Common use case
+### Show the license key
 
-The most common use case is to exclude the `license_key` from being displayed on the status page for security reasons.
+To display the license key on the status page, remove it from the exclusion list:
+
+```ruby
+# config/initializers/avo.rb
+Avo.configure do |config|
+  config.exclude_from_status = []
+end
+```
 
 </Option>
 

--- a/docs/4.0/license-troubleshooting.md
+++ b/docs/4.0/license-troubleshooting.md
@@ -10,7 +10,7 @@ Go to `https://yourapp.com/avo/avo_private/status`. If you mounted Avo under a d
 
 In order to see that page your user has to be an an admin in Avo. Follow [this guide](./authentication#user-roles) to mark your user as an admin.
 
-This should tell you if the license authenticated correctly, what is your used license key and what was the response from our checking server.
+This should tell you if the license authenticated correctly and what was the response from our checking server. The license key is hidden by default for security — set [`exclude_from_status`](./customization#exclude_from_status) to `[]` in your Avo initializer if you need to see it on the status page.
 
 ## Frequent issues
 


### PR DESCRIPTION
## Summary
- Update `exclude_from_status` docs to reflect the new default of `["license_key"]`
- Add an example showing how to opt in to displaying the license key
- Update license troubleshooting to note the key is hidden by default

Companion docs PR for [AVO-1423](https://linear.app/avo-hq/issue/AVO-1423/fix-license-key-exposed-on-status-page-by-default)

## Test plan
- [ ] Confirm customization page renders the updated default and opt-in example
- [ ] Confirm license troubleshooting page links to the customization option


Made with [Cursor](https://cursor.com)