### PR TITLE
Document searchable option on has_one (AVO-1258)

### DIFF
--- a/docs/4.0/associations/has_one.md
+++ b/docs/4.0/associations/has_one.md
@@ -19,6 +19,7 @@ field :admin, as: :has_one
 
 ## Options
 
+<!-- @include: ./../common/associations_searchable_option_common.md-->
 <!-- @include: ./../common/associations_attach_scope_option_common.md-->
 <!-- @include: ./../common/associations_loading_option_common.md-->
 


### PR DESCRIPTION
## Summary
- Restore the shared `searchable` option include on the has_one associations page

## Context
Part of [AVO-1258](https://linear.app/avo-hq/issue/AVO-1258/investigate-fix-has-one-searchable-hard-coded-to-false). The include was removed while `has_one` searchable was broken; the code fix restores the behavior.

Companion PRs:
- avo-hq/avo — core `HasOneField` fix
- avo-hq/workspace — advanced_search extension hook + tests

## Test plan
- [ ] `npx vitepress build docs`


Made with [Cursor](https://cursor.com)