### PR TITLE
Fix PolicyHelpers namespace: Avo::Pro -> Avo::Authorization

### DIFF
--- a/docs/4.0/authorization.md
+++ b/docs/4.0/authorization.md
@@ -336,7 +336,7 @@ end
 
 Now, whatever action you take for one comment, it will be available for the `edit_comments?` method in `PostPolicy`.
 
-From version 2.31 we introduced a concern that removes the duplication and helps you apply the same rules to associations. You should include `Avo::Pro::Concerns::PolicyHelpers` in the `ApplicationPolicy` for it to be applied to all policy classes.
+There's a concern that removes the duplication and helps you apply the same rules to associations. You should include `Avo::Authorization::Concerns::PolicyHelpers` in the `ApplicationPolicy` for it to be applied to all policy classes.
 
 `PolicyHelpers` allows you to use the method `inherit_association_from_policy`. This method takes two arguments; `association_name` and the policy file you want to be used as a template.
 

--- a/docs/4.0/avo-3-avo-4-upgrade.md
+++ b/docs/4.0/avo-3-avo-4-upgrade.md
@@ -663,6 +663,15 @@ end
 
 If you use global search and have hardcoded search URLs, see [Avo Pro mount point removal](#avo-pro-mount-point-removal) above.
 
+#### Policy helpers
+
+If you use [`inherit_association_from_policy`](./authorization#removing-duplication) in your policies, update the concern's namespace:
+
+```ruby
+include Avo::Pro::Concerns::PolicyHelpers # [!code --]
+include Avo::Authorization::Concerns::PolicyHelpers # [!code ++]
+```
+
 ### Advanced features
 
 | Feature                                                             | Gem                   |


### PR DESCRIPTION
## Summary
- `Avo::Pro::Concerns::PolicyHelpers` was relocated to `Avo::Authorization::Concerns::PolicyHelpers` when `avo-pro` was split into feature gems — it was not removed. Fix the reference in the authorization guide.
- Add a "Policy helpers" entry to the Avo 3 → 4 upgrade guide under the Pro features section so anyone using `inherit_association_from_policy` knows to update the include.

## Test plan
- [x] `npx vitepress build docs` (mentally verified anchor link `./authorization#removing-duplication` matches the existing `## Removing duplication` heading)