### PR TITLE
Clarify dash_if_blank checks field value, not block content

### DIFF
--- a/docs/4.0/field-wrappers.md
+++ b/docs/4.0/field-wrappers.md
@@ -21,8 +21,9 @@ You may use the component `Avo::Index::FieldWrapperComponent` or the helper `ind
 
 <Option name="`dash_if_blank`">
 
-This option renders a dash `—` if the content inside responds to true on the `blank?` method.
-In the example below, we'd like to show the field as a red checkmark even if the content is `nil`.
+Controls whether a dash `—` is rendered instead of the block's content.
+
+Avo decides this by checking `@field.value.blank?` — **not** whether the block passed to `index_field_wrapper` actually renders something. In the example below, we'd like to show a red cross icon instead of a dash even when `@field.value` is `nil`, so we pass `dash_if_blank: false`.
 
 #### Default
 
@@ -33,6 +34,11 @@ In the example below, we'd like to show the field as a red checkmark even if the
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
+
+:::warning
+Because the check runs against `@field.value` and not the block's rendered output, a block that renders real content is still discarded in favor of the dash whenever `@field.value` is blank. If you're building a custom field whose block can render meaningful content even when `@field.value` is blank, pass `dash_if_blank: false` explicitly, or your content will never show up.
+:::
+
 </Option>
 
 <Option name="`center_content`">
@@ -120,8 +126,9 @@ This space is rarely used and it's there just to fill some horizontal space so t
 
 <Option name="`dash_if_blank`">
 
-This option renders a dash `—` if the content inside responds to true on the `blank?` method.
-In the example below, we'd like to show the field as a red checkmark even if the content is `nil`.
+Controls whether a dash `—` is rendered instead of the block's content.
+
+Avo decides this by checking `@field.value.blank?` — **not** whether the block passed to `field_wrapper` actually renders something. In the example below, we'd like to show a red cross icon instead of a dash even when `@field.value` is `nil`, so we pass `dash_if_blank: false`.
 
 #### Default
 
@@ -132,6 +139,11 @@ In the example below, we'd like to show the field as a red checkmark even if the
   <%= render Avo::Fields::Common::BooleanCheckComponent.new checked: @field.value %>
 <% end %>
 ```
+
+:::warning
+Because the check runs against `@field.value` and not the block's rendered output, a block that renders real content is still discarded in favor of the dash whenever `@field.value` is blank. If you're building a custom field whose block can render meaningful content even when `@field.value` is blank, pass `dash_if_blank: false` explicitly, or your content will never show up.
+:::
+
 </Option>
 
 <Option name="`compact`">


### PR DESCRIPTION
## Summary
- AVO-791 is scoped to documentation: explain what `dash_if_blank` actually does and confirm its default.
- The existing wording implied Avo checks whether the *rendered block content* is blank. It actually checks `@field.value.blank?`, which is the gotcha reported on Discord (a custom field's block can render real content but still get discarded in favor of the dash).
- Updated both `dash_if_blank` `<Option>` blocks in `docs/4.0/field-wrappers.md` (index field wrapper and show/edit field wrapper) with accurate wording and a `:::warning` callout on when to pass `dash_if_blank: false`.

Ref: https://linear.app/avo-hq/issue/AVO-791/document-dash-if-blank

Note: the underlying rendering behavior itself is unchanged — Adrian asked for a separate reproducible GitHub issue on `avo-hq/avo` if we want to revisit that, this PR only fixes the docs.

## Test plan
- [x] `npx vitepress build docs` completes successfully
- [ ] Visually check the two `dash_if_blank` sections render correctly on the built site