### PR TITLE
docs: rewrite stale namespaced resources section

### DIFF
--- a/docs/2.0/resources.md
+++ b/docs/2.0/resources.md
@@ -10,6 +10,10 @@ Each `Resource` maps out one of your models. There can be multiple `Resource`s a
 
 All resources are located in the `app/avo/resources` directory. Unfortunately, `Resource`s can't be namespaced yet, so they all need to be in the root level of that directory.
 
+:::tip Namespacing lands in Avo 4
+Avo 4 adds full support for namespaced resources — nest them in subdirectories that mirror your model namespace, get automatic model-class inference, and generate any nesting depth with `avo:resource`. Take a look at [namespaced resources](../4.0/resources.html#namespaced-resources) in the Avo 4 docs.
+:::
+
 :::warning
 All resources from `app/avo/resources` are eager loaded on app boot-time to automatically have them available in your app.
 

--- a/docs/3.0/resources.md
+++ b/docs/3.0/resources.md
@@ -329,6 +329,10 @@ class Avo::Resources::SuperDooperTrooperModel < Avo::BaseResource
 end
 ```
 
+:::tip Namespacing lands in Avo 4
+Avo 4 adds full support for namespaced resources — nest them in subdirectories that mirror your model namespace, get automatic model-class inference, and generate any nesting depth with `avo:resource`. Take a look at [namespaced resources](../4.0/resources.html#namespaced-resources) in the Avo 4 docs.
+:::
+
 ## Views
 
 Please read the detailed [views](./views.html) page.

--- a/docs/4.0/i18n.md
+++ b/docs/4.0/i18n.md
@@ -37,6 +37,8 @@ es:
         other: 'usuarios'
 ```
 
+If you don't set `self.translation_key`, Avo derives it from the resource's class name, namespace included — a [namespaced resource](./resources.html#namespaced-resources) like `Avo::Resources::Galaxy::Planet` defaults to `avo.resource_translations.galaxy/planet`.
+
 ## Localizing fields
 
 Similarly, you can even localize fields. All you need to do is add a `translation_key:` option on the field declaration.

--- a/docs/4.0/resources.md
+++ b/docs/4.0/resources.md
@@ -321,13 +321,38 @@ We can still tell Avo which resource to use in other `has_many` or `has_and_belo
 
 ## Namespaced resources
 
-`Resource`s can't be namespaced yet, so they all need to be in the root level of that directory. If you have a model `Super::Dooper::Trooper::Model` you can use `Avo::Resources::SuperDooperTrooperModel` with the `model_class` option.
+Resources can be namespaced by nesting them in subdirectories of `app/avo/resources`, mirroring the namespace with `::` in the class name. This is handy for grouping resources that belong to a namespaced model (`Galaxy::Planet`) or that you just want organized under a common prefix (`Billing::Invoice`).
+
+```ruby
+# app/avo/resources/galaxy/planet.rb
+class Avo::Resources::Galaxy::Planet < Avo::BaseResource
+  self.title = :name
+
+  def fields
+    field :id, as: :id
+    field :name, as: :text
+    field :satellites, as: :has_many
+  end
+end
+```
+
+If the resource's namespace matches its model's namespace (`Avo::Resources::Galaxy::Planet` → `Galaxy::Planet`), Avo infers the model class automatically — no `self.model_class` needed. If it doesn't, set `model_class` explicitly, same as with a flat resource:
 
 ```ruby
 class Avo::Resources::SuperDooperTrooperModel < Avo::BaseResource
   self.model_class = "Super::Dooper::Trooper::Model"
 end
 ```
+
+Generate a namespaced resource (and its matching namespaced controller) the same way you'd generate a flat one, just with the namespace in the name:
+
+```bash
+bin/rails generate avo:resource Galaxy::Planet
+```
+
+That creates `app/avo/resources/galaxy/planet.rb` (`Avo::Resources::Galaxy::Planet`) and `app/controllers/avo/galaxy/planets_controller.rb` (`Avo::Galaxy::PlanetsController`). Namespaces can go as deep as you need — `Universe::Cluster::Star::Comet` generates `app/avo/resources/universe/cluster/star/comet.rb`, and so on.
+
+Namespacing also affects the resource's routes and translation key: `Avo::Resources::Galaxy::Planet` gets the route path `galaxy/planets` and the translation key `avo.resource_translations.galaxy/planet`, following the same underscored, slash-joined convention as the class name.
 
 ## Views
 

--- a/docs/4.0/routing.md
+++ b/docs/4.0/routing.md
@@ -46,6 +46,10 @@ To guarantee that the `locale` scope is included in the `default_url_options`, y
 Check [this documentation section](customization.html#default_url_options) for details on how to configure `default_url_options` setting.
 :::
 
+## Namespaced resource routes
+
+A [namespaced resource](./resources.html#namespaced-resources) like `Avo::Resources::Galaxy::Planet` gets a slash-joined route path derived from its class name — `galaxy/planets` in this case. Avo generates and mounts these routes for you, so there's nothing to configure by hand.
+
 ## Add your own routes
 
 You may want to add your own routes inside Avo so you can access different custom actions that you might have set in the Avo resource controllers.


### PR DESCRIPTION
## Summary
- The "Namespaced resources" section in `docs/4.0/resources.md` said "Resources can't be namespaced yet" — this hasn't been true for a while. `external/avo` fully supports directory-nested, `::`-namespaced resources (automatic model-class inference, the `avo:resource` generator, route/translation-key conventions), up to at least 4 levels deep per the generator specs.
- Rewrote the section to document the real behavior, with a working example (`Avo::Resources::Galaxy::Planet`) and the generator command.

## Test plan
- [x] `npx vitepress build docs` succeeds
- [x] Verified the rendered `4.0/resources.html` output contains the new section correctly

Closes AVO-1225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)