### PR TITLE
docs: allow the clerk license check host in the test suite

### DIFF
--- a/docs/4.0/avo-3-avo-4-upgrade.md
+++ b/docs/4.0/avo-3-avo-4-upgrade.md
@@ -143,6 +143,21 @@ Avo now uses the avatar and initials of a record or resource throughout the app.
 You set the avatar using the `avatar` configuration (ex-profile photo). The avatar will be used by Avo in multiple places in the app like the <Show /> and <Edit /> views, and the new breadcrumbs.
 In addition you can use the `avatar` field to display the avatar in the <Index /> view.
 
+## Allow the license check host in your test suite
+
+Avo 4 verifies your license through an outbound request to `clerk-1.avohq.io` (falling back to `clerk-2.avohq.io`), and this request runs in the `test` environment too. Avo 3 validated licenses differently and didn't make this request, so a suite that passed on Avo 3 can start failing right after the upgrade if it blocks outbound connections.
+
+If you disable network connections in tests (for example with WebMock or VCR `disable_net_connect!`), you'll see failures like `WebMock::NetConnectNotAllowedError: ... POST https://clerk-1.avohq.io/api/v4/licenses/check`. Add Avo's license check hosts to your allow list:
+
+```ruby
+WebMock.disable_net_connect!(
+  allow_localhost: true,
+  allow: ["clerk-1.avohq.io", "clerk-2.avohq.io"] # [!code ++]
+)
+```
+
+See [Testing → Allow the license check host in your test suite](./testing.html#allow-the-license-check-host-in-your-test-suite) for the full details, including the VCR equivalent.
+
 ## Search
 
 Avo 4 introduces significant improvements to the search functionality, with enhanced resource search and global search capabilities.

--- a/docs/4.0/license-troubleshooting.md
+++ b/docs/4.0/license-troubleshooting.md
@@ -29,3 +29,20 @@ end
 In order to check that, use the status page described above.
 
 </Option>
+
+<Option name="License check blocked in the test suite">
+
+Avo 4 verifies the license through an outbound request to `clerk-1.avohq.io` (falling back to `clerk-2.avohq.io`). If your test suite disables outbound network connections (for example with WebMock or VCR `disable_net_connect!`), that request is blocked and unrelated tests fail with `WebMock::NetConnectNotAllowedError`.
+
+Add the license check hosts to your allow list:
+
+```ruby
+WebMock.disable_net_connect!(
+  allow_localhost: true,
+  allow: ["clerk-1.avohq.io", "clerk-2.avohq.io"]
+)
+```
+
+See [Testing → Allow the license check host in your test suite](./testing.html#allow-the-license-check-host-in-your-test-suite) for the full details.
+
+</Option>

--- a/docs/4.0/testing.md
+++ b/docs/4.0/testing.md
@@ -10,6 +10,42 @@ We know the testing guides aren't very detailed, and some testing helpers are ne
 
 Testing is an essential aspect of your app. Most Avo DSLs are Ruby classes, so regular testing methods should apply.
 
+## Allow the license check host in your test suite
+
+Avo 4 verifies your license by making an outbound request to `clerk-1.avohq.io` (falling back to `clerk-2.avohq.io`). This request runs in every environment, including `test`.
+
+If your test suite blocks outbound network connections — for example with [WebMock](https://github.com/bblimke/webmock) or [VCR](https://github.com/vcr/vcr) `disable_net_connect!` — the license check is blocked and otherwise-unrelated tests fail with an error like:
+
+```
+WebMock::NetConnectNotAllowedError:
+  Real HTTP connections are disabled. Unregistered request:
+  POST https://clerk-1.avohq.io/api/v4/licenses/check with body '...'
+```
+
+:::info New in Avo 4
+Avo 3 validated licenses through the legacy HQ endpoint and didn't trip this. Avo 4 validates through `clerk-*.avohq.io`, so an app that never had this problem on Avo 3 can start failing tests right after upgrading.
+:::
+
+The fix is to add Avo's license check hosts to your allow list. Add them to your **existing** `disable_net_connect!` call so you keep whatever options you already have:
+
+```ruby
+# spec/rails_helper.rb, spec/spec_helper.rb, or test/test_helper.rb
+WebMock.disable_net_connect!(
+  allow_localhost: true,
+  allow: ["clerk-1.avohq.io", "clerk-2.avohq.io"] # [!code ++]
+)
+```
+
+If you use **VCR**, ignore the same hosts:
+
+```ruby
+VCR.configure do |config|
+  config.ignore_hosts "clerk-1.avohq.io", "clerk-2.avohq.io"
+end
+```
+
+This only applies when you explicitly disable outbound connections in the test environment. If your tests already permit real HTTP requests, no change is needed.
+
 ## Testing helpers
 
 We prepared a few testing helpers for you to use in your apps. They will help with opening/closing datepickers, choosing the date, saving the records, add/remove tags, and also select a lot of elements throughout the UI.


### PR DESCRIPTION
## What

Documents that Avo 4 verifies the license via an outbound request to `clerk-1.avohq.io` (falling back to `clerk-2.avohq.io`), which now also runs in the `test` environment — and how to unblock it when a suite disables outbound network connections.

## Why

A trial customer upgraded from Avo 3 to Avo 4 and their CI started failing on otherwise-unrelated tests:

```
WebMock::NetConnectNotAllowedError:
  Real HTTP connections are disabled. Unregistered request:
  POST https://clerk-1.avohq.io/api/v4/licenses/check ...
```

Avo 3 validated licenses through the legacy HQ endpoint and never tripped WebMock/VCR, so this is a new surprise on upgrade. The fix is to add the clerk hosts to the allow list:

```ruby
WebMock.disable_net_connect!(
  allow_localhost: true,
  allow: ["clerk-1.avohq.io", "clerk-2.avohq.io"]
)
```

We agreed in support to add this to the upgrade guide.

## Changes

| File | Change |
| --- | --- |
| `docs/4.0/testing.md` | Canonical section — full explanation + WebMock and VCR fixes |
| `docs/4.0/avo-3-avo-4-upgrade.md` | "New in Avo 4" note pointing to the testing page |
| `docs/4.0/license-troubleshooting.md` | `<Option>` for the blocked-in-tests case, pointing to the testing page |

Hostnames verified against `avo-licensing` (`lib/avo/licensing/h_q.rb`). `npx vitepress build docs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)