### PR TITLE
docs(scopes): document the counter option

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -370,8 +370,11 @@ const config = {
                 ? window.location.pathname.match(/^\/(\d+\.\d+)\//)
                 : null
 
-              if (match) {
-                const versionFilter = 'version:' + match[1]
+              // Scope to the current docs version; default to 4.0 on unversioned
+              // pages (home, /team) so search doesn't span every version.
+              const version = match ? match[1] : '4.0'
+              {
+                const versionFilter = 'version:' + version
                 const withFilter = function (request) {
                   // Only scope our docs index; leave any other index (e.g. Ask AI) untouched.
                   if (!request || request.indexName !== 'avohq') return request
@@ -405,8 +408,9 @@ const config = {
           const match = typeof window !== 'undefined'
             ? window.location.pathname.match(/^\/(\d+)\.\d+\//)
             : null
-          if (!match) return null
-          return html`<div class="vp-docsearch-version-note">Searching <strong>v${match[1]}</strong> docs</div>`
+          // Default to v4 on unversioned pages (home, /team) to match the filter.
+          const major = match ? match[1] : '4'
+          return html`<div class="vp-docsearch-version-note">Searching <strong>v${major}</strong> docs</div>`
         },
       },
     },

--- a/docs/4.0/guides/display-scope-record-count.md
+++ b/docs/4.0/guides/display-scope-record-count.md
@@ -1,5 +1,11 @@
 # Display scope record count
 
+:::tip Use the built-in `counter` option
+Avo has a built-in [`counter`](../scopes.html#counter) scope option that renders the count badge for you, with `:lazy` and `:hover` loading to avoid slowing down the page. Prefer it over the manual approach below.
+:::
+
+The manual approach documented here still works when you need full control over the markup.
+
 The `name` and `description` scope options can be callable values and receive the `resource`, `scope` and `query` objects.
 
 The `query` object is the actual Active Record query (unscoped) that is made to fetch the records.

--- a/docs/4.0/scopes.md
+++ b/docs/4.0/scopes.md
@@ -236,7 +236,7 @@ Controls when the count is fetched.
 | -------------------- | --------------------------------------------------------------------- |
 | `:eager` (or `true`) | Count is computed during the request and rendered inline.             |
 | `:lazy`              | Count loads in a deferred turbo-frame after the page paints.          |
-| `:hover`             | Count loads the first time the user hovers the scope, then is cached. |
+| `:hover`             | Same as `:lazy` — loads in a deferred turbo-frame after paint.        |
 
 ```ruby{3}
 # app/avo/scopes/active.rb

--- a/docs/4.0/scopes.md
+++ b/docs/4.0/scopes.md
@@ -1,6 +1,6 @@
 ---
 license: advanced
-outline: [2, 3]
+outline: [2, 4]
 ---
 
 # Scopes
@@ -75,9 +75,8 @@ class Avo::Resources::User < Avo::BaseResource
   end
 end
 ```
+
 </Option>
-
-
 
 <Option name="`remove_scope_all`" headingSize="3">
 
@@ -92,6 +91,7 @@ class Avo::Resources::User < Avo::BaseResource
   end
 end
 ```
+
 </Option>
 
 ## Options
@@ -115,8 +115,9 @@ Inside each proc, you can call `scoped_query`, but use it with caution as it exe
 
 This value is going to be displayed on the scopes bar as the name of the scope.
 
-
-The `scoped_query` method can be used to compute and display the record count. Please see [the recipe](./guides/display-scope-record-count.html) on how to enable it.
+:::tip Record counts
+To show a record count next to the scope, use the built-in [`counter`](#counter) option instead of computing it inside `name`. It supports lazy and on-hover loading so it won't slow down the page.
+:::
 
 ```ruby{3}
 # app/avo/scopes/even_id.rb
@@ -132,6 +133,7 @@ class Avo::Scopes::EvenId < Avo::Scopes::BaseScope
   self.name = -> { "Even (#{scoped_query.count})" }
 end
 ```
+
 </Option>
 
 ---
@@ -155,6 +157,7 @@ class Avo::Scopes::EvenId < Avo::Scopes::BaseScope
   }
 end
 ```
+
 </Option>
 
 ---
@@ -179,6 +182,7 @@ class Avo::Scopes::EvenId < Avo::Scopes::BaseScope
   self.scope = -> { query.where("#{resource.model_key}.id % 2 = ?", "0") }
 end
 ```
+
 </Option>
 
 ---
@@ -201,13 +205,106 @@ end
 
 </Option>
 
+---
+
+<Option name="`counter`" headingSize="3">
+
+Displays a count badge next to the scope's label showing how many records match the scope. This is the built-in, recommended alternative to computing the count manually inside `name`.
+
+The count is computed against the resource's authorization-scoped query and ignores any active search or filters, so it always reflects the whole scope.
+
+Set it to `true` (or `:eager`) to render the count during the request:
+
+```ruby{3}
+# app/avo/scopes/active.rb
+class Avo::Scopes::Active < Avo::Scopes::BaseScope
+  self.counter = true
+end
+```
+
+:::warning Performance Note
+An eager counter runs its `count` query on every page load. For large tables, use `:lazy` or `:hover` to defer it.
+:::
+
+For finer control, pass a Hash with any of the keys below.
+
+<Option name="`counter.loading`" headingSize="4">
+
+Controls when the count is fetched.
+
+| Mode                 | Behavior                                                              |
+| -------------------- | --------------------------------------------------------------------- |
+| `:eager` (or `true`) | Count is computed during the request and rendered inline.             |
+| `:lazy`              | Count loads in a deferred turbo-frame after the page paints.          |
+| `:hover`             | Count loads the first time the user hovers the scope, then is cached. |
+
+```ruby{3}
+# app/avo/scopes/active.rb
+class Avo::Scopes::Active < Avo::Scopes::BaseScope
+  self.counter = :lazy
+end
+```
+
+</Option>
+
+<Option name="`counter.count`" headingSize="4">
+
+A custom count value. The `count` proc runs in the execution context with access to `query`, `resource`, and `scope`, where `query` is the unfiltered base query. It can return any value (not just a number) — whatever it returns becomes `value` in the `format` block:
+
+```ruby{3-6}
+# app/avo/scopes/active.rb
+class Avo::Scopes::Active < Avo::Scopes::BaseScope
+  self.counter = {
+    loading: :lazy,
+    count: -> { query.active.count }
+  }
+end
+```
+
+</Option>
+
+<Option name="`counter.visible`" headingSize="4">
+
+A boolean or proc that shows the badge only in some cases. When it evaluates falsy, the count is hidden — the scope tab itself still shows (use the scope's own [`visible`](#visible) option to hide the tab):
+
+```ruby{5}
+# app/avo/scopes/active.rb
+class Avo::Scopes::Active < Avo::Scopes::BaseScope
+  self.counter = {
+    loading: :lazy,
+    visible: -> { current_user.admin? }
+  }
+end
+```
+
+</Option>
+
+<Option name="`counter.format`" headingSize="4">
+
+By default the count is rendered with `number_to_delimited` (e.g. `1,234`). A `format` block renders it however you like. It runs in the execution context — the count is available as `value` (the result of your `count` block, or the computed count when you don't set one), alongside `query`, `resource`, and `scope` — and can return any value (coerced to a string):
+
+```ruby{5}
+# app/avo/scopes/active.rb
+class Avo::Scopes::Active < Avo::Scopes::BaseScope
+  self.counter = {
+    loading: :lazy,
+    format: -> { "#{value} #{resource.name.pluralize.downcase}" }
+  }
+end
+```
+
+The `format` block can return plain text, so it also works as a text-only badge — it renders even when the scope has no numeric count. If your `format` block raises, Avo falls back to the default delimited format, so a bad formatter never breaks the page.
+
+</Option>
+
+</Option>
+
 ## Full example
 
 ```ruby
 # app/avo/scopes/even_id.rb
 class Avo::Scopes::EvenId < Avo::Scopes::BaseScope
-  # Please see the performance note above if you're using `scoped_query`
-  self.name = -> { "Even (#{scoped_query.count})" }
+  self.name = "Even"
 
   # This will compute the description based on the resource name
   self.description = -> {
@@ -219,5 +316,8 @@ class Avo::Scopes::EvenId < Avo::Scopes::BaseScope
 
   # Only show this scope to admins
   self.visible = -> { current_user.admin? }
+
+  # Show a record count badge, loaded lazily so it won't slow down the page
+  self.counter = :lazy
 end
 ```


### PR DESCRIPTION
Documents the `counter` scope option (from the avo-scopes scope-counters work).

## What's in here

- New **`counter`** reference option in `4.0/scopes.md`, with nested sub-options so each shows in the **On this page** outline (outline widened to `[2, 4]`):
  - `counter.loading` — `:eager` / `:lazy` / `:hover` (`:hover` currently loads like `:lazy`, deferred after paint)
  - `counter.count` — custom count value; can return any value, becomes `value` in `format`
  - `counter.visible` — bool/proc to conditionally show the badge
  - `counter.format` — runs in the execution context with the count as `value`; renders regular text too
- A `:::tip` in the `name` option pointing to `counter` instead of the manual `scoped_query.count` trick
- Updated the **display-scope-record-count** guide to recommend the built-in counter, keeping the manual recipe as the escape hatch

## Notes

- Verified with a local `vitepress build` — the counter keys render as `<h4>` anchors and appear in the outline.
- Pairs with the code in avo-scopes (`feat/scope-counters`) and the core UI changes in avo-hq/avo (`feat/scope-counter-badge`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only except for DocSearch defaulting unversioned pages to v4.0, which is a small UX change with no security or data impact.
> 
> **Overview**
> Documents Avo’s built-in **`counter`** scope option and steers readers away from counting records inside **`name`**.
> 
> **Scopes reference (`4.0/scopes.md`)** adds a full **`counter`** section (outline depth widened to `[2, 4]` so nested `counter.*` options appear in “On this page”), covering eager/lazy/hover loading, custom **`count`**, conditional **`visible`**, and **`format`** (with fallback on errors). The **`name`** option gets a tip pointing to **`counter`**; the full example uses **`self.counter = :lazy`** instead of **`scoped_query.count`** in the label. Minor markup fixes close several `<Option>` blocks correctly.
> 
> **Display scope record count** guide now recommends **`counter`** (with lazy/hover) up front and keeps the manual **`scoped_query`** + HTML recipe as an escape hatch.
> 
> **DocSearch (`config.js`)** changes behavior on unversioned routes (home, `/team`): Algolia requests now default to **`version:4.0`** instead of searching all versions, and the search modal footer shows “Searching **v4** docs” instead of hiding the version note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a513b4c2d4ae6df23ef86d27985b140abbbdb2ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->