### PR TITLE
docs(scopes): document scope counter option

### DIFF
--- a/docs/4.0/scopes.md
+++ b/docs/4.0/scopes.md
@@ -265,7 +265,7 @@ end
 
 <Option name="`counter.visible`" headingSize="4">
 
-A boolean or proc that shows the badge only in some cases. When it evaluates falsy, the count is hidden — the scope tab itself still shows (use the scope's own [`visible`](#visible) option to hide the tab):
+A boolean or proc that shows the badge only in some cases. When it evaluates falsy, the count is hidden — the scope tab itself still shows (use the scope's own [`visible`](#visible) option to hide the tab). On nested association indexes, the proc receives `parent_record` and `parent_resource` the same way the scope's [`visible`](#visible) option does:
 
 ```ruby{5}
 # app/avo/scopes/active.rb

--- a/docs/4.0/scopes.md
+++ b/docs/4.0/scopes.md
@@ -281,7 +281,7 @@ end
 
 <Option name="`counter.format`" headingSize="4">
 
-By default the count is rendered with `number_to_delimited` (e.g. `1,234`). A `format` block renders it however you like. It runs in the execution context — the count is available as `value` (the result of your `count` block, or the computed count when you don't set one), alongside `query`, `resource`, and `scope` — and can return any value (coerced to a string):
+By default the count is rendered with `number_to_delimited` (e.g. `1,234`). A `format` block renders it however you like. It runs in the execution context — the count is available as `value` (the result of your `count` block, or the computed count when you don't set one), alongside `query`, `resource`, and `scope`, where `query` is the same unfiltered base query used by `counter.count` — and can return any value (coerced to a string):
 
 ```ruby{5}
 # app/avo/scopes/active.rb


### PR DESCRIPTION
## What

Documents the scope `counter` option in `docs/4.0/scopes.md`:

- Loading modes (`:eager`, `:lazy`, `:hover` — `:hover` now defers like `:lazy`, after paint)
- `count`, `visible`, and `format` options
- Clarifies that in `counter.format`, `query` is the same unfiltered base query used by `counter.count`

## Notes

Search default bumped to 4.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to scope counter option descriptions; no runtime or API behavior changes.
> 
> **Overview**
> Refines the **scope `counter`** docs in `docs/4.0/scopes.md` with two behavior notes.
> 
> For **`counter.visible`**, it now states that on nested association indexes the visibility proc gets **`parent_record`** and **`parent_resource`**, matching the scope-level [`visible`](#visible) option.
> 
> For **`counter.format`**, it now states that **`query`** in the format block is the same **unfiltered base query** used by **`counter.count`**, so authors know what `query` represents when customizing the badge text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9593874ecf820fbdf9483ee2fb07cdaa4912cc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->