### PR TITLE
docs: dashboard table, list, and HTML cards

### DIFF
--- a/brainstorms/2026-07-20-dashboard-table-card-requirements.md
+++ b/brainstorms/2026-07-20-dashboard-table-card-requirements.md
@@ -1,0 +1,98 @@
+---
+date: 2026-07-20
+topic: dashboard-table-card
+---
+
+# Dashboard Table Card
+
+## Problem Frame
+
+Avo dashboards currently offer three card types: metric, chartkick, and partial. There is no declarative way to show tabular or list data ("latest signups", "top products", "failed jobs") — today users must hand-write a partial card. A `TableCard` gives them a data-in, table-out card that looks like Avo's resource index table but is not tied to a resource.
+
+The same card covers list use cases: a table with one column and no header row is a list. No separate ListCard.
+
+## Requirements
+
+**Card definition API**
+
+- R1. New `Avo::Cards::TableCard < Avo::Cards::BaseCard`, defined the same way as existing cards (class in `app/avo/cards/`, registered via `card` in a dashboard or resource).
+- R2. Column headers are declared with `self.headers = ["Name", "Email", ...]`. Headers are optional — omitting them renders no `thead` (the list look). Like other card attributes, `headers` resolves through `ExecutionContext` (accepts an array or a block), so translated or dynamic headers work per-request.
+- R3. Data comes from the existing `query` / `result(data)` pattern (matching `BaseCard#result(data)`). `data` is an array of row arrays; each row array holds cells positionally matching `headers`. Named `data`, not "rows", to avoid colliding with the existing `rows` grid-height attribute.
+- R4. All `BaseCard` behavior works unchanged and for free: `label`, `description`, `discreet_description`, `cols`/`rows`, `ranges`/`initial_range`, `refresh_every`, `visible`, arguments. Known change surface: `Avo::Cards::BaseCard#type` and the dispatch in `Avo::Cards::CardComponent` (body branch and the range-select type gate) hardcode `:metric`/`:chartkick`/`:partial` and must gain a `:table` branch — everything else is inherited for free.
+
+**Cell types**
+
+- R5. A plain value cell renders as escaped text (`u.email`, numbers, dates via `to_s`).
+- R6. Link cell: `{text:, url:, target: (optional)}` renders an anchor.
+- R7. Image cell: `{image:, alt: (optional), size: (optional)}` renders an image/avatar thumbnail.
+- R8. Badge cell: `{badge:, color:}` reuses Avo's existing badge styling.
+- R9. Cell partial escape hatch: `{partial:, locals: (optional)}` renders any ERB partial inside the cell — the path for arbitrary components/styled elements without growing the cell vocabulary.
+- R10. All cell text is HTML-escaped by default; raw HTML only enters through the partial cell.
+- R16. Record cell: `{record: user}` takes an ActiveRecord object, resolves its Avo resource, and renders a link with the record's title to its show page — the flagship "latest signups" case needs no manual URL building.
+
+**Rendering**
+
+- R11. The card renders through the existing `Avo::Cards::CardComponent` → `Avo::UI::CardComponent` pipeline: when `label`/`description` are present, the normal `card__header` renders (keeping range select, refresh, dev editor link); the table renders below it in the resource-index style (`thead` styled like the index table header, `tbody` as `card__body`). Both the card header and the `thead` are independently optional. This requires extending `BaseCard#type` and `gems/avo-dashboards/app/components/avo/cards/card_component.html.erb` with a `:table` branch; `Avo::UI::CardComponent`'s slots are reusable as-is.
+
+```
+┌─ card ────────────────────────┐
+│ Latest signups        [range] │  ← card__header (optional)
+│ Newest users this week        │
+├───────────────────────────────┤
+│ NAME      EMAIL        PLAN   │  ← thead (optional)
+├───────────────────────────────┤
+│ Jane      j@x.com      Pro    │  ← card__body rows
+│ Omar      o@y.com      Free   │
+└───────────────────────────────┘
+```
+
+- R12. Works with a single row or many. The card's `rows` grid setting acts as a height cap for the table card (today `card_classes` only emits min-heights): content past the cap scrolls vertically inside the card body, and the scroll region is keyboard-focusable (`tabindex="0"`). Wide content horizontally scrolls with the same `overflow-auto` treatment as the index table's `card__wrapper`.
+- R13. Empty result renders a subtle translated empty-state message (e.g. "No records found"), not a bare empty card.
+- R17. When `ranges` are declared, the `card__header` renders even without a `label`/`description`, so the range select (which lives in the header) is never silently lost.
+- R18. Accessibility: the table takes its accessible name from the card label when present (caption/aria-label); header-less mode is presentational and documented as such.
+
+**Docs & examples**
+
+- R14. Example TableCards in the avo-dashboards dummy app: a full table (headers, link/badge/record cells) and a header-less single-column list — the latter validates the "one card covers lists" premise before the API freezes.
+- R15. Dashboards docs page in `docs/4.0/` gets a Table card section (headers, cell types, escape hatch), including guidance that the card is for top-N data — cap row counts in the query (`limit`); there is no pagination.
+
+## Success Criteria
+
+- A linked, badged "latest signups" table is expressible in ~15 lines of card class with zero ERB.
+- The card reuses the resource index table's visual treatment (header styling, row borders, radii) minus interactive affordances — no row hover background or cursor-pointer, since rows are not clickable.
+- A one-column, header-less card reads as a clean list — no ListCard needed.
+
+## Scope Boundaries
+
+- Not a resource table: no sorting, pagination, row selection, row controls, or per-row policies.
+- No separate ListCard.
+- No column DSL / block-based cell formatting — the data-driven hash API plus the partial escape hatch covers it. Revisit only if real usage demands it.
+- Whole-card custom rendering remains `PartialCard`'s job.
+- No bespoke in-card error state: a failing `query` behaves the same as it does in existing card types.
+
+## Key Decisions
+
+- **One TableCard, no ListCard**: a single-column, header-less table is a list; one concept to build and document.
+- **Data-driven cells over column DSL**: matches the existing MetricCard/ChartkickCard "query returns data" pattern; keeps HTML out of card classes; smaller API surface.
+- **Cell vocabulary**: text, link, image, badge, plus per-cell partial as the universal escape hatch.
+- **Header marriage**: stack `card__header` above the table's `thead`, each optional — `Avo::UI::CardComponent` already supports both paths, so no new layout concepts.
+- **Tall tables cap and scroll**: the `rows` grid setting becomes a max-height for this card type; overflow scrolls inside the body. Chosen over letting the card grow unboundedly and distort the grid row.
+- **Wide content horizontal-scrolls**: same treatment as the resource index table, keeping visual/behavioral parity with it rather than truncating.
+- **`{record:}` cell included**: the motivating use cases are resource-backed records; linking to them must be zero-boilerplate.
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R2][Technical] Whether headers need a hash form (`{label:, align:, width:}`) for alignment/width control, or plain strings suffice for v1.
+- [Affects R11][Technical] Exact CSS reuse: whether the index table's `thead`/`tbody` classes can be shared directly or the table card needs its own BEM block in the card stylesheet.
+- [Affects R8][Technical] Which existing badge component/classes to reuse from avo core (likely `Avo::UI::BadgeComponent` — confirm its color/style vocabulary and whether the cell exposes `style:`).
+- [Affects R5–R9][Technical] Cell-hash detection rules: key precedence when multiple type keys appear, behavior when a plain data value is itself a Hash, and behavior for ragged rows (cell count ≠ header count).
+- [Affects R7][Technical] Image cell defaults: size, shape (circle avatar vs rounded thumbnail), and crop (`object-cover`), with `size:` as a small enum rather than arbitrary pixels.
+- [Affects R9][Technical] Partial lookup context for cell partials: resolution against host app vs engine views, and which helpers/locals are available.
+- [Affects R12][Technical] The exact height-cap mechanism (max-height per `rows` value alongside the existing min-heights) and the scrollbar treatment (`mac-styled-scrollbar`).
+- [Affects R13][Product] Whether the empty-state message is customizable per card (e.g. "No signups this week") or global-only in v1.
+
+## Next Steps
+
+→ `/ce:plan` for structured implementation planning

--- a/docs/4.0/cards.md
+++ b/docs/4.0/cards.md
@@ -9,7 +9,7 @@ Cards are one way of quickly adding custom content for your users.
 
 Cards can be used on dashboards or resources, we'll refer to both of them as "parent" since they're hosting the cards.
 
-You can add three types of cards to your parent: `partial`, `metric`, and `chartkick`.
+You can add four types of cards to your parent: `partial`, `metric`, `chartkick`, and `table`.
 
 ## Base settings
 
@@ -412,6 +412,103 @@ end
 ```
 
 <Image src="/assets/img/4_0/cards/map.webp" dark-src="/assets/img/4_0/cards/map-dark.webp" width="1428" height="1056" alt="An Avo partial card embedding a Google Maps view of Manhattan, rendered flush to the card edges because the card header is hidden." />
+
+## Table card
+
+<VersionReq version="4.1" />
+
+Use a table card to show a list of things — latest sign-ups, top products, failed jobs — styled like Avo's index table but fed by any query. Declare the column headers, return the rows from `query`, and the card renders the whole table.
+
+```ruby
+# app/avo/cards/latest_users.rb
+class Avo::Cards::LatestUsers < Avo::Cards::TableCard
+  self.id = "latest_users"
+  self.label = "Latest users"
+  self.headers = ["User", "Email", "Status"]
+  self.cols = 2
+  self.rows = 2
+
+  def query
+    result User.order(created_at: :desc).limit(10).map { |user|
+      [
+        user,
+        {text: user.email, url: "mailto:#{user.email}"},
+        {badge: user.active? ? "Active" : "Inactive", color: :green}
+      ]
+    }
+  end
+end
+```
+
+`result` takes an array of rows, and each row is an array of cells matching the `headers` positionally.
+
+:::info
+Table cards are for top-N data — cap the row count in your query with `limit`. There is no pagination or sorting; if you need the full table experience, use a resource's index view instead.
+:::
+
+### Headers
+
+`headers` accepts an array of strings or a lambda, so translated or dynamic headers resolve on every render:
+
+```ruby
+self.headers = -> { [I18n.t("avo.name"), I18n.t("avo.email")] }
+```
+
+Omit `headers` entirely to render the card without a table header row — handy when the card is really a list:
+
+```ruby
+# app/avo/cards/active_users.rb
+class Avo::Cards::ActiveUsers < Avo::Cards::TableCard
+  self.id = "active_users"
+  self.label = "Active users"
+
+  def query
+    result User.active.order(:name).limit(5)
+  end
+end
+```
+
+Returning records directly (no arrays, no hashes) renders each one as a single linked cell — the quickest way to get a list of records.
+
+### Cell types
+
+A cell can be a plain value or a hash that picks a richer rendering:
+
+| Cell | Renders |
+|------|---------|
+| `"text"`, `42`, any value | Escaped text (`to_s`) |
+| `{text:, url:, target: (optional)}` | A link |
+| `{record: user}` | A link to the record's Avo page, labeled with the record's title |
+| `{badge: "Active", color: :green, style: (optional)}` | A badge (any color supported by Avo's badge component; invalid colors fall back to neutral) |
+| `{image:, alt: (optional), size: (optional)}` | A round thumbnail; `size` accepts `:xs`, `:sm` (default), or `:md` |
+| `{partial: "avo/cards/cell", locals: {…}}` | Any partial — the escape hatch for custom content |
+
+A few things to know:
+
+- Cell text is always HTML-escaped. Raw HTML only enters through the `partial` cell.
+- `url:` and `image:` accept `http`, `https`, `mailto`, and relative URLs; anything else (like `javascript:`) renders as plain text.
+- The `record:` cell needs an Avo resource registered for the record's model; without one, the cell renders an unlinked title (and raises a descriptive error in development).
+- Cell partials receive your `locals` plus the `card`. Don't build the partial path from row data.
+
+### Empty state
+
+When the query returns no rows the card shows a translated "No record found" message. Override it per card:
+
+```ruby
+self.empty_message = "No sign-ups this week"
+# or
+self.empty_message = -> { I18n.t("cards.no_signups") }
+```
+
+### Ranges and refreshing
+
+Table cards support the same `ranges`, `initial_range`, and `refresh_every` settings as every other card. The selected range is available as `range` inside `query` — using it as the query's `limit` is a common pattern.
+
+:::warning
+`refresh_every` reloads the whole card, which resets the scroll position of a tall table. Prefer it on short tables.
+:::
+
+The card's `rows` setting also caps the table's height — rows past the cap scroll inside the card.
 
 ## Cards visibility
 

--- a/docs/4.0/cards.md
+++ b/docs/4.0/cards.md
@@ -419,6 +419,8 @@ end
 
 When the content is simple enough that a dedicated partial file feels like overhead, use an HTML card and build the body straight from Ruby. Implement a `body` method — every view helper (`tag`, `safe_join`, `link_to`, `number_to_currency`, `render`, `main_app`, …) is available directly on the card, and the return value can take three shapes.
 
+This is a great place for your LLM to take over and spit out a version of HTML.
+
 ### Inline ERB string
 
 Return a plain string and it's compiled as an inline ERB template. The template has access to all view helpers plus a `card` local.

--- a/docs/4.0/cards.md
+++ b/docs/4.0/cards.md
@@ -9,7 +9,7 @@ Cards are one way of quickly adding custom content for your users.
 
 Cards can be used on dashboards or resources, we'll refer to both of them as "parent" since they're hosting the cards.
 
-You can add five types of cards to your parent: `partial`, `metric`, `chartkick`, `table`, and `list`.
+You can add six types of cards to your parent: `partial`, `html`, `metric`, `chartkick`, `table`, and `list`.
 
 ## Base settings
 
@@ -413,79 +413,153 @@ end
 
 <Image src="/assets/img/4_0/cards/map.webp" dark-src="/assets/img/4_0/cards/map-dark.webp" width="1428" height="1056" alt="An Avo partial card embedding a Google Maps view of Manhattan, rendered flush to the card edges because the card header is hidden." />
 
+## HTML card
+
+<VersionReq version="4.1" />
+
+When the content is simple enough that a dedicated partial file feels like overhead, use an HTML card and build the body straight from Ruby. Implement a `body` method — every view helper (`tag`, `safe_join`, `link_to`, `number_to_currency`, `render`, `main_app`, …) is available directly on the card, and the return value can take three shapes.
+
+### Inline ERB string
+
+Return a plain string and it's compiled as an inline ERB template. The template has access to all view helpers plus a `card` local.
+
+```ruby{6-17}
+# app/avo/cards/newest_users.rb
+class Avo::Cards::NewestUsers < Avo::Cards::HtmlCard
+  self.id = "newest_users"
+  self.label = "Newest users"
+
+  def body
+    <<~ERB
+      <ul class="divide-y divide-neutral-100">
+        <% User.order(created_at: :desc).limit(5).each do |user| %>
+          <li class="flex justify-between gap-2 px-4 py-2">
+            <%= link_to user.name, main_app.user_path(user) %>
+            <span class="text-content-secondary"><%= user.email %></span>
+          </li>
+        <% end %>
+      </ul>
+    ERB
+  end
+end
+```
+
+For passing data in explicitly, call `render inline:` yourself with `locals:` — the result renders the same way:
+
+```ruby
+def body
+  render inline: "<strong><%= count %></strong> signups", locals: {count: User.count}
+end
+```
+
+### Tag builder
+
+Return tag builder output:
+
+```ruby
+def body
+  tag.div class: "px-4 py-2" do
+    safe_join([
+      tag.strong(number_to_currency(149.99)),
+      tag.span("Total raised", class: "text-content-secondary")
+    ])
+  end
+end
+```
+
+### Renderables
+
+Return anything `render` accepts — a View Component instance, a `{partial:}` hash — and the card renders it:
+
+```ruby
+def body
+  MyStatsComponent.new(user: current_user)
+end
+```
+
+```ruby
+def body
+  {partial: "avo/cards/my_stats", locals: {user: current_user}}
+end
+```
+
+:::warning
+Inline templates go through ActionView, so interpolated values (`<%= user.name %>`) are HTML-escaped as usual. However, never build the template string itself from user input — pass dynamic values through ERB tags or `locals:`, not Ruby string interpolation.
+:::
+
 ## Table card
 
 <VersionReq version="4.1" />
 
-Use a table card to show a list of things — latest sign-ups, top products, failed jobs — styled like Avo's index table but fed by any query. Declare the column headers, return the rows from `query`, and the card renders the whole table.
+Use a table card to show a list of things — latest sign-ups, top products, failed jobs — styled like Avo's index table but fed by any query. Declare the columns as `fields` — the same DSL you use on resources — and return records from `query`.
 
 ```ruby
 # app/avo/cards/latest_users.rb
 class Avo::Cards::LatestUsers < Avo::Cards::TableCard
   self.id = "latest_users"
   self.label = "Latest users"
-  self.headers = ["User", "Email", "Status"]
   self.cols = 2
   self.rows = 2
 
+  def fields
+    field :name, as: :text, name: "User", link_to_record: true
+    field :email, as: :text, protocol: :mailto
+    field :active, as: :badge, name: "Status", options: {success: "Active"} do
+      record.active? ? "Active" : "Inactive"
+    end
+  end
+
   def query
-    result User.order(created_at: :desc).limit(10).map { |user|
-      [
-        user,
-        {text: user.email, url: "mailto:#{user.email}"},
-        {badge: user.active? ? "Active" : "Inactive", color: :green}
-      ]
-    }
+    result User.order(created_at: :desc).limit(10)
   end
 end
 ```
 
-`result` takes an array of rows, and each row is an array of cells matching the `headers` positionally.
+Each record from `result` becomes one row, and each field becomes one cell. Cells render through the same components as the resource <Index /> views, so every field type and option — computed blocks, `format_using`, `link_to_record`, badge `options:`, and the rest — behaves exactly like it does on an index table.
 
 :::info
+The records you return must have an Avo resource registered for their model — the card resolves and renders fields through it.
+
 Table cards are for top-N data — cap the row count in your query with `limit`. There is no pagination or sorting; if you need the full table experience, use a resource's index view instead.
 :::
 
 ### Headers
 
-`headers` accepts an array of strings or a lambda, so translated or dynamic headers resolve on every render:
+Column headers derive from the field names. Pass `name:` to override one:
 
 ```ruby
-self.headers = -> { [I18n.t("avo.name"), I18n.t("avo.email")] }
-```
-
-When the headers come from the same place as the data, declare them inside `query` — it mirrors `result` and wins over the class-level declaration:
-
-```ruby
-def query
-  report = FetchReport.call(range:)
-
-  headers report.column_names
-  result report.rows
-end
+field :created_at, as: :date, name: "Joined"
 ```
 
 If you don't need column headers at all, you probably want the [list card](#list-card) instead.
 
-### Cell types
+### Row links
 
-A cell can be a plain value or a hash that picks a richer rendering:
+Set `row_url` to make every row a link. The block runs per row with `record` in scope:
 
-| Cell | Renders |
-|------|---------|
-| `"text"`, `42`, any value | Escaped text (`to_s`) |
-| `{text:, url:, target: (optional)}` | A link |
-| `{record: user}` | A link to the record's Avo page, labeled with the record's title |
-| `{badge: "Active", color: :green, style: (optional)}` | A badge (any color supported by Avo's badge component; invalid colors fall back to neutral) |
-| `{image:, alt: (optional), size: (optional)}` | A round thumbnail; `size` accepts `:xs`, `:sm` (default), or `:md` |
-| `{partial: "avo/cards/cell", locals: {…}}` | Any partial — the escape hatch for custom content |
+```ruby
+self.row_url = -> { record_path(record) }
+```
 
-A few things to know:
+For a new tab or a tooltip, return a hash instead — the same semantics as [discreet information](resources#self_discreet_information):
 
-- Cell text is always HTML-escaped. Raw HTML only enters through the `partial` cell.
-- `url:` and `image:` accept `http`, `https`, `mailto`, and relative URLs; anything else (like `javascript:`) renders as plain text.
-- The `record:` cell needs an Avo resource registered for the record's model; without one, the cell renders an unlinked title (and raises a descriptive error in development).
-- Cell partials receive your `locals` plus the `card`. Don't build the partial path from row data.
+```ruby
+self.row_url = -> {
+  {url: record_path(record), target: :_blank, tooltip: "View #{record.name}"}
+}
+```
+
+- Each hash value may itself be a block receiving `record`.
+- `url` accepts `http`, `https`, `mailto`, and relative URLs; anything else (like `javascript:`) is ignored.
+- List card rows render a real anchor stretched over the row, so middle-click, copy-link, and no-JS navigation work. Table rows navigate through the same JavaScript as `click_row_to_view_record` on index tables — a `<tr>` can't be wrapped in an anchor. Either way, links inside the row (like a `mailto:` cell) still win over the row link.
+
+### Density
+
+Rows use the global [`config.density`](customization#density) unless the card overrides it:
+
+```ruby
+self.density = :tight # :tight, :normal, :relaxed
+```
 
 ### Empty state
 
@@ -511,13 +585,20 @@ The card's `rows` setting also caps the table's height — rows past the cap scr
 
 <VersionReq version="4.1" />
 
-Use a list card whenever you want to show a list of things without table semantics — it renders a real `<ul>`, not a `<table>`. Each item from `result` becomes one row.
+Use a list card whenever you want to show a list of things without table semantics — it renders a real `<ul>`, not a `<table>`, and there are no column headers. The first field is each row's primary content and every other field trails at the end edge — great for badges, booleans, or timestamps.
 
 ```ruby
 # app/avo/cards/active_users.rb
 class Avo::Cards::ActiveUsers < Avo::Cards::ListCard
   self.id = "active_users"
   self.label = "Active users"
+  self.row_url = -> { record_path(record) }
+
+  def fields
+    field :name, as: :text
+    field :email, as: :text
+    field :active, as: :boolean
+  end
 
   def query
     result User.active.order(:name).limit(5)
@@ -525,17 +606,7 @@ class Avo::Cards::ActiveUsers < Avo::Cards::ListCard
 end
 ```
 
-Returning records directly renders each one as a linked row. For richer rows, return an array per item: the first cell is the primary content and every other cell trails at the end edge — great for badges or timestamps:
-
-```ruby
-def query
-  result User.active.limit(5).map { |user|
-    [user, {badge: user.plan, color: :green}]
-  }
-end
-```
-
-List cells speak the same vocabulary as [table cells](#cell-types), and the empty state, `empty_message`, `ranges`, and height behavior work the same way as the table card.
+Fields, [row links](#row-links), [density](#density), the empty state, `empty_message`, `ranges`, and the height cap all work the same way as on the [table card](#table-card).
 
 ## Cards visibility
 

--- a/docs/4.0/cards.md
+++ b/docs/4.0/cards.md
@@ -454,6 +454,17 @@ Table cards are for top-N data — cap the row count in your query with `limit`.
 self.headers = -> { [I18n.t("avo.name"), I18n.t("avo.email")] }
 ```
 
+When the headers come from the same place as the data, declare them inside `query` — it mirrors `result` and wins over the class-level declaration:
+
+```ruby
+def query
+  report = FetchReport.call(range:)
+
+  headers report.column_names
+  result report.rows
+end
+```
+
 Omit `headers` entirely to render the card without a table header row — handy when the card is really a list:
 
 ```ruby

--- a/docs/4.0/cards.md
+++ b/docs/4.0/cards.md
@@ -9,7 +9,7 @@ Cards are one way of quickly adding custom content for your users.
 
 Cards can be used on dashboards or resources, we'll refer to both of them as "parent" since they're hosting the cards.
 
-You can add four types of cards to your parent: `partial`, `metric`, `chartkick`, and `table`.
+You can add five types of cards to your parent: `partial`, `metric`, `chartkick`, `table`, and `list`.
 
 ## Base settings
 
@@ -465,21 +465,7 @@ def query
 end
 ```
 
-Omit `headers` entirely to render the card without a table header row — handy when the card is really a list:
-
-```ruby
-# app/avo/cards/active_users.rb
-class Avo::Cards::ActiveUsers < Avo::Cards::TableCard
-  self.id = "active_users"
-  self.label = "Active users"
-
-  def query
-    result User.active.order(:name).limit(5)
-  end
-end
-```
-
-Returning records directly (no arrays, no hashes) renders each one as a single linked cell — the quickest way to get a list of records.
+If you don't need column headers at all, you probably want the [list card](#list-card) instead.
 
 ### Cell types
 
@@ -519,7 +505,37 @@ Table cards support the same `ranges`, `initial_range`, and `refresh_every` sett
 `refresh_every` reloads the whole card, which resets the scroll position of a tall table. Prefer it on short tables.
 :::
 
-The card's `rows` setting also caps the table's height — rows past the cap scroll inside the card.
+The card's `rows` setting also caps the table's height — rows past the cap scroll inside the card, with the column headers staying pinned.
+
+## List card
+
+<VersionReq version="4.1" />
+
+Use a list card whenever you want to show a list of things without table semantics — it renders a real `<ul>`, not a `<table>`. Each item from `result` becomes one row.
+
+```ruby
+# app/avo/cards/active_users.rb
+class Avo::Cards::ActiveUsers < Avo::Cards::ListCard
+  self.id = "active_users"
+  self.label = "Active users"
+
+  def query
+    result User.active.order(:name).limit(5)
+  end
+end
+```
+
+Returning records directly renders each one as a linked row. For richer rows, return an array per item: the first cell is the primary content and every other cell trails at the end edge — great for badges or timestamps:
+
+```ruby
+def query
+  result User.active.limit(5).map { |user|
+    [user, {badge: user.plan, color: :green}]
+  }
+end
+```
+
+List cells speak the same vocabulary as [table cells](#cell-types), and the empty state, `empty_message`, `ranges`, and height behavior work the same way as the table card.
 
 ## Cards visibility
 

--- a/docs/4.0/customization.md
+++ b/docs/4.0/customization.md
@@ -636,6 +636,27 @@ end
 <Image src="/assets/img/4_0/customization/click-row-to-view-record.webm" dark-src="/assets/img/4_0/customization/click-row-to-view-record-dark.webm" width="1170" height="528" alt="An Avo resource index where a row name cell is highlighted, clicked, and navigates to the record show view with panel and card DSL layout." />
 </Option>
 
+<Option name="`density`">
+
+Controls how much vertical space rows take up in <Index /> tables and in the dashboard table and list cards. Three options are available: `:tight`, `:normal`, and `:relaxed`.
+
+```ruby
+# config/initializers/avo.rb
+Avo.configure do |config|
+  config.density = :normal # :tight, :normal, :relaxed
+end
+```
+
+Dashboard table and list cards can override the global setting per card:
+
+```ruby
+class Avo::Cards::ExampleList < Avo::Cards::ListCard
+  self.density = :tight
+end
+```
+
+</Option>
+
 ## Associations
 
 <Option name="`associations`">

--- a/plans/2026-07-20-001-feat-dashboard-table-card-plan.md
+++ b/plans/2026-07-20-001-feat-dashboard-table-card-plan.md
@@ -1,0 +1,252 @@
+---
+title: "feat: Dashboard Table Card"
+type: feat
+status: active
+date: 2026-07-20
+origin: docs/brainstorms/2026-07-20-dashboard-table-card-requirements.md
+---
+
+# feat: Dashboard Table Card
+
+## Overview
+
+Add `Avo::Cards::TableCard` to the avo-dashboards gem: a declarative data-in/table-out dashboard card styled like the resource index table but not tied to a resource. Users declare optional `headers`, return rows of cells from `query`/`result(data)`, and cells render as text, links, images, badges, record links, or arbitrary partials. All work lands in `gems/avo-dashboards`; avo core is only consumed (CSS classes, `Avo::UI::BadgeComponent`, resource helpers, existing i18n keys), not modified.
+
+## Problem Frame
+
+Dashboards offer metric, chartkick, and partial cards — there is no declarative way to show tabular or list data ("latest signups", "failed jobs") without hand-writing ERB. A single TableCard covers tables and lists (a one-column, header-less table is a list). See origin: `docs/brainstorms/2026-07-20-dashboard-table-card-requirements.md`.
+
+## Requirements Trace
+
+Carried from the origin doc (stable IDs):
+
+- R1 `Avo::Cards::TableCard < BaseCard`, registered like existing cards → Unit 1
+- R2 optional `headers`, ExecutionContext-resolved (array or block) → Units 1, 2
+- R3 `query`/`result(data)`, data = array of row arrays → Units 1, 2
+- R4 BaseCard behavior inherited; `#type` + `CardComponent` dispatch extended with `:table` → Unit 1
+- R5–R10, R16 cell vocabulary (text, link, image, badge, partial, record) with escaping → Unit 2
+- R11 renders via `CardComponent` → `Avo::UI::CardComponent`; header + thead independently optional → Units 1, 2
+- R12 `rows` acts as height cap with focusable vertical scroll; horizontal scroll like index table → Unit 3
+- R13 translated empty state → Unit 2
+- R17 `card__header` renders when `ranges` present even without label/description → Unit 1
+- R18 accessibility (accessible name from label, keyboard-focusable scroll region) → Units 2, 3
+- R14 dummy-app examples (full table + header-less list) → Unit 4
+- R15 docs page section incl. top-N/`limit` guidance → Unit 5
+
+## Scope Boundaries
+
+- Not a resource table: no sorting, pagination, row selection, row controls, or per-row policies.
+- No separate ListCard; no column DSL.
+- No bespoke in-card error state: a failing `query` behaves like existing card types.
+- No avo core code changes (CSS, components, helpers, locale keys are reused as-is).
+- Trust model: `query` output is developer-curated data — same trust level as PartialCard. No per-row authorization checks; URL scheme guarding (below) is the only hardening.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- Render path: `dashboards_controller#show` → `Avo::CardsComponent` (lazy `turbo_frame_tag` per card) → `Avo::Dashboards::CardsController#show` → `app/views/avo/dashboards/cards/show.html.erb` → `Avo::Cards::CardComponent`. `result_data` is populated by `CardComponent#init_card` calling `card.query` (`gems/avo-dashboards/app/components/avo/cards/card_component.rb`).
+- Change surfaces (verified): `BaseCard#type` (`gems/avo-dashboards/lib/avo/cards/base_card.rb:124-128`) hardcodes three types; `card_component.html.erb` branches its body on `card.type` (lines 44-52) and gates the range select on `card.type.in?([:metric, :chartkick, :partial])` (line 24); `display_header?` keys off label/description only.
+- Card class pattern: `lib/avo/cards/metric_card.rb` — `class_attribute`s + presenter methods resolved through `handle_execution_context` (base_card.rb:244-252). `headers`/`empty_message` follow the `label` pattern exactly (instance override or class attribute, procs handled, plain values passed through).
+- Index table visuals (avo core, reused not modified): `table.w-full.border-separate.border-spacing-0`; th classes `relative text-start px-2 py-2 whitespace-nowrap` + label `text-content-secondary tracking-tight leading-tight text-xs font-semibold` (`external/avo/app/views/avo/partials/_table_header.html.erb`); `tbody.card__body.table-row-group.rounded-lg`; `tr.table-row` (row borders/radii/hover CSS in `external/avo/app/assets/stylesheets/css/table.css` — pure CSS keyed on `.table-row`, no resource coupling); td classes `px-2 py-4 leading-none whitespace-nowrap text-content text-sm` (`external/avo/app/components/avo/index/field_wrapper_component.html.erb`); horizontal scroll via `card__wrapper mac-styled-scrollbar overflow-auto` (`external/avo/app/components/avo/view_types/table_component.html.erb`).
+- Badge: `Avo::UI::BadgeComponent` (`external/avo/app/components/avo/u_i/badge_component.rb`) — props `label`, `color` (22 valid colors, invalid falls back to `:neutral`), `style` (`:solid`/`:subtle`, default subtle), `icon`.
+- Record resolution: `helpers.record_title(record)` / `helpers.record_path(record)` (`external/avo/app/helpers/avo/resources_helper.rb:52-63`), backed by `Avo.resource_manager.get_resource_by_model_class`.
+- Empty state i18n: `avo.no_item_found` ("No record found") already exists in avo core locales (~20 languages); avo-dashboards ships no locale files of its own.
+- Height precedent: `BaseCard#card_classes` maps `rows` → literal `min-h-[Nrem] row-span-N` classes (written out so Tailwind doesn't purge them); ChartkickCard computes inner height as `rows * 144 - 40` px.
+- Dummy/spec conventions: examples at `gems/avo-dashboards/spec/dummy/app/avo/cards/example_*.rb` (`Avo::Cards::Example*`), registered in `spec/dummy/app/avo/dashboards/dashy.rb`; system specs at `spec/system/avo/*_spec.rb` (Capybara/Cuprite, `visit "/admin/..."`); run via `ws test avo-dashboards`.
+- Tailwind: avo-dashboards compiles its own utilities (`tailwind.config.js` content paths cover the gem's components/views); avo-core BEM classes (`.table-row`, `.card__body`) arrive via avo core's stylesheet at runtime.
+
+### Institutional Learnings
+
+- `docs/solutions/` contains a single, unrelated document (hotkeys). Transferable bits: use `around`-block config save/restore in specs if any global config is touched; follow the frozen-DEFAULTS config pattern if TableCard ever grows global config (it doesn't in v1).
+- Prior plan `docs/plans/2026-04-02-001-feat-hotkey-configuration-plan.md` establishes the plan format and R-number tracing used here.
+- Docs convention (affects Unit 5): the docs repo's own `AGENTS.md` (inside `docs/`) is the newer authority — guide + `<Option>`-style reference pages — and wins over the older workspace rule that says plain code blocks.
+
+### External References
+
+None needed — all patterns are local and verified.
+
+## Key Technical Decisions
+
+- **ViewComponent, not an ERB partial, for the table body**: cell dispatch is logic-heavy (type detection, escaping, fallbacks). Create `Avo::Cards::TableCardComponent` in avo-dashboards, rendered from the new `:table` branch. Metric/chartkick keep their partial style; this component follows the repo's component-development conventions. **No lookbook preview**: avo-dashboards has zero lookbook infrastructure (it exists only in avo core's dummy); the gem's dummy dashboard (port 3030) is the live preview. This is a deliberate, documented exception to the "always lookbook" rule.
+- **Cell dispatch precedence** (fixed, documented): for a `Hash` cell after `symbolize_keys` — `:partial` > `:record` > `:badge` > `:image` > `:url`/`:text` > fallback. `{text:}` without `url:` renders as plain text. An unrecognized hash renders as escaped `to_s`. Never raise in the production render path.
+- **Ergonomic coercions**: an ActiveRecord object as a cell is treated as `{record:}`; a non-array row is promoted to a one-cell row (so `result users` "just works" as a list); `result_data` is normalized with `Array(...)`+`to_a` (Relations work); `nil`/never-called `result` → empty state, matching MetricCard's "user must call result" contract.
+- **Record cell fallbacks**: `record: nil` renders an em-dash; a model with no registered Avo resource renders the escaped `to_s` title without a link (and raises a descriptive error in development only).
+- **URL scheme guard**: `url:` and `image:` values are rendered only with http/https/mailto/relative schemes (`javascript:` etc. render as plain text). Cell text is always escaped (R10); raw HTML only via the partial cell. Partial cell contract: standard ActionView lookup (host app first), locals = explicit `locals:` plus `card:` — never derive the partial path from row data.
+- **Range-select gate inverted**: change the gate in `card_component.html.erb` from the type allowlist to `card.ranges.present?` — fixes the class of bug for every future card type instead of growing the list.
+- **Header gate**: `display_header?` becomes `label || description || ranges.present?` (R17). Side effect (accepted, an improvement): existing label-less cards with `ranges` gain a header with the range select — previously the select was silently lost.
+- **Height cap**: a literal `rows` → `max-h` class map (mirroring `classes_for_rows`' anti-purge pattern) applied to the scroll region *inside* the card body (below the optional header), with `overflow-y-auto`, `mac-styled-scrollbar`, `tabindex="0"`, `aria-label` from the card label, and a `focus-visible` ring. The card-level `min-h` grid classes stay untouched.
+- **Full-bleed table**: the `:table` branch must NOT reuse the metric branch's `px-4 pb-4` wrapper — rows run edge to edge like the index table; horizontal overflow scrolls via the same `overflow-auto` treatment.
+- **Empty state**: default `t("avo.no_item_found")` (reuses existing translations in ~20 languages, zero core locale changes); per-card override via `self.empty_message` class attribute, ExecutionContext-resolved (resolves the deferred R13 question).
+- **Headers semantics**: `nil` and `[]` are equivalent (no thead); resolved per render (so block form gives per-locale translation); plain strings for v1 — no `{label:, align:, width:}` hash form (resolves the deferred R2 question; revisit on demand).
+- **`refresh_every` scroll reset accepted**: a frame reload snaps the scrolled body to top; documented ("avoid `refresh_every` on tall tables") rather than engineered around in v1.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Header hash form (align/width)? → No; plain strings/block for v1.
+- CSS reuse vs new BEM block? → Reuse avo core's `.table-row`, `card__body`, th/td utility classes directly; they are resource-agnostic. Only the height-cap classes are new, in avo-dashboards' own stylesheet/build.
+- Which badge component? → `Avo::UI::BadgeComponent`; cell exposes optional `style:`; invalid colors fall back to `:neutral` by component design.
+- Cell-hash detection rules, ragged rows? → Precedence table above; short rows pad with empty `td`s to header count, long rows render all cells.
+- Image cell defaults? → `size-8 rounded-full object-cover` avatar default; `size:` accepts `:xs`/`:sm`/`:md` enum.
+- Partial lookup context? → Standard ActionView resolution, explicit locals + `card:`.
+- Height-cap mechanism? → Literal `max-h` map on the inner scroll region (see decisions).
+- Empty state customizable? → Yes, `self.empty_message` per card; global default `avo.no_item_found`.
+
+### Deferred to Implementation
+
+- Exact `max-h` rem values per `rows` step: tune visually in the dummy app against the `min-h` grid values (8rem per row minus header/chrome).
+- Whether `.table-row` CSS renders pixel-perfect inside the dashboard card's `card__body` context or needs 1-2 local overrides: verify in browser, adjust in avo-dashboards' stylesheet only.
+- `em-dash` vs empty cell for nil record: pick whichever reads better in the dummy app.
+
+## Implementation Units
+
+- [ ] **Unit 1: TableCard class + pipeline dispatch**
+
+**Goal:** `Avo::Cards::TableCard` exists, is recognized by the card pipeline, and header/range gating works per R17.
+
+**Requirements:** R1, R2, R3, R4, R11, R17
+
+**Dependencies:** None
+
+**Files:**
+- Create: `gems/avo-dashboards/lib/avo/cards/table_card.rb`
+- Modify: `gems/avo-dashboards/lib/avo/cards/base_card.rb` (`#type` returns `:table`)
+- Modify: `gems/avo-dashboards/app/components/avo/cards/card_component.rb` + `.html.erb` (`:table` body branch; range gate → `card.ranges.present?`; `display_header?` → label/description/ranges)
+- Test: `gems/avo-dashboards/spec/system/avo/table_card_spec.rb` (created here, grows in later units)
+
+**Approach:**
+- TableCard mirrors `metric_card.rb`: `class_attribute :headers`, `class_attribute :empty_message`; reader methods resolving through `handle_execution_context` (accept instance override like `label` does).
+- The `:table` branch renders `Avo::Cards::TableCardComponent.new(card:)` (stub in this unit, built in Unit 2) with no padding wrapper.
+
+**Patterns to follow:** `lib/avo/cards/metric_card.rb`, `BaseCard#label` ExecutionContext pattern.
+
+**Test scenarios:**
+- Happy path: a registered TableCard on a dashboard renders a card frame with its label in `card__header`.
+- Happy path: `headers` as a block returns per-request values (e.g. interpolating an argument).
+- Edge case: card with `ranges` and no label/description still renders `card__header` containing the range select (R17).
+- Edge case: existing metric/chartkick/partial example cards still render and show their range selects (gate inversion regression check).
+
+**Verification:** dummy dashboard renders a stub table card without breaking any existing card type.
+
+- [ ] **Unit 2: TableCardComponent — cell dispatch and table markup**
+
+**Goal:** The full table renders: thead from headers, tbody rows from `result_data`, all six cell types, escaping, coercions, empty state, accessible name.
+
+**Requirements:** R2, R3, R5–R10, R13, R16, R18
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `gems/avo-dashboards/app/components/avo/cards/table_card_component.rb` + `.html.erb`
+- Test: `gems/avo-dashboards/spec/system/avo/table_card_spec.rb`
+
+**Approach:**
+- Markup mirrors the index table: `table.w-full.border-separate.border-spacing-0`, thead th classes from `_table_header.html.erb`, `tbody.card__body.table-row-group.rounded-lg`, `tr.table-row`, td classes from `field_wrapper_component`. `<caption class="sr-only">` from the card label when present.
+- Cell normalization in the component (not the card class): `Array(result_data)`, row promotion, AR-object coercion, `symbolize_keys`, precedence dispatch, ragged-row padding, URL scheme guard.
+- Badge cells render `Avo::UI::BadgeComponent`; record cells use `helpers.record_title`/`helpers.record_path`; image cells default `size-8 rounded-full object-cover`.
+- Empty/absent data renders the empty-state message (`empty_message` or `t("avo.no_item_found")`) centered in the body; thead still renders if headers are declared.
+
+**Test scenarios:**
+- Happy path: headers + rows of [record cell, plain text, badge cell] render a linked title, escaped text, and a badge with the right color class.
+- Happy path: header-less single-column card (`result users` — bare AR objects, non-array rows) renders a linked list with no thead.
+- Happy path: link cell renders anchor with text/url/target; image cell renders img with default avatar classes; partial cell renders a host-app partial receiving `locals` and `card`.
+- Edge case: `{text: "just text"}` (no url) renders plain text; unrecognized hash renders escaped `to_s`; ragged short row pads `td`s to header count.
+- Edge case: `query` never calls `result`, or `result(nil)` → empty state, no exception; `result(User.limit(3))` (Relation) works.
+- Edge case: `{record: nil}` renders placeholder; record of an unregistered model renders unlinked title (and raises in development).
+- Error path/security: cell text containing `<script>` is escaped; `url: "javascript:alert(1)"` renders as plain text, not an anchor.
+- Integration: changing the range select reloads the frame and re-runs `query` with the new range (rows change).
+
+**Verification:** all cell types visible and correct in the dummy dashboard; system spec green.
+
+- [ ] **Unit 3: Height cap, scrolling, and styling polish**
+
+**Goal:** Tall tables cap at the card's `rows` height and scroll; wide tables scroll horizontally; scroll region is keyboard-accessible.
+
+**Requirements:** R12, R18
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `gems/avo-dashboards/app/components/avo/cards/table_card_component.rb` + `.html.erb` (scroll wrapper)
+- Modify: `gems/avo-dashboards/app/assets/stylesheets/avo-dashboards/application.css` (only if `.table-row` needs local overrides or the focus ring needs a rule)
+- Test: `gems/avo-dashboards/spec/system/avo/table_card_spec.rb`
+
+**Approach:**
+- Literal `rows` → `max-h-[...]` class map (same anti-purge pattern as `card_classes`), on a wrapper div inside `card__body` with `overflow-auto mac-styled-scrollbar`, `tabindex="0"`, `aria-label` = card label, `focus-visible` ring. Values tuned to the `min-h` grid steps (deferred detail).
+- Confirm full-bleed layout (no metric padding) and that `discreet_description`'s corner icon doesn't overlap the scrollbar (add end padding if it does).
+
+**Test scenarios:**
+- Happy path: a 50-row card with `rows = 2` renders capped with a scrollable body (element has `overflow-auto` and bounded height); the dashboard grid row is not stretched.
+- Edge case: a 2-row card shows no scrollbar and does not reserve extra height.
+- Edge case: a very wide table scrolls horizontally inside the card without widening the page.
+
+**Verification:** visual check in dummy app at multiple `cols`/`rows` combos; keyboard focus reaches the scroll region.
+
+- [ ] **Unit 4: Dummy-app examples + full system coverage**
+
+**Goal:** Living examples that double as the feature's preview and regression net (R14) — including the header-less list that validates the "one card covers lists" premise.
+
+**Requirements:** R14
+
+**Dependencies:** Units 1–3
+
+**Files:**
+- Create: `gems/avo-dashboards/spec/dummy/app/avo/cards/example_table.rb` (headers; record/link/badge/image cells; `ranges`; `rows = 2` with enough data to scroll)
+- Create: `gems/avo-dashboards/spec/dummy/app/avo/cards/example_list.rb` (header-less, single-column, bare records)
+- Modify: `gems/avo-dashboards/spec/dummy/app/avo/dashboards/dashy.rb` (register both)
+- Test: `gems/avo-dashboards/spec/system/avo/table_card_spec.rb` (assertions target these examples)
+
+**Test scenarios:** covered by Units 1–3's scenarios running against these example cards; add one scenario asserting both example cards render on the same dashboard without id/frame collisions.
+
+**Verification:** `ws test avo-dashboards` green; both cards look right at `http://localhost:3030`.
+
+- [ ] **Unit 5: Documentation**
+
+**Goal:** Customers can discover and use TableCard from the docs (R15).
+
+**Requirements:** R15
+
+**Dependencies:** Units 1–4 (API frozen)
+
+**Files:**
+- Modify: the dashboards page under `docs/4.0/` (locate the existing cards section; add "Table card")
+- Modify: `docs/.vitepress/config.js` only if a new page is created (prefer extending the existing dashboards page)
+
+**Approach:** Follow the docs repo's own `AGENTS.md` conventions (guide + `<Option>` reference format — it supersedes the older workspace "plain code blocks" rule). Cover: defining a TableCard, headers (string + block form), every cell type with a copy-pasteable example, `empty_message`, the top-N/`limit` guidance, the `refresh_every`-on-tall-tables caveat, and the trust model note (query output is developer-curated; no per-row authorization).
+
+**Test scenarios:** Test expectation: none — documentation-only unit. Verify with `npx vitepress build docs`.
+
+**Verification:** docs build clean; page renders with sidebar/outline intact.
+
+## System-Wide Impact
+
+- **Interaction graph:** `card_component.html.erb` is shared by all card types — the gate changes (range select, `display_header?`) affect metric/chartkick/partial cards. Only visible behavior change: label-less cards with `ranges` now show a header with the range select (previously silently lost — an improvement, but note it in the release notes).
+- **Error propagation:** unchanged — `query` exceptions bubble exactly as for existing cards (scope boundary). Render-path cell handling never raises in production; development gets a descriptive error only for unregistered record-cell models.
+- **State lifecycle risks:** `result_data` is a `class_attribute` (pre-existing pattern shared by all cards); table payloads are bigger than metric scalars but the mechanism is unchanged. `refresh_every` reload resets scroll position — accepted and documented.
+- **API surface parity:** resource-attached cards (`card` in a resource) get TableCard for free via the shared pipeline; verify once in the dummy User resource.
+- **Integration coverage:** range change → frame reload → re-query is covered by a system spec (the select controller mutates `src` before `reload()`; that ordering is load-bearing).
+- **Unchanged invariants:** avo core is untouched — no CSS, component, helper, or locale changes; `MetricCard`/`ChartkickCard`/`PartialCard` public APIs unchanged; the dashboard grid (`card_classes` min-heights, `cols`/`rows` spans) unchanged.
+- **Tailwind builds:** new utility classes used in avo-dashboards templates must be compiled by avo-dashboards' own Tailwind build (content paths already cover `app/components`) — the literal-class-map pattern keeps the `max-h` steps purge-safe.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `.table-row` CSS renders differently inside the dashboard card's `card__body` context than on the index page | Verify visually in the dummy app early (Unit 2); add minimal local overrides in avo-dashboards' stylesheet if needed — do not touch core CSS |
+| Height cap fights the grid's `min-h` classes (cap smaller than min height) | Tune `max-h` values against the `min-h` steps in Unit 3; cap applies to the inner scroll region, not the card |
+| Gate inversion changes behavior of third-party custom cards with `ranges` | Behavior change is strictly additive (select now appears); call out in changelog |
+| Cell-hash heuristics misfire on legitimate hash *data* | Documented precedence + escaped `to_s` fallback; users can always stringify explicitly |
+| `avo.no_item_found` wording ("No record found") slightly off for arbitrary tables | Per-card `empty_message` override is first-class; acceptable default |
+
+## Documentation / Operational Notes
+
+- Release: avo-dashboards patch/minor via `ws release minor -g avo-dashboards` (new feature → minor). No core avo release required.
+- Changelog note for the header/range-gate behavior change.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-07-20-dashboard-table-card-requirements.md](../brainstorms/2026-07-20-dashboard-table-card-requirements.md)
+- Related code: `gems/avo-dashboards/lib/avo/cards/base_card.rb`, `gems/avo-dashboards/app/components/avo/cards/card_component.html.erb`, `external/avo/app/components/avo/view_types/table_component.html.erb`, `external/avo/app/views/avo/partials/_table_header.html.erb`, `external/avo/app/assets/stylesheets/css/table.css`, `external/avo/app/components/avo/u_i/badge_component.rb`, `external/avo/app/helpers/avo/resources_helper.rb`
+- Prior plan (format reference): `docs/plans/2026-04-02-001-feat-hotkey-configuration-plan.md`


### PR DESCRIPTION
## Summary

Documents the new avo-dashboards card types and their options (avo-hq/workspace#52, core support in avo-hq/avo#4645).

- **Cards page** — the existing Table card / List card sections (written against an earlier draft API) now document the shipped API: cards declare `fields` with the resource DSL and `query` returns plain records; headers derive from field names (`name:` to override). New sections cover **Row links** (`row_url` as a URL or `{url:, target:, tooltip:}` hash with block values, plus the anchor-vs-JavaScript navigation note) and **Density** (`self.density` with `:tight` / `:normal` / `:relaxed`). Includes the earlier-drafted **HTML card** section (inline ERB string, tag builder, renderables) and bumps the card-type count.
- **Customization page** — new `density` option documenting `config.density` and the per-card override.

Built cleanly with `vitepress build`.

---

[![Compound Engineering v2.59.0](https://img.shields.io/badge/Compound_Engineering-v2.59.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Fable 5 via [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and planning-only changes with no runtime or auth impact.
> 
> **Overview**
> Documents **avo-dashboards** card types shipped in 4.1: **HTML**, **table**, and **list** cards, plus global **`density`**.
> 
> On **`docs/4.0/cards.md`**, the intro now lists six card types. New **HTML card** coverage explains `body` via inline ERB, tag builders, and renderables, with a security note on template strings. **Table** and **list** sections describe the **shipped** API: `fields` with the resource field DSL, `query` returning records (not row/cell hashes), headers from field `name:`, **`row_url`** (URL or hash with `target`/`tooltip`), **`density`**, **`empty_message`**, ranges/refresh, height cap via `rows`, and list-vs-table row navigation behavior.
> 
> **`docs/4.0/customization.md`** adds a **`config.density`** option for index tables and table/list cards, with per-card override.
> 
> Also adds internal **requirements**, **implementation plan**, and related planning artifacts (earlier single-`TableCard` design vs documented separate list card and fields-based API).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bd36c1b2daa83b40f19f60037e49ca53f518735. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->