### PR TITLE
docs(http-resources): document the debug console

### DIFF
--- a/docs/4.0/http-resources.md
+++ b/docs/4.0/http-resources.md
@@ -196,3 +196,38 @@ end
 ```
 
 This approach grants you complete control over how HTTP Resources interact with your external services, allowing seamless integration, even with APIs that have unconventional or highly specific requirements.
+
+## Debug console
+
+HTTP Resources ship with an interactive debug console for inspecting exactly what your resource sends and receives. Visit `<avo_root>/http-resource/debug` (e.g. `/avo/http-resource/debug`), pick a resource and an action (`index`, `show`, `count`, `create`, `update`, or `delete`), and fire the request.
+
+For each run you can inspect:
+
+- the sent URL, query params, and (masked) request headers
+- the raw response alongside the parsed result
+- the request timing
+- the output of your `parse_collection`, `parse_record`, and `parse_count` blocks
+
+Errors are surfaced inline per stage — a failed request and a failing `parse_*` block are reported separately — so a broken adapter never crashes the page.
+
+The console is gated behind the `avo-http_resource` license feature and Avo's developer/admin access, the same gate as Avo's own debug tools.
+
+:::warning
+The `create`, `update`, and `delete` actions hit your real external API. From the console they require an explicit confirmation before running.
+:::
+
+### Add it to the sidebar
+
+To surface the console as a tool in the sidebar's **Tools** section, add a sidebar item partial to your app at `app/views/avo/sidebar/items/_http_resource_debugger.html.erb`:
+
+```erb
+<%= render Avo::Sidebar::LinkComponent.new(
+  label: "HTTP debugger",
+  path: File.join(avo.root_path, "http-resource", "debug"),
+  icon: "tabler/outline/api"
+) %>
+```
+
+### JSON API
+
+The same diagnostics are available as JSON for scripting or agent use. `POST` to `<avo_root>/http-resource/debug/run.json` with the params `resource`, `probe_action`, `id`, `page`, `limit`, `query`, `body`, and `confirm`. Write actions (`create`, `update`, `delete`) require `confirm=1` since they hit the real external API.

--- a/docs/4.0/http-resources.md
+++ b/docs/4.0/http-resources.md
@@ -210,7 +210,7 @@ For each run you can inspect:
 
 Errors are surfaced inline per stage — a failed request and a failing `parse_*` block are reported separately — so a broken adapter never crashes the page.
 
-The console is gated behind the `avo-http_resource` license feature and Avo's developer/admin access, the same gate as Avo's own debug tools.
+The console is gated behind the `avo-http_resource` license feature and Avo's developer/admin access, the same gate as Avo's own debug tools. On top of that, it only lists — and only runs against — resources the current user is authorized to access, honoring each resource's [authorization policy](authorization). If you use Avo's authorization, a user can never reach a resource from the console that their policy would otherwise hide; if you don't configure authorization, only the developer/admin gate applies.
 
 :::warning
 The `create`, `update`, and `delete` actions hit your real external API. From the console they require an explicit confirmation before running.


### PR DESCRIPTION
## What

Documents the interactive HTTP resource debug console shipped in [avo-hq/workspace#59](https://github.com/avo-hq/workspace/pull/59) (avo-http_resource 4.1.0).

Adds a **Debug console** section to `4.0/http-resources.md` covering:

- the debugger at `<avo_root>/http-resource/debug` — actions, what you can inspect, per-stage error reporting, and the license/developer-access gate
- a warning that `create`/`update`/`delete` hit the real external API and need confirmation
- the opt-in sidebar partial (`_http_resource_debugger.html.erb`)
- the JSON API (`POST …/http-resource/debug/run.json`)

Guide-only (no `-api.md`) — the console has no real config surface, so a single section on the existing guide is the right home per the docs conventions.

## Verification

`npx vitepress build docs` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security behavior modifications.
> 
> **Overview**
> Adds a **Debug console** section to the HTTP Resources guide describing the interactive debugger at `<avo_root>/http-resource/debug`: supported probe actions, per-run diagnostics (URL, headers, timing, parse block output), staged error reporting, and access controls (license feature, developer/admin gate, and resource authorization policies).
> 
> Documents a warning that **create/update/delete** probes call the live external API and need confirmation, plus optional **sidebar** setup via `_http_resource_debugger.html.erb` and a **JSON** `POST …/http-resource/debug/run.json` endpoint for scripting (including `confirm=1` for writes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df842356d4b67fbbbc6647b4159b5ba1524ed52a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->