### PR TITLE
docs: document opt-in card body padding

### DIFF
--- a/docs/4.0/native-components/avo-panel-component.md
+++ b/docs/4.0/native-components/avo-panel-component.md
@@ -170,12 +170,17 @@ the panel (no card wrapper).
 
 <Option name="`card`">
 
-Wraps the content in a card automatically. Use this instead of `body` when you want
-the content to sit inside a bordered, padded card.
+Wraps the content in a bordered card automatically. Use this instead of `body` when
+you want the content to sit inside a distinct card surface.
+
+The card body ships **unpadded** so wide content (tables, horizontal scrollers) can
+sit flush to the card edge. Opt into the standard body padding with `padded: true`
+(or the `card--padded` CSS modifier) when your content is free-form — forms, prose,
+custom tools:
 
 ```erb{2-4}
 <%= render Avo::UI::PanelComponent.new do |panel| %>
-  <% panel.with_card do %>
+  <% panel.with_card(padded: true) do %>
     Something here.
   <% end %>
 <% end %>


### PR DESCRIPTION
Documents the card padding change from [avo-hq/avo#4650](https://github.com/avo-hq/avo/pull/4650).

## What changed

The panel's `card` slot previously described the card as "bordered, padded". Card bodies now ship **unpadded** by default so wide content (tables, horizontal scrollers) sits flush to the edge. Padding is now an explicit opt-in:

```erb
<% panel.with_card(padded: true) do %>
  ...
<% end %>
```

(or the `card--padded` CSS modifier).

## Page

- `4.0/native-components/avo-panel-component.md` — updated the `card` `<Option>` description + example.

Pairs with avo-hq/avo#4650; merge after that ships.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> Updates the **`card` slot** docs on `avo-panel-component.md` to match Avo 4.0 behavior from avo-hq/avo#4650: the slot still wraps content in a bordered card, but the card body is **unpadded by default** so tables and horizontal scrollers can sit flush to the edge.
> 
> The **`card` `<Option>`** now explains opting into standard padding with **`padded: true`** or the **`card--padded`** modifier, and the example uses `panel.with_card(padded: true)` instead of bare `with_card`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a264ce1a687571964fd8369aed6da1e6a08cf72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->