### PR TITLE
docs(theming): main content background image via avo-overrides.css

### DIFF
--- a/docs/4.0/theming.md
+++ b/docs/4.0/theming.md
@@ -138,6 +138,25 @@ bin/rails generate avo:eject --partial :head
 
 Avo renders the `:head` partial after its bundled stylesheets, so these take precedence too. The full list of component variables, with defaults and descriptions, lives in the [CSS variables reference](./appearance-api.html#css-variables).
 
+### Set a background image
+
+The main content panel takes a solid color from [`--color-main-content-background`](./appearance-api.html#css-variables). For an **image or gradient** instead, there's no config option — set `background-image` on `.main-content` in `avo-overrides.css`. It layers over that color, so keep an opaque image or leave the color as the fallback for any area the image doesn't cover:
+
+```css
+/* app/assets/stylesheets/avo-overrides.css */
+.main-content {
+  background-image: url("/my-background.png"); /* a file in public/, or a full URL */
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+/* Or a gradient — no asset needed: */
+/* .main-content { background-image: linear-gradient(135deg, #dbeafe, #fce7f3); } */
+```
+
+Scope a different image per scheme with `.dark .main-content { background-image: … }`.
+
 ## Style your custom UI
 
 Theming variables cover Avo's own screens. When you build [custom tools](./custom-tools.html), [custom fields](./custom-fields.html), or [resource tools](./resource-tools.html), you're writing your own markup — style it with Tailwind utility classes or your own CSS:


### PR DESCRIPTION
Documents how to give the main content panel a background **image** (or gradient), in the [Theming guide](https://docs.avohq.io/4.0/theming.html) — the page Avo points AI agents and users at for theming.

### Context

AVO-1517 asked to enable a main-section background image. It already works today via Avo's existing CSS lever, with no core change: the main content panel takes a solid color from `--color-main-content-background`, and an image/gradient is a one-line `.main-content { background-image: … }` override in `avo-overrides.css`.

### Change

Adds a **Set a background image** subsection under *Theming → Fine-tune specific components*, using the canonical `avo-overrides.css` mechanism the page leads with, with a per-scheme note. No config option, no code change.

Rebased onto latest `main` (the theming refactor, #564). The earlier code PR (avo-hq/avo#4657) is closed in favor of this docs-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or configuration code.
> 
> **Overview**
> Adds a **Set a background image** subsection under *Fine-tune specific components* in the theming guide.
> 
> It explains that images and gradients use `background-image` on `.main-content` in `avo-overrides.css` (no Ruby config), layered on top of `--color-main-content-background`, with example CSS for a file/URL background and an optional gradient. It also notes using `.dark .main-content` for per-scheme images.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dba28c411206e22f61dc14b614c1b24ab453f615. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->