### PR TITLE
docs(i18n): resolved translations are used verbatim (AVO-1461)

### DIFF
--- a/docs/4.0/i18n.md
+++ b/docs/4.0/i18n.md
@@ -7,6 +7,10 @@ outline: [2, 3]
 
 Avo leverages Rails' powerful `I18n` translations module.
 
+:::warning Translations are used exactly as you write them
+Avo renders a resolved resource or field translation verbatim. It only humanizes the name it generates for you when no translation is found. Write `one: 'Usuario'` and you get `Usuario`; write `one: 'usuario'` and you get `usuario`. This also means acronyms and proper nouns survive -- `'Payment Intent ID'` stays `Payment Intent ID` instead of becoming `Payment intent id`.
+:::
+
 :::warning Multi-language URL Support
 If you're serving Avo using multiple languages and you're using the locale in your routes (`/en/resources/users`, `/de/resources/users`), check out [this guide](./guides/multi-language-urls).
 :::
@@ -33,10 +37,12 @@ es:
     # ... other translation keys
     resource_translations:
       user:
-        zero: 'usuarios'
-        one: 'usuario'
-        other: 'usuarios'
+        zero: 'Usuarios'
+        one: 'Usuario'
+        other: 'Usuarios'
 ```
+
+These values are used as written, so capitalize them the way you want them to appear in page titles, breadcrumbs, and the sidebar.
 
 If you don't set `self.translation_key`, Avo derives it from the resource's class name, namespace included — a [namespaced resource](./resources.html#namespaced-resources) like `Avo::Resources::Galaxy::Planet` defaults to `avo.resource_translations.galaxy/planet`.
 
@@ -103,9 +109,9 @@ es:
     # ... other translation keys
     field_translations:
       file:
-        zero: 'archivos'
-        one: 'archivo'
-        other: 'archivos'
+        zero: 'Archivos'
+        one: 'Archivo'
+        other: 'Archivos'
 ```
 
 To override a field label for a single resource, add a resource-scoped entry. It wins over the shared `field_translations` key, while other resources keep using the shared one:
@@ -218,20 +224,22 @@ If you try to localize your resources and fields and it doesn't seem to work, pl
 
 Internally the localization works like so `I18n.t(translation_key, count: 1, default: default)` where the `default` is the computed field/resource name. So check the structure of your translation keys.
 
+The `default` is the only value Avo humanizes. When your key resolves, the translation is used exactly as written.
+
 ```yaml
 # config/locales/avo.pt-BR.yml
 pt-BR:
   avo:
     field_translations:
       file:
-        zero: 'arquivos'
-        one: 'arquivo'
-        other: 'arquivos'
+        zero: 'Arquivos'
+        one: 'Arquivo'
+        other: 'Arquivos'
     resource_translations:
       user:
-        zero: 'usuários'
-        one: 'usuário'
-        other: 'usuários'
+        zero: 'Usuários'
+        one: 'Usuário'
+        other: 'Usuários'
 ```
 
 ### Using a Route Scope for Localization

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -24,9 +24,20 @@ pt-BR:
   avo:
     resource_translations:
       user:
+        zero: 'usuários' # [!code --]
+        one: 'usuário' # [!code --]
+        other: 'usuários' # [!code --]
         zero: 'Usuários' # [!code ++]
         one: 'Usuário' # [!code ++]
         other: 'Usuários' # [!code ++]
+    field_translations:
+      file:
+        zero: 'arquivos' # [!code --]
+        one: 'arquivo' # [!code --]
+        other: 'arquivos' # [!code --]
+        zero: 'Arquivos' # [!code ++]
+        one: 'Arquivo' # [!code ++]
+        other: 'Arquivos' # [!code ++]
 ```
 
 Grep your locale files for `resource_translations` and `field_translations`, and capitalize any entry you want capitalized on screen. Nothing else changes: resources and fields without a translation still fall back to the humanized class or attribute name.

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -5,3 +5,32 @@ We'll update this page when we release new Avo 4 versions.
 If you're looking for the Avo 3 to Avo 4 upgrade guide, please visit [the dedicated page](./avo-3-avo-4-upgrade).
 
 Migrating to TailwindCSS 4? See the [TailwindCSS 4 Migration Guide](./tailwind-4-migration).
+
+## Resource and field translations are used verbatim
+
+Avo used to humanize every resource and field label it resolved from your locale files. That silently overrode the casing you wrote: `'Payment Intent ID'` rendered as `Payment intent id`, and `'API Products'` rendered as `Api products`.
+
+Avo now renders a resolved translation exactly as written and humanizes only the name it generates for you when no translation is found.
+
+:::warning Lowercase translations now render lowercase
+If your locale entries are lowercase, they used to appear capitalized. They will now appear as written.
+:::
+
+To keep the previous output, capitalize the entry:
+
+```yaml
+# config/locales/avo.pt-BR.yml
+pt-BR:
+  avo:
+    resource_translations:
+      user:
+        zero: 'Usuários' # [!code ++]
+        one: 'Usuário' # [!code ++]
+        other: 'Usuários' # [!code ++]
+```
+
+Grep your locale files for `resource_translations` and `field_translations`, and capitalize any entry you want capitalized on screen. Nothing else changes: resources and fields without a translation still fall back to the humanized class or attribute name.
+
+Avo's own interface strings are unaffected — the "New", "Edit", and "View" labels still render as before.
+
+See [Localization (i18n)](./i18n) for the full picture.


### PR DESCRIPTION
# Description

Companion docs for [avo-hq/avo#4639](https://github.com/avo-hq/avo/pull/4639) ([AVO-1461](https://linear.app/avo-hq/issue/AVO-1461/trust-resolved-translations-verbatim)), which stops Avo from humanizing a resolved resource or field translation.

This matters more than a typical docs follow-up: **the examples on this page recommend lowercase locale values**, and after #4639 those render lowercase in page titles, breadcrumbs, and the sidebar. Shipping the code change without this would leave us telling users to write `one: 'usuario'` and then rendering `usuario` where they used to get `Usuario`.

## Changes

**`docs/4.0/i18n.md`**

- Added a `:::warning` up top stating the rule: a resolved translation is used exactly as written, and only the generated fallback is humanized.
- Capitalized the YAML examples under *Localizing resources* and *Localizing fields* (`'usuario'` → `'Usuario'`, `'archivo'` → `'Archivo'`), plus the `pt-BR` example in the FAQ.
- Noted in the FAQ that `default` is the only value Avo humanizes.

**`docs/4.0/upgrade.md`**

Was a five-line stub. Adds the first real Avo 4 entry for this behavior change: what changed, the lowercase-renders-lowercase warning, how to respond, and a note that Avo's own chrome strings ("New", "Edit", "View") are unaffected.

## Verification

- `npx vitepress build docs` completes without errors.
- Follows `AGENTS.md`: VitePress callouts, code spans for option names, real copy-pasteable YAML with the file path as the first-line comment.

## Merge order

Land this together with (or just after) avo-hq/avo#4639 — on its own it would document behavior that has not shipped.