### PR TITLE
docs: document the `back_to_top` configuration option

### DIFF
--- a/docs/4.0/customization-api.md
+++ b/docs/4.0/customization-api.md
@@ -395,8 +395,18 @@ config.back_to_top = {
 
 Raise `threshold` if you'd rather the pill only show up further down long pages.
 
+The button's label is translated — override it like any other Avo string:
+
+```yaml
+# config/locales/avo.en.yml
+en:
+  avo:
+    back_to_top: Back to top
+```
+
 - **Type:** Hash, merged over the defaults
 - **Default:** `{ enabled: false, threshold: 64 }`
+- **i18n key:** `avo.back_to_top` ("Back to top")
 
 </Option>
 

--- a/docs/4.0/customization-api.md
+++ b/docs/4.0/customization-api.md
@@ -380,6 +380,26 @@ config.hide_layout_when_printing = true
 
 </Option>
 
+<Option name="`back_to_top`" headingSize="3">
+
+A floating "Back to top" pill that appears centered below the navbar. It stays hidden within `threshold` pixels of the top of the page, reveals when you scroll back up, and hides again when you scroll down. Clicking it smooth-scrolls to the top.
+
+It's off by default — opt in from your initializer:
+
+```ruby
+config.back_to_top = {
+  enabled: true, # show the "Back to top" pill
+  threshold: 64  # pixels scrolled down before an upward scroll reveals it
+}
+```
+
+Raise `threshold` if you'd rather the pill only show up further down long pages.
+
+- **Type:** Hash, merged over the defaults
+- **Default:** `{ enabled: false, threshold: 64 }`
+
+</Option>
+
 ## Behavior
 
 <Option name="`resource_default_view`" headingSize="3">


### PR DESCRIPTION
Documents the opt-in "Back to top" pill added in avo-hq/avo#4661.

Adds a `back_to_top` entry to the **Layout** section of the customization API page, next to `sidebar_toggle_visible` and `hide_layout_when_printing`, following the existing `<Option>` block format.

Covers:

- What the button is and where it appears
- The scroll-direction reveal (hidden near the top, shows on scroll up, hides on scroll down)
- Both config keys, and that it's **off by default**
- When you'd want to raise `threshold`

```ruby
config.back_to_top = {
  enabled: true, # show the "Back to top" pill
  threshold: 64  # pixels scrolled down before an upward scroll reveals it
}
```

Verified with `npx vitepress build docs` — builds clean.

> [!NOTE]
> Merge after avo-hq/avo#4661, since the option doesn't exist until then.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> Adds a **Layout** section entry for **`config.back_to_top`** on the customization API reference page, matching the existing `<Option>` format used by options like `hide_layout_when_printing`.
> 
> The new block documents the opt-in floating “Back to top” pill (placement, scroll-up reveal / scroll-down hide behavior near the top), the **`enabled`** and **`threshold`** hash keys with defaults **`{ enabled: false, threshold: 64 }`**, guidance on raising **`threshold`**, and overriding the label via **`avo.back_to_top`** in locale YAML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8404bfd68850368aa76e52d59419ddea9f2ed97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->