### PR TITLE
docs: standardize how translation keys are documented

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,7 @@ Rules:
   - `**Default:**` — the actual default in a code span, or `nil`.
   - `**Values:**` — allowed values when not obvious from the type.
   - `**Validation:**` — what raises and when (e.g. "raises `ArgumentError` if any shade is missing").
+  - `**i18n key:**` — when the option renders a translatable string, the key followed by the English text in parentheses: `` `avo.run` ("Run") ``. Always its own bullet, never folded into `**Default:**` — plenty of translatable strings aren't defaults, and a separate line keeps every key greppable.
   - Any feature-specific flag (e.g. `**Lockable:** yes — ...`, `**Context:** evaluated in a controller context`, `**Locals:** ...`).
 
 5. Use `:::warning` / `:::info` callouts for sharp edges (type coercion, things forwarded verbatim to a third party, etc.).
@@ -112,6 +113,7 @@ config.feature = {
 - **Type:** ...
 - **Default:** `...`
 - **Values:** ...
+- **i18n key:** `avo.some_key` ("English text")
 
 </Option>
 ````

--- a/docs/4.0/actions-api.md
+++ b/docs/4.0/actions-api.md
@@ -176,7 +176,8 @@ end
 ```
 
 - **Type:** String or Proc
-- **Default:** `"Are you sure you want to run this action?"` (translated, i18n key `avo.are_you_sure_you_want_to_run_this_option`)
+- **Default:** `"Are you sure you want to run this action?"`
+- **i18n key:** `avo.are_you_sure_you_want_to_run_this_option` ("Are you sure you want to run this action?")
 
 </Option>
 
@@ -196,7 +197,8 @@ end
 ```
 
 - **Type:** String or Proc
-- **Default:** `"Run"` (translated, i18n key `avo.run`)
+- **Default:** `"Run"`
+- **i18n key:** `avo.run` ("Run")
 
 </Option>
 
@@ -216,7 +218,8 @@ end
 ```
 
 - **Type:** String or Proc
-- **Default:** `"Cancel"` (translated, i18n key `avo.cancel`)
+- **Default:** `"Cancel"`
+- **i18n key:** `avo.cancel` ("Cancel")
 
 </Option>
 

--- a/docs/4.0/basic-filters-api.md
+++ b/docs/4.0/basic-filters-api.md
@@ -89,7 +89,8 @@ self.empty_message = "Please select a country to view options."
 ```
 
 - **Type:** String
-- **Default:** `nil` — falls back to the localized `avo.no_options_available` ("No options available")
+- **Default:** `nil` — falls back to the translated default
+- **i18n key:** `avo.no_options_available` ("No options available")
 
 </Option>
 

--- a/docs/4.0/cards-api.md
+++ b/docs/4.0/cards-api.md
@@ -462,7 +462,8 @@ self.empty_message = "No sign-ups this week"
 ```
 
 - **Type:** String or Proc
-- **Default:** the translated `avo.no_item_found`
+- **Default:** the translated default
+- **i18n key:** `avo.no_item_found` ("No record found")
 
 </Option>
 

--- a/docs/4.0/custom-controls-api.md
+++ b/docs/4.0/custom-controls-api.md
@@ -93,7 +93,8 @@ Links to the record's <Show /> view. Rendered by default in the row controls.
 Submits the form on the <Edit /> and <New /> views.
 
 - **Options:** [`label`](#label), [`title`](#title), [`style`](#style), [`color`](#color), [`icon`](#icon)
-- **Default label:** "Save", or the resource's `save` translation when defined
+- **Default label:** `"Save"`
+- **i18n key:** `avo.save` ("Save"), overridden by the resource's own `save` translation when defined
 
 </Option>
 
@@ -204,9 +205,9 @@ Renders a link to a path set by you. The first two arguments are the label and t
 link_to "Fish.com", "https://fish.com", icon: "heroicons/outline/academic-cap", target: :_blank
 ```
 
-- **Options:** [`title`](#title), [`style`](#style), [`color`](#color), [`icon`](#icon), `target`, `data`, `class`
+- **Options:** [`title`](#title), [`style`](#style), [`color`](#color), [`icon`](#icon), [`size`](#size), `target`, `data`, `class`
 
-Any other arguments (`rel: "noopener"`, etc.) are forwarded to the link.
+Only these options are rendered on the link — any other argument (`rel: "noopener"`, etc.) is ignored. Use [`data`](#data) for `data-*` attributes, including the Turbo and Stimulus ones.
 
 #### `target`
 

--- a/docs/4.0/dynamic-filters-api.md
+++ b/docs/4.0/dynamic-filters-api.md
@@ -439,7 +439,8 @@ config.button_label = "Advanced filters"
 ```
 
 - **Type:** String or Proc
-- **Default:** the localized `avo.filters` ("Filters")
+- **Default:** the translated default
+- **i18n key:** `avo.filters` ("Filters")
 
 The button only renders when [`always_expanded`](#always_expanded) is `false`.
 

--- a/docs/4.0/field-options-api.md
+++ b/docs/4.0/field-options-api.md
@@ -35,7 +35,8 @@ field :is_available, as: :boolean, name: "Availability"
 ```
 
 - **Type:** String or Proc
-- **Default:** the humanized field id, or its translation when one exists
+- **Default:** the humanized field id
+- **i18n key:** `avo.field_translations.<field_id>` — used when defined, otherwise the id is humanized
 
 </Option>
 
@@ -61,7 +62,8 @@ field :password, as: :password, help: 'Verify the password strength <a href="htt
 ```
 
 - **Type:** String (HTML allowed) or Proc
-- **Default:** `nil`, falling back to the `avo.field_translations.<field_id>.help` i18n key when defined
+- **Default:** `nil`
+- **i18n key:** `avo.field_translations.<field_id>.help` — used when defined
 
 </Option>
 
@@ -87,7 +89,8 @@ field :name, as: :text, placeholder: "John Doe"
 ```
 
 - **Type:** String or Proc
-- **Default:** the `avo.field_translations.<field_id>.placeholder` i18n key when defined, otherwise the field's name
+- **Default:** the field's name
+- **i18n key:** `avo.field_translations.<field_id>.placeholder` — used when defined
 
 </Option>
 


### PR DESCRIPTION
Follow-up to #572. Translation keys were documented **five different ways** across the API pages, none of them greppable:

```
- **Default:** `"Run"` (translated, i18n key `avo.run`)
- **Default:** `nil` — falls back to the localized `avo.no_options_available` ("No options available")
- **Default:** the translated `avo.no_item_found`
- **Default label:** "Save", or the resource's `save` translation when defined
- **Default:** the `avo.field_translations.<field_id>.placeholder` i18n key when defined, otherwise the field's name
```

## The standard

A dedicated bullet alongside `Type`/`Default`, with the key and its English text:

```
- **Type:** String or Proc
- **Default:** `"Run"`
- **i18n key:** `avo.run` ("Run")
```

Why its own bullet rather than folded into `**Default:**`:

- Plenty of translatable strings **aren't** defaults. `back_to_top` (#572) is a good example — its `Default` is `{ enabled: false, threshold: 64 }`, and the label's key has nothing to do with it. The old inline style had nowhere to put the key.
- It keeps `**Default:**` meaning "the value when unset", which is what it means everywhere else.
- Every documented key is now findable with one grep.

## Changes

- Normalizes all 10 existing spots across `actions-api`, `basic-filters-api`, `cards-api`, `custom-controls-api`, `dynamic-filters-api`, and `field-options-api`.
- Records the convention in `AGENTS.md` — both in the `<Option>` contract bullet list and the template — since that's where the `<Option>` format is defined (`CLAUDE.md` delegates to it).

## Two things worth a look

- **`avo.no_item_found` was documented without its English text, and it isn't what you'd guess** — the actual string is **"No record found"**, not "No item found". Now stated explicitly. Verified against `lib/generators/avo/templates/locales/avo.en.yml`.
- **`field_options.translation_key` is deliberately left unchanged.** That option's *value* is itself a key, so a `**i18n key:**` bullet would be circular. Flagging it so it doesn't read as an oversight.

All English strings verified against the gem's `avo.en.yml` rather than copied from the existing docs.

Builds clean with `npx vitepress build docs`.

> [!NOTE]
> Independent of #572 — no overlapping lines, either order merges fine.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Edits are limited to contributor docs and API reference markdown; no application code or configuration behavior changes.
> 
> **Overview**
> **Standardizes how translatable strings appear in API reference `<Option>` blocks.** `AGENTS.md` now requires a separate `**i18n key:**` line (key plus English in parentheses) instead of folding keys into `**Default:**`, and the `<Option>` template shows the same pattern.
> 
> **Updates ~10 call sites** in `actions-api`, `basic-filters-api`, `cards-api`, `dynamic-filters-api`, and `field-options-api` so defaults and translation keys are split and greppable. **`avo.no_item_found`** is documented explicitly as **"No record found"** on the cards empty-message option.
> 
> **`custom-controls-api`** gets the same i18n treatment for `save_button` and documents `link_to` more precisely: `size` is listed as a supported option, and only documented kwargs are rendered (others are ignored).
> 
> Documentation-only; no runtime or gem behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b39e83475bfd9c83ac8cf1fffcb489b1aec45c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->