### PR TITLE
Add `Concepts` category

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,4 +10,6 @@ Reference example to copy: [`docs/4.0/appearance.md`](./4.0/appearance.md) (guid
 
 **No blur in code blocks.** Don't use the `[!code focus]` marker — it blurs every unfocused line, which we don't want. Emphasize lines with highlights instead (`[!code highlight]`, or `[!code ++]` / `[!code --]` for diffs). If you think a specific block genuinely needs focus/blur, don't add it silently — point it out and ask.
 
+**The Concepts sidebar section is a curated static list**, not a dynamic one. It lives in `.vitepress/config.js` (the `text: "Concepts"` block). Add a page by hand as `{ text, link }`, keeping the flat `/4.0/<page>.html` URL so nothing breaks — don't move pages into a `concepts/` folder and don't convert the section to the dynamic `getFiles()` pattern (that would change URLs and break inbound links, and it loses the custom titles/order). Only list pages that describe a system spanning the whole admin (breadcrumbs, tooltips, icons, resource controllers…); anything scoped to a single resource or field stays in its own docs.
+
 Running the site locally and component details: [`readme.md`](./readme.md).

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -279,7 +279,6 @@ const config = {
             { text: "Theming", link: "/4.0/theming.html" },
             // { text: "User Preferences", link: "/4.0/user-preferences.html" },
             { text: "Multitenancy", link: "/4.0/multitenancy.html" },
-            { text: "Breadcrumbs", link: "/4.0/breadcrumbs.html" },
             {
               text: "Build your own UI",
               collapsed: false,
@@ -288,7 +287,6 @@ const config = {
                 { text: "Resource tools", link: "/4.0/resource-tools.html" },
                 { text: "Custom fields", link: "/4.0/custom-fields.html" },
                 { text: "Custom errors", link: "/4.0/custom-errors.html" },
-                { text: "Icons", link: "/4.0/icons.html" },
                 { text: "Asset handling", link: "/4.0/asset-handling.html" },
                 { text: "JavaScript & Stimulus", link: "/4.0/javascript.html" },
                 { text: "TailwindCSS integration", link: "/4.0/tailwindcss-integration.html" },
@@ -315,6 +313,18 @@ const config = {
         //     { text: "Overview", link: "/4.0/mcp.html" },
         //   ],
         // },
+        {
+          text: "Concepts",
+          items: [
+            { text: "Overview", link: "/4.0/concepts.html" },
+            { text: "Breadcrumbs", link: "/4.0/breadcrumbs.html" },
+            { text: "Tooltips", link: "/4.0/tooltips.html" },
+            { text: "Icons", link: "/4.0/icons.html" },
+            { text: "Resource controllers", link: "/4.0/controllers.html" },
+            { text: "How pages are rendered", link: "/4.0/how-pages-are-rendered.html" },
+            { text: "Rails engines and path helpers", link: "/4.0/rails-engines-paths.html" },
+          ],
+        },
         {
           text: "Add-ons",
           items: [
@@ -351,8 +361,6 @@ const config = {
             { text: "<code>Avo::ExecutionContext</code>", link: "/4.0/execution-context.html" },
             { text: "<code>Avo::Services::EncryptionService</code>", link: "/4.0/encryption-service.html" },
             { text: "Reserved model names and routes", link: "/4.0/internal-model-names.html" },
-            { text: "Rails engines and path helpers", link: "/4.0/rails-engines-paths.html" },
-            { text: "Controller configuration", link: "/4.0/controllers.html" },
             { text: "<code>Avo::ApplicationController</code>", link: "/4.0/avo-application-controller.html" },
           ],
         },

--- a/docs/4.0/concepts.md
+++ b/docs/4.0/concepts.md
@@ -1,0 +1,22 @@
+---
+outline: [2, 3]
+---
+
+# Concepts
+
+Avo is built from a handful of small systems that show up on almost every screen — the breadcrumb trail, tooltips, icons, the controller behind each resource. This section explains **how those pieces work and fit together**, so when you customize one you know what you're reaching into.
+
+These aren't step-by-step guides. Read a concept page when you're curious how something behaves or where to hook in — each one links out to the reference and how-to details when you're ready to change something.
+
+## What's here
+
+- **[Breadcrumbs](./breadcrumbs.html)** — how Avo builds the trail from your resource hierarchy, and where to change where it starts.
+- **[Tooltips](./tooltips.html)** — the tippy.js primitive Avo wires up for you, and how to add your own with two attributes.
+- **[Icons](./icons.html)** — the icon libraries Avo ships with and how the `svg` helper resolves them.
+- **[Resource controllers](./controllers.html)** — the controller Avo generates per resource, and the hooks you can override.
+- **[How pages are rendered](./how-pages-are-rendered.html)** — the path from request to rendered screen, and how Avo picks the view component for each page.
+- **[Rails engines and path helpers](./rails-engines-paths.html)** — why path helpers behave differently inside the Avo engine, and the `avo.` / `main_app.` prefixes.
+
+## What belongs here
+
+A page lands in Concepts when it describes a system that spans the whole admin, rather than a single resource or field. If a topic only affects one resource, it lives in that resource's own docs; the deeper plumbing you rarely touch lives under [Internals](./internals.html).

--- a/docs/4.0/custom-controls.md
+++ b/docs/4.0/custom-controls.md
@@ -137,6 +137,105 @@ end
 
 <Image src="/assets/img/4_0/customizable-controls/default_controls.webp" dark-src="/assets/img/4_0/customizable-controls/default_controls-dark.webp" width="441" height="52" alt="A show controls bar with a custom &quot;View on site&quot; link prepended before the default back, delete, and edit controls." prompt="show controls bar with a custom link prepended before the default controls" />
 
+## What you can put in a control
+
+Beyond the built-in buttons, a control block accepts your own links and action buttons — and because a `link_to` forwards its `data`, `class`, and `target` to the rendered `<a>`, you can drive Turbo and Stimulus straight from a control.
+
+### Links
+
+`link_to` takes a label and any path — an external URL, a Rails path helper, a `mailto:`, whatever you need:
+
+```ruby
+self.show_controls = -> do
+  # External URL in a new tab
+  link_to "Docs", "https://avohq.io/docs", icon: "heroicons/outline/book-open", target: :_blank
+
+  # Rails path helper for the current record
+  link_to "View on site", post_path(record), icon: "heroicons/outline/globe-alt"
+
+  # mailto: link
+  link_to "Email author", "mailto:#{record.author.email}", icon: "heroicons/outline/envelope"
+
+  # Icon-only — the label becomes the tooltip
+  link_to "Open in Stripe", "https://dashboard.stripe.com/customers/#{record.stripe_id}",
+    icon: "heroicons/outline/credit-card", style: :icon
+
+  default_controls
+end
+```
+
+### Built-in controls
+
+Relabel, restyle, or reorder the [built-in buttons](./custom-controls-api.html#controls) — `back_button`, `edit_button`, `show_button`, `delete_button`, and the rest:
+
+```ruby
+self.show_controls = -> do
+  back_button label: "", title: "Back"          # icon-only
+  edit_button label: "Edit this fish"
+  delete_button label: "", icon: "heroicons/outline/trash",
+    confirmation_message: "Delete this fish for good?"
+end
+```
+
+### Actions
+
+Pull an [action](./actions.html) out as its own button, pass it `arguments`, and keep the rest in the dropdown:
+
+```ruby
+self.show_controls = -> do
+  # A single action as a button
+  action Avo::Actions::ReleaseFish, style: :primary, color: :fuchsia, icon: "heroicons/outline/globe"
+
+  # Send data to the action
+  action Avo::Actions::ExportSelection, arguments: { format: :csv }
+
+  # Everything else stays in the dropdown
+  actions_list exclude: [Avo::Actions::ReleaseFish], label: "More"
+
+  default_controls
+end
+```
+
+### Turbo triggers
+
+A `link_to` forwards its `data` hash to the `<a>`, so any `data-turbo-*` attribute works. Load a response into a Turbo Frame, or turn a link into a `POST`/`DELETE` button:
+
+```ruby
+self.show_controls = -> do
+  # Render the response into a Turbo Frame already on the page
+  link_to "Preview", preview_fish_path(record),
+    icon: "heroicons/outline/eye",
+    data: { turbo_frame: "fish_preview" }
+
+  # A link that submits as a POST, with a confirmation dialog
+  link_to "Archive", archive_fish_path(record),
+    icon: "heroicons/outline/archive-box",
+    data: { turbo_method: :post, turbo_confirm: "Archive this fish?" }
+
+  default_controls
+end
+```
+
+### JavaScript triggers
+
+The same `data` pass-through lets you wire a control to a [Stimulus controller](./javascript.html) — set the `controller`, `action`, and any value attributes, and Avo renders them on the link:
+
+```ruby
+self.show_controls = -> do
+  link_to "Copy API key", "#",
+    icon: "heroicons/outline/clipboard",
+    data: {
+      controller: "clipboard",
+      action: "clipboard#copy",
+      clipboard_text_value: record.api_key
+    }
+
+  default_controls
+end
+```
+
+Load the controller through your [asset pipeline](./asset-handling.html) so Stimulus picks it up.
+
 ## Group links and actions in a dropdown
 
 If you have too many controls for the bar, group your custom links and actions in a [`list`](./custom-controls-api.html#list) dropdown:

--- a/docs/4.0/how-pages-are-rendered.md
+++ b/docs/4.0/how-pages-are-rendered.md
@@ -1,0 +1,156 @@
+---
+license: community
+outline: [2, 3]
+---
+
+# How pages are rendered
+
+Every Avo screen — index, show, new, edit — is served by the same controller and follows the same pipeline: a request hits a resource controller, a chain of `before_action`s builds the resource, the action picks a **view component**, and a thin ERB template renders that component inside a layout.
+
+Understanding this flow helps when you want to [customize a controller](./controllers), swap in a [custom view component](./customization), or debug why a page renders the way it does.
+
+:::info
+This documents Avo's private controllers. They are a private API and may change between versions without notice. Read this to understand the flow, not to copy internals into your app. When you need to hook in, use the officially supported extension points linked throughout.
+:::
+
+## The request lifecycle
+
+Take a typical request like `GET /avo/resources/users`. Here's what happens:
+
+```
+Router
+  └─► Avo::UsersController  (inherits Avo::BaseController)
+        ├─ before_action chain   → builds @resource, @record, fields, authorization
+        ├─ #index (the action)   → breadcrumbs, filters, actions, picks @component
+        ├─ layout :choose_layout → avo/application (or avo/modal)
+        └─ index.html.erb        → renders @component wrapped in a Turbo frame
+```
+
+The controller is `Avo::UsersController`, but it barely contains any code. All the shared logic lives in `Avo::BaseController`, which every resource controller inherits from. See [Resource controllers](./controllers) for how to add your own behavior to a single resource.
+
+## 1. The `before_action` chain
+
+Before the action method runs, `Avo::BaseController` runs a series of `before_action`s that assemble everything the page needs. The important ones, in order:
+
+| Callback | Runs for | What it does |
+| --- | --- | --- |
+| `set_resource_name` | all | Reads the resource name from the params/route. |
+| `set_resource` | all | Instantiates the resource (`resource.new(view:, user:, params:)`) into `@resource`, then sets up `@authorization`. Raises `Avo::ResourceNotFoundError` if no resource matches. |
+| `set_record` | show, edit, destroy, update, preview | Finds the DB record via `@resource.find_record` and hydrates the resource with it (`@record`). |
+| `set_record_to_fill` | new, edit, create, update | Prepares the record that form input will be written into. |
+| `detect_fields` | all | Runs the resource's `fields` block for the current view, producing the field list. |
+| `fill_record` | create, update (and reactive requests) | Writes permitted params into the record. |
+| `authorize_base_action` | all except preview/search | Runs the authorization policy for the action. |
+
+By the time the action method executes, `@resource`, `@record`, `@authorization`, and the resolved fields are all in place.
+
+:::info
+Fields are detected **per view**. The `fields` block runs against the current view (`:index`, `:show`, `:new`, `:edit`), which is why a field marked `hide_on: :index` never shows up on the index page — it was never even collected for that view.
+:::
+
+## 2. The action method
+
+Each action (`index`, `show`, `new`, `edit`) is small and does the same handful of things:
+
+- Sets `@page_title`.
+- Builds the breadcrumbs for the current context (including the parent record when viewing an association).
+- Collects the [filters](./filters) and [actions](./actions) available on the page (`set_filters`, `set_actions`).
+- Calls `set_component_for(...)` to decide **which view component** renders the page.
+
+For `index`, this is also where the query is built and paginated (`build_index_query`, `apply_pagination`), turning the resource into a list of hydrated resources — one per record.
+
+## 3. Choosing the view component
+
+This is the heart of the render. Avo doesn't render fields directly from ERB — each view is a [ViewComponent](https://viewcomponent.org/). The controller resolves which component to use in `set_component_for`:
+
+```ruby
+def set_component_for(view, fallback_view: nil)
+  default_component = "Avo::Views::Resource#{(fallback_view || view).to_s.classify}Component"
+
+  # Look for a custom component declared on the resource, by key or by class name
+  custom_component = @resource.custom_components.dig(:"resource_#{view}_component") ||
+    @resource.custom_components.dig(default_component)
+
+  # Fall back to the default component when the resource doesn't override it
+  return @component = default_component.constantize if custom_component.nil?
+
+  @component = custom_component.to_s.safe_constantize
+
+  # A declared-but-missing component is a hard error
+  if @component.nil?
+    raise "The component '#{custom_component}' was not found."
+  end
+end
+```
+
+The rules:
+
+- **Default** — each view maps to a built-in component: `Avo::Views::ResourceIndexComponent`, `ResourceShowComponent`, `ResourceNewComponent`, `ResourceEditComponent`.
+- **Custom** — if the resource declares a component via the `self.components` option, that one is used instead. It's looked up first by the conventional key (`resource_index_component`, `resource_show_component`, …) and then by the default class name.
+- **Fallbacks** — `new` and `create` fall back to the edit component (forms share one component), and `create`/`update` reuse `:edit` after a failed save so validation errors re-render the same form.
+
+Override the component on a resource like this:
+
+```ruby
+class Avo::Resources::User < Avo::BaseResource
+  self.components = {
+    resource_index_component: "Avo::Views::Users::CustomIndexComponent"
+  }
+end
+```
+
+See [Customize components](./customization) for the full list of overridable keys.
+
+## 4. The layout
+
+`Avo::BaseController` sets its layout with `layout :choose_layout`:
+
+```ruby
+def choose_layout
+  if params[:modal_layout].present?
+    "avo/modal"
+  else
+    "avo/application"
+  end
+end
+```
+
+Most requests render inside `avo/application` — the full chrome with sidebar, header, and breadcrumbs. Requests that open a record in a modal (for example, creating an associated record inline) pass `modal_layout` and render in the stripped-down `avo/modal` layout instead.
+
+## 5. The ERB template
+
+Finally, the matching template in `app/views/avo/base/` renders the resolved `@component`. The templates are intentionally thin — they only pass state into the component and wrap it in a Turbo frame:
+
+```erb
+<%# app/views/avo/base/show.html.erb %>
+<%= render Avo::TurboFrameWrapperComponent.new(params[:turbo_frame]) do %>
+  <%= render @component.new(
+    resource: @resource,
+    reflection: @reflection,
+    actions: @actions,
+    parent_record: @parent_record,
+    parent_resource: @parent_resource,
+  ) %>
+<% end %>
+```
+
+The `Avo::TurboFrameWrapperComponent` is what makes association tables, filters, and search update in place without a full page reload — the same controller action can respond to a full page load or a Turbo Frame request, and the component renders accordingly.
+
+## Turbo Stream responses
+
+Not every request ends in a rendered page. Some actions respond with [Turbo Streams](https://turbo.hotwired.dev/handbook/streams) instead of HTML — for example:
+
+- **Search** on the index page replaces just the table body (`#{resource}_body_content`) rather than reloading the whole view.
+- **Create/update failures** re-render the form with validation errors via `create_fail_action` / `update_fail_action`.
+- **Destroy** from a Turbo Frame reloads the frame and flashes an alert instead of redirecting.
+
+These paths reuse the same `@resource`, fields, and components — they just wrap the output in a `turbo_stream` response targeting a specific part of the page.
+
+## Where to hook in
+
+You almost never need to touch the controller internals above. The supported ways to change what renders are:
+
+- [**Resource controllers**](./controllers) — add `before_action`s or override actions on a single resource's controller.
+- [**Custom components**](./customization) — swap the view component for any resource/view via `self.components`.
+- [**`Avo::ApplicationController`**](./avo-application-controller) — add cross-cutting behavior (multitenancy, `Current` attributes) the safe way, using concerns.
+- [**Eject views**](./eject-views) — take over a specific partial or component template when you need full control of the markup.

--- a/docs/4.0/rails-engines-paths.md
+++ b/docs/4.0/rails-engines-paths.md
@@ -31,16 +31,49 @@ main_app.posts_path
 main_app.user_path(@user)
 ```
 
+### Linking to Avo add-ons
+
+Avo isn't a single engine. Most add-ons ship their own engine with its own routes, mounted **inside** Avo's root path. Each one gets its own prefix, so a dashboard link is `avo_dashboards.dashboard_path`, not `avo.dashboard_path`.
+
+| Add-on                               | Prefix                 | Mounted at                 | Example                                    |
+| ------------------------------------ | ---------------------- | -------------------------- | ------------------------------------------ |
+| Core                                 | `avo.`                 | `/avo`                     | `avo.resources_users_path`                 |
+| [Dashboards](./dashboards)           | `avo_dashboards.`      | `/avo/dashboards`          | `avo_dashboards.dashboard_path(dashboard)` |
+| [Kanban](./kanban-boards)            | `avo_kanban.`          | `/avo/boards`              | `avo_kanban.board_path(board)`             |
+| [Collaboration](./collaboration)     | `avo_collaboration.`   | `/avo/collaboration`       | `avo_collaboration.entries_path`           |
+| [Notifications](./notifications)     | `avo_notifications.`   | `/avo/notifications`       | `avo_notifications.notifications_path`     |
+| [Dynamic filters](./dynamic-filters) | `avo_dynamic_filters.` | `/avo/avo-dynamic_filters` | `avo_dynamic_filters.fields_path`          |
+
+The mount points are relative to your configured `root_path`. If you mounted Avo at `/admin`, dashboards live at `/admin/dashboards`.
+
+:::warning
+A prefix only exists when that gem is installed. Calling `avo_kanban.board_path` in an app without `avo-kanban` raises `NoMethodError`, so guard optional add-ons with `Avo.plugin_manager.installed?("avo-kanban")`.
+:::
+
+### Inside view components
+
+ViewComponents don't have the routing proxies in scope directly — reach them through `helpers`:
+
+```ruby
+# In a ViewComponent
+helpers.avo_dashboards.dashboard_path(dashboard)
+helpers.avo.resources_users_path
+helpers.main_app.posts_path
+```
+
 ## Why this matters
 
 Without the prefix, Rails resolves helpers in the current context. Calling `posts_path` from inside Avo could fail (undefined method) or resolve to the wrong route if both Avo and your app define it. The `avo` and `main_app` proxies explicitly tell Rails which route set to use.
 
 ## Quick reference
 
-| You want to link to… | Use this prefix |
-| -------------------- | --------------- |
-| Avo pages (resources, tools, dashboards, etc.) | `avo.` |
-| Your main application routes | `main_app.` |
+| You want to link to…                                       | Use this prefix                              |
+| ---------------------------------------------------------- | -------------------------------------------- |
+| Avo core pages (resources, tools, media library, etc.)     | `avo.`                                       |
+| An Avo add-on's pages (dashboards, boards, notifications…) | that add-on's prefix, e.g. `avo_dashboards.` |
+| Your main application routes                               | `main_app.`                                  |
+
+Not sure which prefix an add-on uses? Run `rails routes` and look at the `Mounts` lines — each mounted engine is listed with the name you use as the prefix.
 
 ## Learn more
 

--- a/docs/4.0/tooltips.md
+++ b/docs/4.0/tooltips.md
@@ -1,0 +1,72 @@
+---
+license: community
+outline: [2, 3]
+---
+
+# Tooltips
+
+Avo ships with [tippy.js](https://atomiks.github.io/tippyjs/) and wires it up for you, so you rarely instantiate a tooltip by hand. Any element that carries a `data-tippy="tooltip"` attribute and a `title` becomes a hover tooltip — the `title` is used as the content, and Avo hides the native browser tooltip so you don't get both.
+
+```erb
+<button data-tippy="tooltip" title="Copy to clipboard">
+  <%= svg "tabler/outline/clipboard" %>
+</button>
+```
+
+Tooltips are hover-triggered, initialized automatically on every page load and Turbo navigation, and appended into the nearest modal when the trigger lives inside one (so they never paint underneath it). If the `title` is empty, nothing is shown.
+
+This is the same primitive Avo uses internally for action buttons, index row controls, the view switcher, and [discreet information](./discreet-information.html) — so tooltips you add look and behave exactly like the built-in ones.
+
+## Add a tooltip to any element
+
+Anywhere you write your own markup — a [custom tool](./custom-tools.html), a [resource tool](./resource-tools.html), a [custom field](./custom-fields.html), or an ejected partial — add the two attributes:
+
+```erb
+<span data-tippy="tooltip" title="This value is read-only">
+  <%= record.status %>
+</span>
+```
+
+That's the whole setup. Avo's global initializer picks the element up on the next render; you don't register a Stimulus controller or call any JavaScript.
+
+## Use it with Avo's buttons and links
+
+Avo's [`a_button` and `a_link`](./native-components/avo-button-component.html) helpers take `title:` and `data:` like any tag helper, so the same pattern works:
+
+```erb
+<%= a_button title: "Refresh the data", data: { tippy: "tooltip" }, icon: "tabler/outline/refresh" %>
+```
+
+## Show rich, HTML tooltips
+
+When you need more than a line of text — a formatted list, checkboxes, multiple lines — use the `tippy` Stimulus controller instead. Mark the trigger with `tippy-target="source"` and put the tooltip body in a hidden `tippy-target="content"` element; its `innerHTML` becomes the tooltip (HTML is allowed).
+
+```erb
+<div data-controller="tippy">
+  <%= link_to "Included permissions", "javascript:void(0);", data: { tippy_target: :source } %>
+
+  <div class="hidden" data-tippy-target="content">
+    <div class="p-1 space-y-1">
+      <div>✓ Read records</div>
+      <div>✓ Export to CSV</div>
+    </div>
+  </div>
+</div>
+```
+
+## Re-initialize after injecting markup
+
+The initializer runs on load, on Turbo navigations, and after Turbo Stream renders — so markup that arrives through those paths is covered. If you inject elements some other way (e.g. your own JavaScript building DOM on the fly), call `window.initTippy()` afterward to attach tooltips to the new nodes.
+
+```js
+container.insertAdjacentHTML("beforeend", myHtml)
+window.initTippy()
+```
+
+## Built-in tooltips
+
+Some Avo features render tooltips for you through configuration rather than raw HTML — reach for those instead of hand-rolling markup when they fit:
+
+- [Discreet information](./discreet-information.html) — icons and timestamps that reveal detail on hover next to the record title.
+- Card [`discreet_description`](./cards.html) — a small info icon at the bottom-right of a card with the text in a tooltip.
+- [Field layout](./fields-layout.html) tab `description` — shown as a tooltip on the tab switcher.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and VitePress navigation only; no application code or URL path changes for existing pages.
> 
> **Overview**
> Introduces a **Concepts** sidebar section in `.vitepress/config.js` with a new overview page and curated links to cross-admin topics (breadcrumbs, tooltips, icons, resource controllers, page rendering, Rails engine paths). **Breadcrumbs**, **Icons**, and **Resource controllers** move out of Customize Avo / Internals into Concepts; existing `/4.0/*.html` URLs are unchanged.
> 
> Adds **`concepts.md`** as the section hub, **`tooltips.md`** (tippy.js usage), and **`how-pages-are-rendered.md`** (request → component pipeline). **`rails-engines-paths.md`** gains add-on routing prefixes, ViewComponent `helpers` usage, and an expanded quick reference. **`CLAUDE.md`** documents that Concepts is a hand-maintained static list (not `getFiles()`).
> 
> **`custom-controls.md`** expands with a “What you can put in a control” section: custom links, built-in buttons, actions, Turbo `data` attributes, and Stimulus wiring via `link_to`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bff98e5c774b73eeef305251f4f8ba64381da2fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->