### PR TITLE
Custom controls copy

### DIFF
--- a/docs/4.0/custom-controls-api.md
+++ b/docs/4.0/custom-controls-api.md
@@ -247,8 +247,6 @@ end
 
 Within the block the permitted elements are `link_to`, `action`, and [`divider`](#divider). Unlike a directly declared `action` control, actions inside a `list` do respect the action's `visible` block.
 
-The dropdown styles its own items, so [`style`](#style), [`color`](#color), and [`size`](#size) have no effect on a nested `link_to` or `action` — only [`icon`](#icon), [`label`](#label), and (for links) `target`, `data`, and `class` are used.
-
 :::warning
 Button controls like `back_button` or `edit_button` are not allowed inside a `list` block — in development they raise an error.
 :::

--- a/docs/4.0/custom-controls-api.md
+++ b/docs/4.0/custom-controls-api.md
@@ -247,6 +247,8 @@ end
 
 Within the block the permitted elements are `link_to`, `action`, and [`divider`](#divider). Unlike a directly declared `action` control, actions inside a `list` do respect the action's `visible` block.
 
+The dropdown styles its own items, so [`style`](#style), [`color`](#color), and [`size`](#size) have no effect on a nested `link_to` or `action` — only [`icon`](#icon), [`label`](#label), and (for links) `target`, `data`, and `class` are used.
+
 :::warning
 Button controls like `back_button` or `edit_button` are not allowed inside a `list` block — in development they raise an error.
 :::

--- a/docs/4.0/faq.md
+++ b/docs/4.0/faq.md
@@ -13,6 +13,8 @@ You might want to hide some buttons and not show them to your users. That's pret
 - Attach button -> `attach_#{RESOURCE_PLURL_NAME}?` (eg: `attach_posts?`) method
 - Detach button -> `detach_#{RESOURCE_PLURL_NAME}?` (eg: `detach_posts?`) method
 
+If you want to remove or relabel a button regardless of authorization, use [custom controls](./custom-controls) to take over the controls area and declare only the buttons you want.
+
 ## Why don't regular URL helpers work as expected?
 
 When writing rails code somewhere in the Avo domain you might want to use your regular URL helpers like the below:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> **Docs update** to the FAQ section on hiding admin buttons via authorization.
> 
> After the policy-method list for show/edit/delete and related actions, the FAQ now clarifies that **authorization only controls visibility based on policy**—not arbitrary relabeling or removal. Readers who need to **remove or relabel buttons regardless of authorization** are directed to the [custom controls](./custom-controls) guide to take over the controls area and declare only the buttons they want.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56fc0867ee920ac19ee3e7470142bfec71f74a7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->