### PR TITLE
docs(customization): resizable sidebar

### DIFF
--- a/docs/4.0/customization-api.md
+++ b/docs/4.0/customization-api.md
@@ -342,6 +342,39 @@ config.sidebar_toggle_visible = false
 
 </Option>
 
+<Option name="`sidebar_default_width`" headingSize="3">
+
+Width in pixels the desktop sidebar starts at before a user drags it. See the [Resizable sidebar](./customization.html#resizable-sidebar) guide.
+
+```ruby
+config.sidebar_default_width = 320
+```
+
+Clamped into the same 200–480 range as dragging, so the handle can always drag back to it. A value Avo cannot read as an integer falls back to `256` rather than clamping to the minimum.
+
+Applies at `lg` (1024px) and wider only. Below that the sidebar is a full-height overlay and keeps its 256px default, so a wide value cannot cover a small screen. A width the user has dragged to takes precedence over this setting.
+
+- **Type:** Integer
+- **Default:** `256`
+- **Values:** `200`–`480` — values outside the range are clamped; unparseable values fall back to the default
+
+</Option>
+
+<Option name="`sidebar_resizable`" headingSize="3">
+
+Whether the sidebar's drag-to-resize handle is rendered. When `false` the handle is neither rendered nor wired up, and the sidebar stays at [`sidebar_default_width`](#sidebar_default_width).
+
+```ruby
+config.sidebar_resizable = false
+```
+
+Resizing is a drag-only gesture and so does not satisfy [WCAG 2.2 SC 2.5.7 (Dragging Movements)](https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html). Set this to `false` if you are working to an AA conformance claim or a VPAT.
+
+- **Type:** Boolean
+- **Default:** `true`
+
+</Option>
+
 <Option name="`body_classes`" headingSize="3">
 
 Custom CSS classes added to Avo's `<body>` tag.

--- a/docs/4.0/customization.md
+++ b/docs/4.0/customization.md
@@ -214,6 +214,56 @@ end
 
 <Image src="/assets/img/4_0/customization/sidebar-toggle-hidden.webp" dark-src="/assets/img/4_0/customization/sidebar-toggle-hidden-dark.webp" width="2880" height="2360" alt="An Avo resource index on desktop with the sidebar permanently open and no toggle button in the navbar, because sidebar_toggle_visible is set to false." prompt="Full Avo resource index page with config.sidebar_toggle_visible = false: the sidebar is open on the left and the navbar at the top has NO collapse/expand toggle button next to the logo. Capture the entire page (sidebar + navbar + content) at a desktop width." />
 
+## Resizable sidebar
+
+On desktop, the boundary between the sidebar and the content is a drag handle. Users drag it to whatever width suits their navigation labels, and the choice sticks across pages and browser restarts.
+
+The handle is deliberately quiet: at rest there is nothing new to see — the divider is the same one Avo has always drawn — and the affordance announces itself through the `col-resize` cursor when the pointer crosses the boundary. A grip appears on hover and while dragging. Double-clicking the handle resets the sidebar to its starting width, and pressing <kbd>Escape</kbd> mid-drag cancels the drag and reverts to the width it started from.
+
+Widths are clamped to **200px–480px**, and never wider than 40% of the viewport, so the content area cannot be squeezed out on a narrower screen. If a user picks 480px on a wide monitor and later opens the same admin on a 1100px window, the sidebar renders narrower to fit and returns to 480px when there is room again — the stored preference is not overwritten.
+
+Sidebar labels no longer wrap: a link, section, or group name that overflows renders on a single line with an ellipsis, and the full label is available in a tooltip on hover. This applies at every width, so even the 200px minimum stays tidy.
+
+The chosen width is stored in a cookie and applied before the first paint, so there is no flash of the default width on load.
+
+:::info Scope of the preference
+The width is stored **per browser**, not per user — two people sharing a browser profile share a width, the same as Avo's theme and per-page preferences. It does not sync across devices.
+:::
+
+Resizing is desktop-only. Below the `lg` breakpoint (1024px) the sidebar is a full-height overlay, so there is no handle and no resizing — the sidebar uses its default width there regardless of what was chosen on desktop. The handle is also hidden on touch devices and anywhere without a precise pointer.
+
+### Change the starting width
+
+Set [`sidebar_default_width`](./customization-api.html#sidebar_default_width) to change where the sidebar starts before a user drags it — useful when your resource names are consistently long.
+
+```ruby
+# config/initializers/avo.rb
+Avo.configure do |config|
+  config.sidebar_default_width = 320 # [!code focus]
+end
+```
+
+The value is in pixels and is clamped to the same 200–480 range as dragging, so the handle can always drag back to it. It applies on desktop only; below `lg` the sidebar keeps its 256px default so a wide value cannot cover a small screen. A user who has dragged the sidebar keeps their own width — their preference wins over this setting.
+
+### Turn resizing off
+
+Set [`sidebar_resizable`](./customization-api.html#sidebar_resizable) to `false` to remove the handle entirely. The sidebar then stays at its configured width and behaves exactly as it did before.
+
+```ruby
+# config/initializers/avo.rb
+Avo.configure do |config|
+  config.sidebar_resizable = false # [!code focus]
+end
+```
+
+:::warning Accessibility
+Resizing is a drag-only gesture, which does not satisfy [WCAG 2.2 SC 2.5.7 (Dragging Movements)](https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html). If you are working to an AA conformance claim or a VPAT, use this option to opt out.
+:::
+
+:::info Without JavaScript
+The stored width is applied by a small nonce'd script in `<head>`, so with JavaScript disabled the sidebar renders at its default width and no handle appears.
+:::
+
 ## Body classes
 
 Add custom CSS classes to Avo's `<body>` tag with [`body_classes`](./customization-api.html#body_classes) — useful for applying global styles, theme variations, or targeting specific layouts with CSS.

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -6,6 +6,30 @@ If you're looking for the Avo 3 to Avo 4 upgrade guide, please visit [the dedica
 
 Migrating to TailwindCSS 4? See the [TailwindCSS 4 Migration Guide](./tailwind-4-migration).
 
+## Unreleased — resizable sidebar
+
+<Option name="Sidebar labels truncate instead of wrapping">
+
+### Breaking Change
+
+The sidebar is now [resizable](./customization.html#resizable-sidebar), and as part of that change sidebar link, section, and group labels render on a single line with an ellipsis when they overflow, instead of wrapping onto multiple lines. The full label shows in a tooltip on hover.
+
+**Action required:** None for most apps. If your navigation relied on long labels wrapping, either shorten the labels or point users at the drag handle to widen the sidebar.
+
+Hosts with an accessibility conformance obligation can disable the drag handle with [`sidebar_resizable`](./customization-api.html#sidebar_resizable).
+
+</Option>
+
+<Option name="`.container-small` is now `max-width`-based">
+
+### Breaking Change
+
+`.container-small` (the wrapper around show and edit pages) used a fixed width; it now fills its container up to a `max-width` so content adapts when the sidebar is wide. If you override `.container-small`'s `width` from your own stylesheets, the new Avo-owned `max-width` now clamps it — override `max-width` instead.
+
+**Action required:** None unless you override `.container-small`.
+
+</Option>
+
 ## Upgrade to 4.0.18
 
 <Option name="Resource and field translations are used verbatim">


### PR DESCRIPTION
Documents the resizable sidebar shipping in avo-hq/avo#4665.

- **`customization.md`** — new "Resizable sidebar" guide section: drag handle behavior (quiet at rest, `col-resize` cursor, hover grip, double-click reset, Escape revert), 200–480px / 40vw bounds with clamp-without-overwrite on narrow windows, label truncation, per-browser cookie persistence applied before first paint, desktop-only scope, plus task sections for `sidebar_default_width` and `sidebar_resizable` with the WCAG 2.5.7 opt-out warning and the no-JS note.
- **`customization-api.md`** — `<Option>` entries for `sidebar_default_width` (Type/Default/Values, clamping, unparseable fallback, drag precedence, `lg` gate) and `sidebar_resizable`, cross-linked with the guide.
- **`upgrade.md`** — unreleased section for the two silent behavior changes: sidebar labels truncate instead of wrapping, and `.container-small` is now `max-width`-based (hosts overriding its `width` get clamped).

Verified against the gem source on `feat/resizable-sidebar` (`lib/avo/configuration.rb`, initializer template) per AGENTS.md. Docs-map regeneration produced no changes (no new pages).

Hold merge until the feature ships; the "Unreleased" heading should fold into the release's `## Upgrade to X.Y.Z` at that point.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes with no runtime or security impact; merge timing should follow the feature release per the PR note.
> 
> **Overview**
> Documentation-only PR for the resizable sidebar feature (avo-hq/avo#4665).
> 
> **`customization.md`** adds a **Resizable sidebar** guide: desktop drag handle behavior, 200–480px / 40vw limits, cookie persistence before first paint, label truncation with tooltips, and subsections for **`sidebar_default_width`** and **`sidebar_resizable`** (WCAG 2.5.7 opt-out, no-JS behavior).
> 
> **`customization-api.md`** adds API `<Option>` entries for **`sidebar_default_width`** and **`sidebar_resizable`**, cross-linked to the guide.
> 
> **`upgrade.md`** adds an **Unreleased — resizable sidebar** section calling out two breaking changes: sidebar labels truncate instead of wrap, and **`.container-small`** is **`max-width`**-based (custom `width` overrides may need **`max-width`** instead).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70bf90017c5f091cbdc5c4ef99103101e4af368a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->