### PR TITLE
docs: tab badges + tab/panel title translations

### DIFF
--- a/docs/4.0/fields-layout-api.md
+++ b/docs/4.0/fields-layout-api.md
@@ -227,7 +227,32 @@ end
 tab(title:, **args, &block)
 ```
 
-An individual tab inside a `tabs` group. `title` is required; it also accepts `description` and `visible` (see [`tabs`](#tabs)), plus the two loading options below. Standalone fields placed directly in a tab are auto-wrapped in a card, so a `panel` or `card` is optional — add one only to attach a title or description.
+An individual tab inside a `tabs` group. `title` is required; it also accepts `description` and `visible` (see [`tabs`](#tabs)), plus the `badge` and loading options below. Standalone fields placed directly in a tab are auto-wrapped in a card, so a `panel` or `card` is optional — add one only to attach a title or description.
+
+<Option name="`badge`" headingSize="3">
+
+Renders a small pill next to the tab's label on the switcher — handy for a count or a status hint. Pass a string, or any renderable component (Avo ships `Avo::UI::CountComponent` for count pills).
+
+```ruby{2}
+tabs do
+  tab title: "Orders", badge: Avo::UI::CountComponent.new(count: 3) do
+    field :orders, as: :has_many
+  end
+end
+```
+
+A plain string works too:
+
+```ruby
+tab title: "Reviews", badge: "new" do
+  # ...
+end
+```
+
+- **Type:** String or a renderable component (responds to `render_in`)
+- **Default:** `nil` (no badge)
+
+</Option>
 
 <Option name="`lazy_load`" headingSize="3">
 

--- a/docs/4.0/fields-layout.md
+++ b/docs/4.0/fields-layout.md
@@ -243,7 +243,7 @@ end
 
 <Image src="/assets/img/4_0/tabs/show.webp" dark-src="/assets/img/4_0/tabs/show-dark.webp" width="2144" height="780" alt="An Avo User show page with id and User Email in the main panel, a tab switcher listing User information, Teams, People, Spouses and Projects, and the User information panel showing first name, last name and the Is active boolean." prompt="User show page with id and User Email in the main panel, tab switcher with User information Teams People Spouses and Projects tabs, and the User information panel showing first name last name and Is active" />
 
-The tab [`title`](./fields-layout-api.html#title) is mandatory and labels the switcher; the [`description`](./fields-layout-api.html#description) shows as a tooltip on hover. Both `tabs` groups and individual `tab`s accept a [`visible`](./fields-layout-api.html#visible) boolean or lambda, and the whole group takes its own `title` and `description`.
+The tab [`title`](./fields-layout-api.html#title) is mandatory and labels the switcher; the [`description`](./fields-layout-api.html#description) shows as a tooltip on hover. Both `tabs` groups and individual `tab`s accept a [`visible`](./fields-layout-api.html#visible) boolean or lambda, and the whole group takes its own `title` and `description`. Add a [`badge`](./fields-layout-api.html#badge) to a tab — a string or a renderable like `Avo::UI::CountComponent` — to show a count or status pill next to its label. Tab and panel titles also [localize through the resource's translation key](./i18n.html#localizing-tabs-and-panels).
 
 ### Loading behavior on Show and Edit
 

--- a/docs/4.0/i18n.md
+++ b/docs/4.0/i18n.md
@@ -173,6 +173,52 @@ field :dates,
 
 Explicit `help:`, `placeholder:`, and `include_blank:` options (strings or lambdas) still win over the locale file.
 
+## Localizing tabs and panels
+
+[Tab](./fields-layout.html#organize-fields-under-tabs) and [panel](./fields-layout.html#group-fields-into-panels) titles localize through the resource's translation key too. Avo parameterizes the configured `title:` (downcased, non-alphanumerics turned into `_`) and looks it up under a `tabs` or `panels` scope:
+
+- `avo.resource_translations.<resource>.tabs.<title>` for a `tab`
+- `avo.resource_translations.<resource>.panels.<title>` for a `panel`
+
+So `tab title: "Activity"` resolves to `avo.resource_translations.user.tabs.activity`, and `panel title: "Contact information"` resolves to `avo.resource_translations.user.panels.contact_information`:
+
+```ruby
+# app/avo/resources/user.rb
+class Avo::Resources::User < Avo::BaseResource
+  def fields
+    tabs do
+      tab title: "Activity" do
+        field :last_seen_at, as: :date_time
+      end
+    end
+
+    panel title: "Contact information" do
+      field :email, as: :text
+    end
+  end
+end
+```
+
+```yaml
+# avo.es.yml
+es:
+  avo:
+    resource_translations:
+      user:
+        tabs:
+          activity: "Actividad"
+        panels:
+          contact_information: "Información de contacto"
+```
+
+The configured `title:` stays the fallback whenever the key has no translation. If the generated key doesn't suit you, pass an explicit `translation_key:` to the `tab` or `panel` and Avo uses it verbatim:
+
+```ruby
+tab title: "Activity", translation_key: "avo.resource_translations.user.tabs.recent_activity" do
+  # ...
+end
+```
+
 ## Localizing buttons label
 
 The `avo.save` configuration applies to all save buttons. If you wish to customize the localization for a specific resource, such as `Avo::Resources::Product`, you can achieve this by:


### PR DESCRIPTION
## What & why

I reviewed the last 7 days of activity in [`avo-hq/avo`](https://github.com/avo-hq/avo) (Jul 20–27, ~34 commits) to see what the docs were missing. The docs team had already covered most of the week's features — this PR fills the two user-facing gaps that were left.

## Changes

**1. Tab `badge:` DSL option** — avo [#4664](https://github.com/avo-hq/avo/pull/4664) / [#4643](https://github.com/avo-hq/avo/pull/4643)
Tabs now accept a `badge:` that renders a pill next to the tab label (a string, or any renderable such as `Avo::UI::CountComponent`). It wasn't listed among the `tab` options.
- `docs/4.0/fields-layout-api.md` — new `<Option name="badge">` under `tab`.
- `docs/4.0/fields-layout.md` — one-line mention in the tabs guide, linked to the anchor.

**2. Resource-scoped translations for tab & panel titles** — avo [#4640](https://github.com/avo-hq/avo/pull/4640)
Tab and panel titles now resolve through the resource translation key — `avo.resource_translations.<resource>.tabs.<title>` and `.panels.<title>` (the configured `title:` is parameterized with `_` and stays the fallback). The i18n guide documented resources, actions, fields, and buttons but not tabs/panels.
- `docs/4.0/i18n.md` — new "Localizing tabs and panels" section.

## Review notes — already covered, no action needed

For the record, these week's features were already documented by the team, so I left them alone:

- Resizable sidebar (#4665), Back-to-top button (#4661), `config.density` (#4645)
- Lazy-loaded index views / `self.index_view_loading = :lazy` (#4646)
- `avo-overrides.css` / `avo-overrides.js` eject + theming, card body padding
- Resource-scoped field label cascade + `help`/`placeholder`/`include_blank` sibling keys, `action_translations` (#4635), "resolved translations used verbatim" (#4639)
- Tool generator inserting the route inside `mount_avo` (#4656)

## Not reviewed

`avo-hq/workspace` is private and couldn't be reached with this session's credentials, so it wasn't included. The `avo:sym_link` rake task removal (avo #4660) only affects v3-era docs, which correctly still reference it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjN6HrepL2GEfEyQGMMB7L)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, security, or data-handling impact.
> 
> **Overview**
> **Docs-only** update for Avo 4.0 layout and i18n guides, covering two recently shipped DSL features that were missing from the docs.
> 
> The **`tab` `badge:`** option is documented in the fields layout API (`badge` as a string or renderable such as `Avo::UI::CountComponent`), and the tabs guide now points readers to that anchor.
> 
> **Tab and panel title localization** gets a new i18n section: titles resolve under `avo.resource_translations.<resource>.tabs` / `.panels` (parameterized from `title:`), with `translation_key:` override and YAML examples; the tabs guide links to that section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a75a8a198dfd078139cac25fa399f8b817ed843e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->