### PR TITLE
docs(cards): correct the rows range to 1-12

### DIFF
--- a/docs/4.0/cards-api.md
+++ b/docs/4.0/cards-api.md
@@ -105,7 +105,7 @@ self.rows = 2
 
 - **Type:** Integer (or Proc returning one)
 - **Default:** `1`
-- **Values:** `1` to `6`
+- **Values:** `1` to `12`
 
 </Option>
 

--- a/docs/4.0/cards.md
+++ b/docs/4.0/cards.md
@@ -18,7 +18,7 @@ You can add six types of cards to your parent: `partial`, `html`, `metric`, `cha
 
 All cards have some standard settings like [`id`](./cards-api.html#self.id), which must be unique, [`label`](./cards-api.html#self.label), [`description`](./cards-api.html#self.description), and [`discreet_description`](./cards-api.html#self.discreet_description). The `label` is the title of your card, the `description` is a subtitle rendered below the title, and the `discreet_description` shows a tiny info icon at the bottom-right of the card with a tooltip containing the text.
 
-Each card has its own [`cols`](./cards-api.html#self.cols) and [`rows`](./cards-api.html#self.rows) settings to control the width and height of the card inside the parent's grid. They can have values from `1` to `6`.
+Each card has its own [`cols`](./cards-api.html#self.cols) and [`rows`](./cards-api.html#self.rows) settings to control the width and height of the card inside the parent's grid. `cols` takes values from `1` to `6`; `rows` takes values from `1` to `12`.
 
 All these settings can be set to a lambda.
 


### PR DESCRIPTION
Daily docs sweep over yesterday's changes in `avo-hq/avo` and `avo-hq/workspace`.

## What changed

`self.rows` on cards is documented as accepting `1` to `6` in both the guide and the API reference. It has always accepted **1 through 12**:

- `Avo::Cards::BaseCard#classes_for_rows` builds modifiers for `(1..12)` — [`base_card.rb:110`](https://github.com/avo-hq/avo/blob/main/lib/avo/cards/base_card.rb)
- the avo-dashboards stylesheet defines `.dashboard-card--rows-1` through `--rows-12`, each with a matching `min-height` (8rem … 96rem)

This predates the CSS authoring refactor — the old Tailwind class map it replaced also listed rows 7–12. Only `cols` is genuinely capped at 6 (`classes_for_cols` is `(1..6)`, and the stylesheet stops at `--cols-6`), so the guide sentence is split to state each range separately.

| File | Before | After |
| --- | --- | --- |
| `docs/4.0/cards.md` | "They can have values from `1` to `6`." | `cols` → `1`–`6`; `rows` → `1`–`12` |
| `docs/4.0/cards-api.md` | `self.rows` — **Values:** `1` to `6` | **Values:** `1` to `12` |

## Sweep notes — no docs change needed

- **[avo-dashboards#85](https://github.com/avo-hq/workspace/pull/85) — expose `card` in the description execution context.** The docs already documented `card` as available in `description` / `discreet_description` blocks (`cards.md` and the `cards-api.md` intro). This commit made the code match the docs, so both pages are now accurate as written. No edit needed.
- **avo [#4638](https://github.com/avo-hq/avo/pull/4638) (Marksmith heading sizes) and [#4667](https://github.com/avo-hq/avo/pull/4667) (Inter contextual alternates in inputs).** Both are CSS-only fixes to existing behavior with no documented surface. No edit needed.
- The 2026-07-25 tabs and resizable-sidebar work was already documented in #577 and #579.

## Flagged for a code fix, not a docs fix

While tracing the `card` change I found the **same bug one level up**, on dashboards:

`docs/4.0/dashboards.md:58` says *"Both `name` and `description` accept a Proc, evaluated through `Avo::ExecutionContext` with access to all its attributes plus the `dashboard`"*. That holds for `name`, which passes `dashboard: self` explicitly, but not for `description`:

- `Avo::Concerns::HasDescription#description` merges `**description_attributes`, which the concern defaults to `{}`
- `Avo::Dashboards::BaseDashboard` never overrides `description_attributes` (`BaseCard` does, `BaseScope` does, `Resources::Base` does — the dashboard is the one that doesn't)

So `dashboard` is not an accessor inside a dashboard's `description` proc, and the i18n example the sentence is selling would fail there.

I deliberately left `dashboards.md` untouched. The fix that matches intent is the one-liner applied to cards yesterday — adding `def description_attributes = {dashboard: self}` to `BaseDashboard` — rather than documenting the gap and reverting it later. Happy to open that PR against `workspace` if you'd like.

Verified by reading the code paths; specs weren't run in this environment (the gems aren't installed and `external/avo` isn't populated here).

---
_Generated by [Claude Code](https://claude.ai/code/session_019LsSmzUWhQZMXuungugKAS)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only corrections with no code or behavior changes.
> 
> **Overview**
> Fixes card grid docs that incorrectly said both **`cols`** and **`rows`** accept `1`–`6`. **`self.rows`** is now documented as **`1`–`12`** in the API reference; the Cards guide states **`cols`** → `1`–`6` and **`rows`** → `1`–`12`, matching runtime behavior (row modifiers/CSS through 12; columns still capped at 6).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a63ef4b2d1b619fc82f23005cb6865b1930c669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->