### PR TITLE
docs: merge CLAUDE.md into AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS.md — writing Avo docs
 
+This repo holds the Avo documentation site (VitePress). Running the site locally and component details: [`readme.md`](./readme.md).
+
 Operational rules for writing and editing documentation in this repo. Humans: the prose version is [`writing-docs.md`](./docs/contributing/writing-docs.md) (published at `/contributing/writing-docs.html`). This file is the precise, copy-paste version — follow it exactly.
 
 The reference implementation for everything below is the pair
@@ -181,6 +183,7 @@ Apply it:
 - Use VitePress containers for callouts: `:::warning`, `:::info`, `:::tip`, `:::danger`.
 - Enum/lookup data goes in Markdown tables, not prose.
 - One feature, one guide page. Split large guides by task with `##` headings rather than creating many files.
+- **No blur in code blocks.** Don't use the `[!code focus]` marker — it blurs every unfocused line, which we don't want. Emphasize lines with highlights instead (`[!code highlight]`, or `[!code ++]` / `[!code --]` for diffs). If you think a specific block genuinely needs focus/blur, don't add it silently — point it out and ask.
 
 ## Available components
 
@@ -189,6 +192,10 @@ Apply it:
 - `<Option name="`x`">…</Option>` — reference option block.
 - `<Demo link="https://avodemo.com" label="See the demo" />` — `label` optional.
 - `:::warning` / `:::info` / `:::tip` / `:::danger` — callouts.
+
+## The Concepts sidebar section
+
+**It's a curated static list**, not a dynamic one. It lives in `.vitepress/config.js` (the `text: "Concepts"` block). Add a page by hand as `{ text, link }`, keeping the flat `/4.0/<page>.html` URL so nothing breaks — don't move pages into a `concepts/` folder and don't convert the section to the dynamic `getFiles()` pattern (that would change URLs and break inbound links, and it loses the custom titles/order). Only list pages that describe a system spanning the whole admin (breadcrumbs, tooltips, icons, resource controllers…); anything scoped to a single resource or field stays in its own docs.
 
 ## Renaming or moving a page
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,3 @@
 # CLAUDE.md
 
-This repo holds the Avo documentation site (VitePress).
-
-**When writing or editing docs, follow [`AGENTS.md`](./AGENTS.md).** It defines how we document a feature: the guide + reference (API) two-page model, the `<Option>` reference format, required frontmatter, and cross-linking rules.
-
-Humans who want the short version: read [`writing-docs.md`](./docs/contributing/writing-docs.md) (published at `/contributing/writing-docs.html`).
-
-Reference example to copy: [`docs/4.0/appearance.md`](./4.0/appearance.md) (guide) and [`docs/4.0/appearance-api.md`](./4.0/appearance-api.md) (reference).
-
-**No blur in code blocks.** Don't use the `[!code focus]` marker — it blurs every unfocused line, which we don't want. Emphasize lines with highlights instead (`[!code highlight]`, or `[!code ++]` / `[!code --]` for diffs). If you think a specific block genuinely needs focus/blur, don't add it silently — point it out and ask.
-
-**The Concepts sidebar section is a curated static list**, not a dynamic one. It lives in `.vitepress/config.js` (the `text: "Concepts"` block). Add a page by hand as `{ text, link }`, keeping the flat `/4.0/<page>.html` URL so nothing breaks — don't move pages into a `concepts/` folder and don't convert the section to the dynamic `getFiles()` pattern (that would change URLs and break inbound links, and it loses the custom titles/order). Only list pages that describe a system spanning the whole admin (breadcrumbs, tooltips, icons, resource controllers…); anything scoped to a single resource or field stays in its own docs.
-
-Running the site locally and component details: [`readme.md`](./readme.md).
+**Follow [`AGENTS.md`](./AGENTS.md).** It's the single source of instructions for this repo — read it before writing or editing anything here.


### PR DESCRIPTION
`AGENTS.md` is now the single source of instructions for this repo; `CLAUDE.md` is a 3-line pointer to it.

Moved into `AGENTS.md`:
- VitePress/repo intro + `readme.md` link → top of the file
- No-blur `[!code focus]` rule → **House style**
- Concepts sidebar (curated static list) → new `## The Concepts sidebar section`

The `writing-docs.md` and `appearance.md`/`appearance-api.md` references were already in `AGENTS.md`, so nothing was duplicated.

`CLAUDE.md` is kept rather than deleted because Claude Code auto-loads it — the stub guarantees the redirect.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to internal agent/contributor markdown; no site content or build behavior changes.
> 
> **Overview**
> **`AGENTS.md` becomes the single source of truth** for writing and editing this VitePress docs repo. Content that lived only in `CLAUDE.md` is folded in: a short repo intro with a link to `readme.md`, the **no `[!code focus]` / blur** rule under **House style**, and a new **## The Concepts sidebar section** (curated static list in `.vitepress/config.js`, flat `/4.0/*.html` URLs).
> 
> **`CLAUDE.md` is reduced to a three-line stub** that points at `AGENTS.md`, so Claude Code still auto-loads it without maintaining duplicate rules. References that were already in `AGENTS.md` (`writing-docs.md`, `appearance` pair) were not duplicated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 042ed8450b71682c72ba0ff89ea8d0f1fb3eaa24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->