### PR TITLE
docs: document self.cache_for on cards

### DIFF
--- a/docs/4.0/cards-api.md
+++ b/docs/4.0/cards-api.md
@@ -185,10 +185,10 @@ Cards with no `query` — [HTML](#html-card) and [partial](#self.partial) cards 
 :::info
 `arguments` is deliberately not part of the key. It's fixed at registration time, so a card's position already separates two registrations of the same class.
 
-If your `query` reads something the key doesn't cover, override `cache_hash`:
+If your `query` reads something the key doesn't cover, override `cache_key`:
 
 ```ruby
-def cache_hash
+def cache_key
   super + [Current.account.id]
 end
 ```

--- a/docs/4.0/cards-api.md
+++ b/docs/4.0/cards-api.md
@@ -166,7 +166,14 @@ class Avo::Cards::UsersCount < Avo::Cards::MetricCard
 end
 ```
 
-Avo caches through `Avo.configuration.cache_store`, and the key covers the card class, its parent, its position, the current [range](#self.ranges), and — for a [resource card](./cards.html) — the record being viewed.
+Avo caches through `Avo.configuration.cache_store`. The key is scoped to the current user and tenant, so a card querying `current_user` never serves one user's data to another. In full, it covers:
+
+| Part | Why |
+| --- | --- |
+| Card class, parent, and position | Separates cards, and two registrations of the same class |
+| [`range`](#self.ranges) and the dashboard's global range | Each range is its own result |
+| Current user and tenant | Keeps per-user and per-tenant queries apart |
+| The resource's view and record | A [resource card](./cards.html) caches per record and per view |
 
 - **Type:** `ActiveSupport::Duration` (or seconds as an Integer), or a Proc returning one
 - **Default:** `nil` (no caching)
@@ -176,13 +183,21 @@ Cards with no `query` — [HTML](#html-card) and [partial](#self.partial) cards 
 :::
 
 :::info
-If your `query` reads anything the key doesn't cover — `params`, `current_user` — override `cache_key` so those variants don't share an entry:
+`arguments` is deliberately not part of the key. It's fixed at registration time, so a card's position already separates two registrations of the same class.
+
+If your `query` reads something the key doesn't cover, override `cache_hash`:
 
 ```ruby
-def cache_key
-  super + [current_user.id]
+def cache_hash
+  super + [Current.account.id]
 end
 ```
+
+Returning a narrower key is how you opt *into* sharing one entry across users.
+:::
+
+:::warning
+Outside production `Avo.configuration.cache_store` defaults to a file store under `tmp/cache`, which isn't shared between machines — on a multi-server staging environment each server caches on its own. Set `config.cache_store` in the Avo initializer to share it.
 :::
 
 </Option>

--- a/docs/4.0/cards-api.md
+++ b/docs/4.0/cards-api.md
@@ -152,6 +152,41 @@ On [table](#self.fields)/[list](#self.fields) cards a refresh reloads the whole 
 
 </Option>
 
+<Option name="`self.cache_for`" headingSize="3">
+
+Caches the result of the card's `query` for that duration. Within the window the query is skipped entirely and the stored result is replayed — useful for cards whose `query` is expensive.
+
+```ruby
+class Avo::Cards::UsersCount < Avo::Cards::MetricCard
+  self.cache_for = 5.minutes # [!code focus]
+
+  def query
+    result User.where(active: true).count
+  end
+end
+```
+
+Avo caches through `Avo.configuration.cache_store`, and the key covers the card class, its parent, its position, the current [range](#self.ranges), and — for a [resource card](./cards.html) — the record being viewed.
+
+- **Type:** `ActiveSupport::Duration` (or seconds as an Integer), or a Proc returning one
+- **Default:** `nil` (no caching)
+
+:::warning
+Cards with no `query` — [HTML](#html-card) and [partial](#self.partial) cards — build their content at render time, so `cache_for` does nothing for them. Wrap the markup in Rails' own `cache` block instead.
+:::
+
+:::info
+If your `query` reads anything the key doesn't cover — `params`, `current_user` — override `cache_key` so those variants don't share an entry:
+
+```ruby
+def cache_key
+  super + [current_user.id]
+end
+```
+:::
+
+</Option>
+
 ## Ranges
 
 Let the user query data across different time ranges via a dropdown in the card header.
@@ -484,12 +519,13 @@ def cards
     rows: 2,
     visible: -> { true },
     refresh_every: 2.minutes,
+    cache_for: 5.minutes,
     chart_options: {library: {plugins: {legend: {display: true}}}},
     arguments: {active_users: true}
 end
 ```
 
-- **Overridable keys:** `label`, `description`, `discreet_description`, `cols`, `rows`, `refresh_every`, `visible`, `chart_options`, `arguments`
+- **Overridable keys:** `label`, `description`, `discreet_description`, `cols`, `rows`, `refresh_every`, `cache_for`, `visible`, `chart_options`, `arguments`
 
 </Option>
 

--- a/docs/4.0/cards.md
+++ b/docs/4.0/cards.md
@@ -135,7 +135,7 @@ class Avo::Cards::UsersMetric < Avo::Cards::MetricCard
 end
 ```
 
-Entries are scoped to the current user and tenant, so a card querying `current_user` is safe to cache. Each [range](#ranges) is cached separately too, and on a resource card each record gets its own entry. If your `query` varies on something else, override `cache_hash` as shown in the [reference](./cards-api.html#self.cache_for).
+Entries are scoped to the current user and tenant, so a card querying `current_user` is safe to cache. Each [range](#ranges) is cached separately too, and on a resource card each record gets its own entry. If your `query` varies on something else, override `cache_key` as shown in the [reference](./cards-api.html#self.cache_for).
 
 :::warning
 Partial and HTML cards build their content at render time instead of running a `query`, so `cache_for` does nothing for them. Wrap the markup in Rails' own `cache` block instead.

--- a/docs/4.0/cards.md
+++ b/docs/4.0/cards.md
@@ -120,6 +120,27 @@ class Avo::Cards::UsersMetric < Avo::Cards::MetricCard
 end
 ```
 
+## Cache an expensive query
+
+When a card's `query` is slow — an aggregate over a large table, a call to an external service — you rarely need it recomputed on every page load. Give it [`cache_for`](./cards-api.html#self.cache_for) and Avo stores the result for that long, skipping the query entirely until it expires.
+
+```ruby{3}
+class Avo::Cards::UsersMetric < Avo::Cards::MetricCard
+  self.id = 'users_metric'
+  self.cache_for = 5.minutes
+
+  def query
+    result User.where(active: true).count
+  end
+end
+```
+
+Each [range](#ranges) is cached separately, and on a resource card each record gets its own entry. If your `query` reads anything else that should vary the result — `params`, the current user — override `cache_key` as shown in the [reference](./cards-api.html#self.cache_for).
+
+:::warning
+Partial and HTML cards build their content at render time instead of running a `query`, so `cache_for` does nothing for them. Wrap the markup in Rails' own `cache` block instead.
+:::
+
 ## Hide the header
 
 In cases where you need to embed some content that should fill the whole card (like a map, for example), you can choose to hide the label and ranges dropdown with [`display_header`](./cards-api.html#self.display_header).

--- a/docs/4.0/cards.md
+++ b/docs/4.0/cards.md
@@ -135,7 +135,7 @@ class Avo::Cards::UsersMetric < Avo::Cards::MetricCard
 end
 ```
 
-Each [range](#ranges) is cached separately, and on a resource card each record gets its own entry. If your `query` reads anything else that should vary the result — `params`, the current user — override `cache_key` as shown in the [reference](./cards-api.html#self.cache_for).
+Entries are scoped to the current user and tenant, so a card querying `current_user` is safe to cache. Each [range](#ranges) is cached separately too, and on a resource card each record gets its own entry. If your `query` varies on something else, override `cache_hash` as shown in the [reference](./cards-api.html#self.cache_for).
 
 :::warning
 Partial and HTML cards build their content at render time instead of running a `query`, so `cache_for` does nothing for them. Wrap the markup in Rails' own `cache` block instead.


### PR DESCRIPTION
Companion to avo-hq/workspace#87, which adds `self.cache_for` to cards. Closes avo-hq/avo#2171.

Follows the guide + reference split in `AGENTS.md`:

**`4.0/cards.md` (guide)** — a task section, *Cache an expensive query*, next to *Keep the data fresh*. Plain English, one code block, notes that ranges and resource records key separately, and warns that partial/HTML cards aren't covered.

**`4.0/cards-api.md` (reference)** — a `self.cache_for` `<Option>` after `self.refresh_every`, with type, default, what the cache key includes, and how to override `cache_key` when the query reads `params` or `current_user`. `cache_for` is also added to the registration-overrides example and its overridable-keys list.

https://claude.ai/code/session_01VobEkPpesFLsyvjA5L8GSd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Documents **`self.cache_for`**, which caches a card’s `query` result for a set duration so expensive work isn’t rerun on every load.
> 
> The **guide** (`cards.md`) adds a *Cache an expensive query* section beside *Keep the data fresh*, with a short example and notes on user/tenant scoping, per-range and per-resource keys, and that partial/HTML cards need Rails’ `cache` instead.
> 
> The **API reference** (`cards-api.md`) adds a full `self.cache_for` option (types, defaults, cache key parts, `cache_key` override, `Avo.configuration.cache_store`, multi-server staging caveat), and includes **`cache_for`** in the registration override example and overridable-keys list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3e90ef12ab55b5d646ea4576f37a2d8cf4a6ebb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->