### PR TITLE
docs(cards): document the manual card refresh control

### DIFF
--- a/docs/4.0/cards-api.md
+++ b/docs/4.0/cards-api.md
@@ -150,6 +150,10 @@ self.refresh_every = 10.minutes
 On [table](#self.fields)/[list](#self.fields) cards a refresh reloads the whole card, resetting the scroll position of a tall table. Prefer it on short cards.
 :::
 
+:::info
+This controls the interval only. Every card also renders a manual refresh control that needs no configuration — see [Refresh a card on demand](./cards.html#refresh-a-card-on-demand). Refreshing by hand restarts this countdown.
+:::
+
 </Option>
 
 <Option name="`self.cache_for`" headingSize="3">

--- a/docs/4.0/cards.md
+++ b/docs/4.0/cards.md
@@ -120,6 +120,16 @@ class Avo::Cards::UsersMetric < Avo::Cards::MetricCard
 end
 ```
 
+### Refresh a card on demand
+
+Sometimes an interval is the wrong tool — someone runs an action, comes back, and wants that one number brought up to date now. Every card renders a refresh control for exactly that. There is nothing to configure and no way to opt a card out; it is there on every card type.
+
+The control sits at the end of the card header, next to the ranges dropdown. On a card that renders no header at all, it floats in the card's top corner instead, so the card keeps its original height.
+
+A manual refresh re-runs only that card's query and swaps that card in place — the rest of the page is untouched. It keeps whatever range the viewer has selected rather than snapping back to `initial_range`, and preserves any dashboard filters that are applied.
+
+On a card that also sets `refresh_every`, refreshing by hand restarts that countdown.
+
 ## Cache an expensive query
 
 When a card's `query` is slow — an aggregate over a large table, a call to an external service — you rarely need it recomputed on every page load. Give it [`cache_for`](./cards-api.html#self.cache_for) and Avo stores the result for that long, skipping the query entirely until it expires.

--- a/docs/4.0/dashboards-api.md
+++ b/docs/4.0/dashboards-api.md
@@ -101,6 +101,23 @@ self.global_ranges = [7, 30, 60, 365]
 
 </Option>
 
+<Option name="`self.refresh_button`" headingSize="3">
+
+Renders a control next to the dashboard's title that reloads every card at once. Cards reload in place, so the page never navigates and each card keeps its selected range.
+
+```ruby
+self.refresh_button = true
+```
+
+- **Type:** Boolean
+- **Default:** `false`
+
+:::info
+Off by default because refreshing a dashboard runs every card's query at once. The [per-card control](./cards.html#refresh-a-card-on-demand) needs no opt-in and is always present.
+:::
+
+</Option>
+
 ## Visibility and authorization
 
 <Option name="`self.visible`" headingSize="3">

--- a/docs/4.0/dashboards.md
+++ b/docs/4.0/dashboards.md
@@ -81,6 +81,26 @@ end
 
 Each entry is a number of days; its button label comes from the `avo.<days>` translation key. The default is an empty array (no global range bar).
 
+## Refresh every card at once
+
+Every card [refreshes on its own](cards#refresh-a-card-on-demand) without any setup. A dashboard can also carry a single control that refreshes all of them together — useful on a screen someone leaves up all day. Turn it on with [`refresh_button`](dashboards-api#self.refresh_button):
+
+```ruby{4}
+class Avo::Dashboards::Dashy < Avo::Dashboards::BaseDashboard
+  self.id = "dashy"
+  self.name = "Dashy"
+  self.refresh_button = true
+
+  def cards
+    card Avo::Cards::UsersCount
+  end
+end
+```
+
+The control appears next to the dashboard's title and reloads each card in place, so the page never navigates — scroll position and every card's selected range survive the refresh.
+
+This one is off by default, unlike the per-card control. Refreshing a whole dashboard runs every card's query at once, so it's worth opting in deliberately on dashboards with expensive cards.
+
 ## Cards
 
 Dashboards host cards — metrics, charts, tables, lists, and custom content. You declare them in the `cards` method, as shown in the [generated dashboard](#generate-a-dashboard) above.


### PR DESCRIPTION
Documents the manual card refresh control shipping in [avo-hq/workspace#88](https://github.com/avo-hq/workspace/pull/88).

Every card now renders a refresh control next to the ranges dropdown — or floating in the card's top corner when the card has no header. It re-runs only that card's query, keeps the viewer's selected range instead of snapping back to `initial_range`, and preserves dashboard filters.

## What changed

| Page | Change |
| --- | --- |
| `cards.md` | New `### Refresh a card on demand` under the existing **Keep the data fresh** section, where the `refresh_every` interval is already covered |
| `cards-api.md` | An `:::info` cross-reference on `self.refresh_every` noting the manual control exists and that refreshing by hand restarts the countdown |

No new `<Option>`: the control carries no configuration and no per-card opt-out, so there is nothing to reference. Per `AGENTS.md` that makes this guide-only.

It's a `###` under **Keep the data fresh** rather than its own `##` because it serves the same reader goal — keeping a card's numbers current — and the guide is organised by goal rather than by machinery.

## Two things for you to decide

**1. How does this interact with `cache_for`?** I couldn't verify it. `cache_for` doesn't exist in the avo-dashboards checkout this branch was built against, so the docs here are ahead of the code I had. If a cached card replays its stored result, then a manual refresh on a card with `cache_for` set would *not* fetch fresh data — which is exactly the case a user clicking "refresh" expects to work. Worth confirming; if it's true it deserves a warning in both pages and I'm happy to add it.

**2. `self.display_header` appears to be dead.** Documented here in both `cards.md` ("Hide the header") and `cards-api.md`, and offered in the partial-card generator template — but nothing reads it. In `avo-dashboards` it's declared as a `class_attribute` and never referenced; the component decides via `label.present? || description.present? || ranges.present?`. So `self.display_header = false` looks like a no-op today. I've left both pages alone rather than delete documentation for something that may just need a two-line fix in the gem. Flagging so someone can pick which end to fix.

## Note on this branch

The local clone of this repo had 1987 commits of stale history — `main` was force-pushed at some point and the clone never caught up, so a branch cut from it shared no ancestry with the current `main` and GitHub refused the PR. This branch is cut fresh from `origin/main` and the edits re-applied on top of current content (which is why they sit around the newer `cache_for` section). Worth knowing if others' clones are in the same state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior in this repo.
> 
> **Overview**
> Documents the **manual per-card refresh control** (always on, no config) and the opt-in **dashboard-wide** refresh via `refresh_button`.
> 
> In **`cards.md`**, a new **Refresh a card on demand** subsection under **Keep the data fresh** explains placement (header vs corner), in-place Turbo reload, preserved range and dashboard filters, and that a manual refresh resets `refresh_every`. **`cards-api.md`** adds an `:::info` on `self.refresh_every` cross-linking that behavior.
> 
> In **`dashboards.md`** and **`dashboards-api.md`**, **`self.refresh_button`** is documented as a title-bar control that reloads all cards in place (default `false`), with a note that it runs every card’s query at once and that per-card refresh needs no opt-in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e15f3f644f8abea51dc4dee9fab5afdfcff46ea3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->