### PR TITLE
docs(card): rename Variants to Modifiers, drop card--full-width

### DIFF
--- a/docs/4.0/native-components/avo-card-component.md
+++ b/docs/4.0/native-components/avo-card-component.md
@@ -185,12 +185,21 @@ for this modifier when you're already passing a `class` string.
 Tightens the padding of the wrapper that surrounds the header, body, and footer.
 </Option>
 
-<Option name="`card--compact-header`">
+<Option name="`card--compact-header-y`">
 
-Reduces only the header padding, leaving the body spacing untouched.
+Shortens the header — reduces its vertical padding only, leaving the horizontal
+padding and the body spacing untouched.
+</Option>
+
+<Option name="`card--compact-header-x`">
+
+Narrows the header — reduces its horizontal padding only.
+
+Split per axis so a card can shorten its header without also narrowing it.
+Compose the two when you want both:
 
 ```erb
-<%= render ui.card(title: "Editor", class: "card--compact-wrapper card--compact-header") do %>
+<%= render ui.card(title: "Editor", class: "card--compact-header-y card--compact-header-x") do %>
   ...
 <% end %>
 ```

--- a/docs/4.0/native-components/avo-card-component.md
+++ b/docs/4.0/native-components/avo-card-component.md
@@ -68,7 +68,7 @@ changes. It's equivalent to adding the `card--padded` CSS modifier via `class`.
 <Option name="`class`">
 
 A list of CSS classes applied to the outer `.card` container. This is also how you
-apply the built-in [variants](#variants).
+apply the built-in [modifiers](#modifiers).
 
 ```erb
 <%= render ui.card(title: "Card", class: "ring-2 ring-blue-500") do %>
@@ -170,9 +170,9 @@ The lowest area of the card, rendered under the body. Handy for actions or pagin
 ```
 </Option>
 
-## Variants
+## Modifiers
 
-Variants are applied through the `class` option. Combine them as needed.
+Modifiers are applied through the `class` option. Combine them as needed.
 
 <Option name="`card--padded`">
 
@@ -180,22 +180,17 @@ Adds the standard body padding. Equivalent to the [`padded`](#padded) option —
 for this modifier when you're already passing a `class` string.
 </Option>
 
-<Option name="`card--compact`">
+<Option name="`card--compact-wrapper`">
 
-Tightens the spacing of the wrapper and header for a denser card.
+Tightens the padding of the wrapper that surrounds the header, body, and footer.
 </Option>
 
 <Option name="`card--compact-header`">
 
 Reduces only the header padding, leaving the body spacing untouched.
-</Option>
-
-<Option name="`card--full-width`">
-
-Makes the card span the full width of its container.
 
 ```erb
-<%= render ui.card(title: "Editor", class: "card--full-width card--compact-header") do %>
+<%= render ui.card(title: "Editor", class: "card--compact-wrapper card--compact-header") do %>
   ...
 <% end %>
 ```


### PR DESCRIPTION
Companion to avo-hq/avo#4669.

The card page called these "Variants", which read like they were mutually exclusive and set through a `variant:` option. They're neither — they're CSS modifiers applied via `class:` and meant to be combined. Renamed the section accordingly.

| Before | After |
|---|---|
| `card--full-width` | removed — the modifier is gone from core |
| `card--compact` | `card--compact-wrapper`, description now says wrapper padding only |
| `card--compact-header` | `card--compact-header-y` + `card--compact-header-x`, documented separately |

The compose example now shows the two axes together, which is what avo-dashboards does.

## Merge order

Merge alongside or after avo-hq/avo#4669 so the docs don't describe classes that haven't shipped.