### PR TITLE
docs(cards): document display_header's block form and corner refresh

### DIFF
--- a/docs/4.0/cards-api.md
+++ b/docs/4.0/cards-api.md
@@ -117,7 +117,9 @@ Whether the card header (label and ranges dropdown) is rendered. Set it to `fals
 self.display_header = false
 ```
 
-- **Type:** Boolean
+As a Proc it has access to `card`, `parent`, `dashboard` (nil when the parent is a resource), and `resource` (nil when the parent is a dashboard).
+
+- **Type:** Boolean (or Proc returning one)
 - **Default:** `true`
 
 </Option>

--- a/docs/4.0/cards.md
+++ b/docs/4.0/cards.md
@@ -24,7 +24,7 @@ All these settings can be set to a lambda.
 
 The lambda will be executed using [`Avo::ExecutionContext`](execution-context). Within this blocks, you gain access to all attributes of [`Avo::ExecutionContext`](execution-context) along with the `parent`, `resource`, `dashboard` and `card`.
 
-```ruby{2-8}
+```ruby{2-7}
 class Avo::Cards::UsersMetric < Avo::Cards::MetricCard
   self.id = "users_metric"
   self.label = -> { "Users count" }
@@ -32,9 +32,12 @@ class Avo::Cards::UsersMetric < Avo::Cards::MetricCard
   self.discreet_description = -> { "How this number is calculated" }
   self.cols = 1
   self.rows = 1
-  self.display_header = true
 end
 ```
+
+:::warning
+Not every card setting takes a lambda. [`display_header`](./cards-api.html#self.display_header) is a plain boolean — a lambda is always truthy, so `-> { false }` would keep the header. Check the [API reference](./cards-api.html) for each option's type.
+:::
 
 <Image src="/assets/img/4_0/cards/metric.webp" dark-src="/assets/img/4_0/cards/metric-dark.webp" width="353" height="182" alt="An Avo metric card titled “Users count” showing a large number with a range dropdown in its header." />
 
@@ -124,7 +127,7 @@ end
 
 Sometimes an interval is the wrong tool — someone runs an action, comes back, and wants that one number brought up to date now. Every card renders a refresh control for exactly that. There is nothing to configure and no way to opt a card out; it is there on every card type.
 
-The control sits at the end of the card header, next to the ranges dropdown. On a card that renders no header at all, it floats in the card's top corner instead, so the card keeps its original height.
+The control sits at the end of the card header, next to the ranges dropdown. On a card that renders no header at all — one with no label, description, or ranges, or one that [hides its header](#hide-the-header) — it floats in the card's top corner instead, so the card keeps its original height.
 
 A manual refresh re-runs only that card's query and swaps that card in place — the rest of the page is untouched. It keeps whatever range the viewer has selected rather than snapping back to `initial_range`, and preserves any dashboard filters that are applied.
 
@@ -413,7 +416,7 @@ class Avo::Cards::ExampleCustomPartial < Avo::Cards::PartialCard
   self.cols = 1
   self.rows = 4
   self.partial = "avo/cards/custom_card"
-  # self.display_header = true
+  # self.display_header = false
 end
 ```
 

--- a/docs/4.0/cards.md
+++ b/docs/4.0/cards.md
@@ -24,7 +24,7 @@ All these settings can be set to a lambda.
 
 The lambda will be executed using [`Avo::ExecutionContext`](execution-context). Within this blocks, you gain access to all attributes of [`Avo::ExecutionContext`](execution-context) along with the `parent`, `resource`, `dashboard` and `card`.
 
-```ruby{2-7}
+```ruby{2-8}
 class Avo::Cards::UsersMetric < Avo::Cards::MetricCard
   self.id = "users_metric"
   self.label = -> { "Users count" }
@@ -32,12 +32,9 @@ class Avo::Cards::UsersMetric < Avo::Cards::MetricCard
   self.discreet_description = -> { "How this number is calculated" }
   self.cols = 1
   self.rows = 1
+  self.display_header = true
 end
 ```
-
-:::warning
-Not every card setting takes a lambda. [`display_header`](./cards-api.html#self.display_header) is a plain boolean — a lambda is always truthy, so `-> { false }` would keep the header. Check the [API reference](./cards-api.html) for each option's type.
-:::
 
 <Image src="/assets/img/4_0/cards/metric.webp" dark-src="/assets/img/4_0/cards/metric-dark.webp" width="353" height="182" alt="An Avo metric card titled “Users count” showing a large number with a range dropdown in its header." />
 
@@ -163,6 +160,12 @@ class Avo::Cards::UsersMetric < Avo::Cards::MetricCard
   self.id = 'users_metric'
   self.display_header = false
 end
+```
+
+Like the other base settings it also takes a block, so the header can come and go with the viewer or the card's parent.
+
+```ruby
+self.display_header = -> { !parent.is_a?(Avo::Dashboards::Kiosk) }
 ```
 
 <Image src="/assets/img/4_0/cards/map.webp" dark-src="/assets/img/4_0/cards/map-dark.webp" width="1428" height="1056" alt="An Avo partial card embedding a Google Maps view of Manhattan, rendered flush to the card edges because the card header is hidden." />


### PR DESCRIPTION
Docs half of [AVO-1560](https://linear.app/avo-hq/issue/AVO-1560/selfdisplay-header-is-documented-and-generated-but-never-read). Pairs with avo-hq/workspace#93, which makes `self.display_header` actually work — until now it was declared, documented, and offered in a generator template, but no code path read it.

The prose describing what the option *does* was already right. These are the spots around it that weren't.

## 1. The block form

`cards.md` "Base settings" lists `self.display_header = true` in the example under **"All these settings can be set to a lambda"**, but the reader read the class attribute raw — and a Proc is truthy, so `-> { false }` kept the header. avo-hq/workspace#93 now resolves it through `Avo::ExecutionContext` like every neighbouring setting, so that example is correct and stays as it is.

What changes here is the reference, which claimed **Type Boolean** flat: it now reads **Boolean (or Proc returning one)** with its block locals spelled out, matching how `cols`, `rows`, and `visible` are written. The guide gains a worked block example.

> The first commit on this branch did the opposite — it removed the line and added a warning saying the option is boolean-only. That was the right read of the code at the time; the second commit reverses it now that the code supports blocks. Squashing on merge collapses both.

## 2. Corner refresh placement

The refresh-control section said the control floats in the card's top corner "on a card that renders no header at all". True, and now reachable deliberately via `display_header` — so it links to that section rather than leaving it to be inferred.

## 3. Generator hint

The partial-card example showed `# self.display_header = true`. Uncommenting it does nothing, since that's the default. Flipped to `false`, matching the template change in avo-hq/workspace#93.

## Verification

`yarn build` clean on both revisions (152 pages, dead-link check passes on the new `#hide-the-header` anchor). The `llms.txt` / `docs-map.md` regeneration in the AGENTS.md checklist is a no-op — both files are gitignored, so there's nothing to commit; that checklist line looks stale.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes with no runtime or security impact.
> 
> **Overview**
> **Documentation-only** update for card `self.display_header`, aligned with the engine change that actually reads this option.
> 
> The **Cards API** reference now treats `display_header` like `cols`/`rows`: **Boolean or Proc**, with Proc scope documented (`card`, `parent`, `dashboard`, `resource`).
> 
> The **Cards guide** adds a Proc example under **Hide the header**, clarifies that the on-demand refresh control moves to the card corner when the header is hidden (including via `display_header`, with a link to that section), and changes the partial-card snippet comment from `# self.display_header = true` to `# self.display_header = false` so uncommenting demonstrates hiding the header instead of a no-op default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91d18c6f9fcc7bc4dc9b568d631c83b78738f73c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->