### PR TITLE
docs(cards): a manual refresh bypasses cache_for

### DIFF
--- a/docs/4.0/cards-api.md
+++ b/docs/4.0/cards-api.md
@@ -182,6 +182,10 @@ Avo caches through `Avo.configuration.cache_store`. The key is scoped to the cur
 - **Type:** `ActiveSupport::Duration` (or seconds as an Integer), or a Proc returning one
 - **Default:** `nil` (no caching)
 
+:::info
+The card's [refresh control](./cards.html#refresh-a-card-on-demand) bypasses the cache: clicking it re-runs the `query` and rewrites the entry, so the card never animates over a stale value. Because the key is per user, that only busts the clicker's own entry. [`self.refresh_every`](#self.refresh_every) polling does *not* bypass it — pair the two to poll a card often while querying rarely.
+:::
+
 :::warning
 Cards with no `query` — [HTML](#html-card) and [partial](#self.partial) cards — build their content at render time, so `cache_for` does nothing for them. Wrap the markup in Rails' own `cache` block instead.
 :::

--- a/docs/4.0/cards.md
+++ b/docs/4.0/cards.md
@@ -128,7 +128,7 @@ The control sits at the end of the card header, next to the ranges dropdown. On 
 
 A manual refresh re-runs only that card's query and swaps that card in place — the rest of the page is untouched. It keeps whatever range the viewer has selected rather than snapping back to `initial_range`, and preserves any dashboard filters that are applied.
 
-On a card that also sets `refresh_every`, refreshing by hand restarts that countdown.
+On a card that also sets `refresh_every`, refreshing by hand restarts that countdown. On one that sets [`cache_for`](#cache-an-expensive-query), it bypasses the cache and re-runs the query.
 
 ## Cache an expensive query
 
@@ -146,6 +146,8 @@ end
 ```
 
 Entries are scoped to the current user and tenant, so a card querying `current_user` is safe to cache. Each [range](#ranges) is cached separately too, and on a resource card each record gets its own entry. If your `query` varies on something else, override `cache_key` as shown in the [reference](./cards-api.html#self.cache_for).
+
+Someone clicking the card's [refresh control](#refresh-a-card-on-demand) is asking for current data, so that click re-runs the `query` and rewrites the entry — but only their own, since the key is per user. Automatic `refresh_every` polling still respects `cache_for`, which is what makes the two worth pairing: poll often, query rarely.
 
 :::warning
 Partial and HTML cards build their content at render time instead of running a `query`, so `cache_for` does nothing for them. Wrap the markup in Rails' own `cache` block instead.


### PR DESCRIPTION
Docs half of [AVO-1559](https://linear.app/avo-hq/issue/AVO-1559/a-manual-card-refresh-does-not-bypass-cache-for). Code half: avo-hq/workspace#96.

`cards.md` and `cards-api.md` each described the card refresh control and `cache_for` in full, and never mentioned that they interact — so the only way to find out which one wins was to click the control and compare timestamps.

Both pages now say it:

- **The control bypasses the cache.** Clicking it re-runs the `query` and rewrites the entry, so the card never animates over a stale value.
- **It busts one entry, not the pool.** The cache key is per user, so a refresh only affects the person who clicked.
- **`refresh_every` polling does *not* bypass it.** That's what makes pairing the two worthwhile: poll often, query rarely.

Also adds a pointer from the refresh section to the caching section and back, since a reader hitting either one is likely to want the other.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Documents how the card **refresh control** interacts with **`cache_for`**, which the cards guide and API reference previously described separately.
> 
> **Manual refresh** re-runs the `query`, bypasses the cache, and rewrites that user’s cache entry so the UI does not animate over stale data. **`refresh_every`** polling still honors `cache_for`; the docs call out pairing both so cards can poll often while querying rarely.
> 
> Cross-links were added between the on-demand refresh section and the caching section in `cards.md`, plus an info callout under `self.cache_for` in `cards-api.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 765c8da7753af775971ba7bdb9fc4624a680990a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->