### PR TITLE
docs(cards): the per-card refresh control is opt-in

### DIFF
--- a/docs/4.0/cards-api.md
+++ b/docs/4.0/cards-api.md
@@ -153,7 +153,26 @@ On [table](#self.fields)/[list](#self.fields) cards a refresh reloads the whole 
 :::
 
 :::info
-This controls the interval only. Every card also renders a manual refresh control that needs no configuration — see [Refresh a card on demand](./cards.html#refresh-a-card-on-demand). Refreshing by hand restarts this countdown.
+This controls the interval only. A card can also carry a manual refresh control — see [`self.refresh_button`](#self.refresh_button). Refreshing by hand restarts this countdown.
+:::
+
+</Option>
+
+<Option name="`self.refresh_button`" headingSize="3">
+
+Renders a manual refresh control on the card, so a viewer can bring that one card up to date without reloading the page.
+
+```ruby
+self.refresh_button = true
+```
+
+- **Type:** Boolean
+- **Default:** `false`
+
+The control sits at the end of the card header, or in the card's top corner when it renders no header. See [Refresh a card on demand](./cards.html#refresh-a-card-on-demand) for how it behaves.
+
+:::info
+Same name and same default as the dashboard's [`refresh_button`](./dashboards-api.html#self.refresh_button), which refreshes every card at once. Setting it on a dashboard does not turn it on for that dashboard's cards — the two are independent.
 :::
 
 </Option>

--- a/docs/4.0/cards.md
+++ b/docs/4.0/cards.md
@@ -122,7 +122,16 @@ end
 
 ### Refresh a card on demand
 
-Sometimes an interval is the wrong tool — someone runs an action, comes back, and wants that one number brought up to date now. Every card renders a refresh control for exactly that. There is nothing to configure and no way to opt a card out; it is there on every card type.
+Sometimes an interval is the wrong tool — someone runs an action, comes back, and wants that one number brought up to date now. A card can carry a refresh control for exactly that. Turn it on with [`refresh_button`](./cards-api.html#self.refresh_button):
+
+```ruby{3}
+class Avo::Cards::UsersMetric < Avo::Cards::MetricCard
+  self.id = 'users_metric'
+  self.refresh_button = true
+end
+```
+
+It's off by default, matching the [dashboard-wide button](./dashboards.html#refresh-every-card-at-once). Put it on the cards where re-running the query means something — an HTML or partial card re-renders identical content, so a control there does nothing.
 
 The control sits at the end of the card header, next to the ranges dropdown. On a card that renders no header at all — one with no label, description, or ranges, or one that [hides its header](#hide-the-header) — it floats in the card's top corner instead, so the card keeps its original height.
 

--- a/docs/4.0/dashboards-api.md
+++ b/docs/4.0/dashboards-api.md
@@ -113,7 +113,7 @@ self.refresh_button = true
 - **Default:** `false`
 
 :::info
-Off by default because refreshing a dashboard runs every card's query at once. The [per-card control](./cards.html#refresh-a-card-on-demand) needs no opt-in and is always present.
+Off by default because refreshing a dashboard runs every card's query at once. The [per-card control](./cards-api.html#self.refresh_button) is a separate opt-in under the same name — setting one does not set the other.
 :::
 
 </Option>

--- a/docs/4.0/dashboards.md
+++ b/docs/4.0/dashboards.md
@@ -83,7 +83,7 @@ Each entry is a number of days; its button label comes from the `avo.<days>` tra
 
 ## Refresh every card at once
 
-Every card [refreshes on its own](cards#refresh-a-card-on-demand) without any setup. A dashboard can also carry a single control that refreshes all of them together — useful on a screen someone leaves up all day. Turn it on with [`refresh_button`](dashboards-api#self.refresh_button):
+A card can carry [its own refresh control](cards#refresh-a-card-on-demand). A dashboard can also carry a single control that refreshes all of them together — useful on a screen someone leaves up all day. Turn it on with [`refresh_button`](dashboards-api#self.refresh_button):
 
 ```ruby{4}
 class Avo::Dashboards::Dashy < Avo::Dashboards::BaseDashboard
@@ -99,7 +99,9 @@ end
 
 The control appears next to the dashboard's title and reloads each card in place, so the page never navigates — scroll position and every card's selected range survive the refresh.
 
-This one is off by default, unlike the per-card control. Refreshing a whole dashboard runs every card's query at once, so it's worth opting in deliberately on dashboards with expensive cards.
+It's off by default, as the [per-card control](cards-api#self.refresh_button) is. Refreshing a whole dashboard runs every card's query at once, so it's worth opting in deliberately on dashboards with expensive cards.
+
+Setting it here does not turn on the per-card controls; the two are independent, and a dashboard button reloads every card whether or not the cards carry one.
 
 ## Cards
 

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -6,6 +6,31 @@ If you're looking for the Avo 3 to Avo 4 upgrade guide, please visit [the dedica
 
 Migrating to TailwindCSS 4? See the [TailwindCSS 4 Migration Guide](./tailwind-4-migration).
 
+## Unreleased — avo-dashboards
+
+<Option name="The per-card refresh control is now opt-in">
+
+### Breaking Change
+
+`avo-dashboards` 4.0.8 rendered a manual refresh control on every card, with no way to opt out. It is now off by default and turned on per card with [`refresh_button`](./cards-api.html#self.refresh_button), matching the dashboard-wide button that shipped alongside it.
+
+Two controls doing the same job with opposite defaults was harder to learn than either default alone, and the card control rendered on HTML and partial cards too, where refreshing re-renders identical content.
+
+### Action Required
+
+If you were relying on the card controls, add `self.refresh_button = true` to the cards that should keep one:
+
+```ruby
+class Avo::Cards::UsersMetric < Avo::Cards::MetricCard
+  self.id = "users_metric"
+  self.refresh_button = true # [!code ++]
+end
+```
+
+Nothing changes for the dashboard-wide `refresh_button` — it keeps its own default, and it still reloads every card whether or not those cards carry a control of their own.
+
+</Option>
+
 ## Unreleased — resizable sidebar
 
 <Option name="Sidebar labels truncate instead of wrapping">

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -6,31 +6,6 @@ If you're looking for the Avo 3 to Avo 4 upgrade guide, please visit [the dedica
 
 Migrating to TailwindCSS 4? See the [TailwindCSS 4 Migration Guide](./tailwind-4-migration).
 
-## Unreleased — avo-dashboards
-
-<Option name="The per-card refresh control is now opt-in">
-
-### Breaking Change
-
-`avo-dashboards` 4.0.8 rendered a manual refresh control on every card, with no way to opt out. It is now off by default and turned on per card with [`refresh_button`](./cards-api.html#self.refresh_button), matching the dashboard-wide button that shipped alongside it.
-
-Two controls doing the same job with opposite defaults was harder to learn than either default alone, and the card control rendered on HTML and partial cards too, where refreshing re-renders identical content.
-
-### Action Required
-
-If you were relying on the card controls, add `self.refresh_button = true` to the cards that should keep one:
-
-```ruby
-class Avo::Cards::UsersMetric < Avo::Cards::MetricCard
-  self.id = "users_metric"
-  self.refresh_button = true # [!code ++]
-end
-```
-
-Nothing changes for the dashboard-wide `refresh_button` — it keeps its own default, and it still reloads every card whether or not those cards carry a control of their own.
-
-</Option>
-
 ## Unreleased — resizable sidebar
 
 <Option name="Sidebar labels truncate instead of wrapping">


### PR DESCRIPTION
Docs half of AVO-1566. Pairs with avo-hq/workspace#98, which gives `Avo::Cards::BaseCard` a `refresh_button` attribute matching the dashboard's.

Four pages currently state that the card control is always present and needs no configuration. Two of them draw the contrast with the dashboard button explicitly, so once #98 lands they say the exact opposite of what ships.

| Page | Change |
| --- | --- |
| `4.0/cards.md` | "Refresh a card on demand" — replaces "nothing to configure and no way to opt a card out" with the `refresh_button` example and a note on why HTML/partial cards are poor candidates |
| `4.0/cards-api.md` | New `self.refresh_button` option; fixes `self.refresh_every`'s note, which pointed at a control that "needs no configuration" |
| `4.0/dashboards.md` | "Every card refreshes on its own without any setup" and "off by default, unlike the per-card control" both inverted; adds that a dashboard button reloads every card whether or not the cards carry one |
| `4.0/dashboards-api.md` | Same stale claim inside the `self.refresh_button` info block |
| `4.0/upgrade.md` | Breaking Change entry under `## Unreleased` |

The two `refresh_button` reference entries now cross-link, each saying setting one doesn't set the other — that ambiguity is the likeliest way to read the shared name wrong.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior in this diff.
> 
> **Overview**
> Documentation is aligned with **AVO-1566** / workspace#98: the manual refresh control on cards is **`self.refresh_button`**, off by default, instead of always present with no way to disable it.
> 
> The **Cards** guide’s “Refresh a card on demand” section adds the `refresh_button = true` example and notes that HTML/partial cards are poor candidates. **`cards-api.md`** documents the new **`self.refresh_button`** option and updates **`self.refresh_every`** to point at it instead of an always-on control.
> 
> **Dashboard** guide and API copy no longer say every card refreshes on its own without setup or that the per-card button differs from the dashboard default in the old way. Both **`refresh_button`** entries now state that dashboard and card settings share a name but are **independent**—enabling one does not enable the other, and the dashboard control still reloads all cards regardless of per-card buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76547ae8e405cadcbe3e35b914ca514e76f518e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->