### PR TITLE
docs: collapse the three sidebar configs into config.sidebar

### DIFF
--- a/docs/4.0/customization-api.md
+++ b/docs/4.0/customization-api.md
@@ -329,49 +329,30 @@ When a specific key and a group alias target the same view, the specific key win
 
 </Option>
 
-<Option name="`sidebar_toggle_visible`" headingSize="3">
+<Option name="`sidebar`" headingSize="3">
 
-Shows or hides the navbar button that collapses the sidebar on desktop. When `false`, the sidebar stays permanently open on desktop. On mobile the toggle is always visible.
-
-```ruby
-config.sidebar_toggle_visible = false
-```
-
-- **Type:** Boolean
-- **Default:** `true`
-
-</Option>
-
-<Option name="`sidebar_default_width`" headingSize="3">
-
-Width in pixels the desktop sidebar starts at before a user drags it. See the [Resizable sidebar](./customization.html#resizable-sidebar) guide.
+The sidebar's three knobs, in one hash merged over the defaults.
 
 ```ruby
-config.sidebar_default_width = 320
+config.sidebar = {
+  toggle_visible: true, # show the navbar button that collapses the sidebar on desktop
+  resizable: true,      # render the drag-to-resize handle
+  default_width: 256    # width in pixels the desktop sidebar starts at
+}
 ```
 
-Clamped into the same 200–480 range as dragging, so the handle can always drag back to it. A value Avo cannot read as an integer falls back to `256` rather than clamping to the minimum.
+`toggle_visible` — when `false` the sidebar stays permanently open on desktop. On mobile the toggle is always visible.
 
-Applies at `lg` (1024px) and wider only. Below that the sidebar is a full-height overlay and keeps its 256px default, so a wide value cannot cover a small screen. A width the user has dragged to takes precedence over this setting.
+`resizable` — when `false` the handle is neither rendered nor wired up, and the sidebar stays at `default_width`. Resizing is a drag-only gesture and so does not satisfy [WCAG 2.2 SC 2.5.7 (Dragging Movements)](https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html). Set this to `false` if you are working to an AA conformance claim or a VPAT.
 
-- **Type:** Integer
-- **Default:** `256`
-- **Values:** `200`–`480` — values outside the range are clamped; unparseable values fall back to the default
+`default_width` — where the sidebar starts before a user drags it. See the [Resizable sidebar](./customization.html#resizable-sidebar) guide. Clamped into the same 200–480 range as dragging, so the handle can always drag back to it. A value Avo cannot read as an integer falls back to `256` rather than clamping to the minimum. It applies at `lg` (1024px) and wider only — below that the sidebar is a full-height overlay and keeps its 256px default, so a wide value cannot cover a small screen. A width the user has dragged to takes precedence.
 
-</Option>
+- **Type:** Hash, merged over the defaults
+- **Default:** `{ toggle_visible: true, resizable: true, default_width: 256 }`
 
-<Option name="`sidebar_resizable`" headingSize="3">
-
-Whether the sidebar's drag-to-resize handle is rendered. When `false` the handle is neither rendered nor wired up, and the sidebar stays at [`sidebar_default_width`](#sidebar_default_width).
-
-```ruby
-config.sidebar_resizable = false
-```
-
-Resizing is a drag-only gesture and so does not satisfy [WCAG 2.2 SC 2.5.7 (Dragging Movements)](https://www.w3.org/WAI/WCAG22/Understanding/dragging-movements.html). Set this to `false` if you are working to an AA conformance claim or a VPAT.
-
-- **Type:** Boolean
-- **Default:** `true`
+:::info Replaces `sidebar_toggle_visible`
+`config.sidebar_toggle_visible = false` still works and writes into `config.sidebar[:toggle_visible]`, but `config.sidebar` is the canonical home.
+:::
 
 </Option>
 

--- a/docs/4.0/customization.md
+++ b/docs/4.0/customization.md
@@ -203,12 +203,12 @@ config.container_width = { single: :full, show: :small }
 
 ## Toggle the sidebar button visibility
 
-By default, Avo displays a toggle button in the navbar that allows users to collapse and expand the sidebar on desktop. Hide it with [`sidebar_toggle_visible`](./customization-api.html#sidebar_toggle_visible) — the sidebar then stays permanently open on desktop. On mobile, the sidebar toggle is always visible regardless of this setting.
+By default, Avo displays a toggle button in the navbar that allows users to collapse and expand the sidebar on desktop. Hide it with [`sidebar[:toggle_visible]`](./customization-api.html#sidebar) — the sidebar then stays permanently open on desktop. On mobile, the sidebar toggle is always visible regardless of this setting.
 
 ```ruby
 # config/initializers/avo.rb
 Avo.configure do |config|
-  config.sidebar_toggle_visible = false
+  config.sidebar = {toggle_visible: false}
 end
 ```
 
@@ -234,12 +234,12 @@ Resizing is desktop-only. Below the `lg` breakpoint (1024px) the sidebar is a fu
 
 ### Change the starting width
 
-Set [`sidebar_default_width`](./customization-api.html#sidebar_default_width) to change where the sidebar starts before a user drags it — useful when your resource names are consistently long.
+Set [`sidebar[:default_width]`](./customization-api.html#sidebar) to change where the sidebar starts before a user drags it — useful when your resource names are consistently long.
 
 ```ruby
 # config/initializers/avo.rb
 Avo.configure do |config|
-  config.sidebar_default_width = 320 # [!code focus]
+  config.sidebar = {default_width: 320} # [!code focus]
 end
 ```
 
@@ -247,12 +247,12 @@ The value is in pixels and is clamped to the same 200–480 range as dragging, s
 
 ### Turn resizing off
 
-Set [`sidebar_resizable`](./customization-api.html#sidebar_resizable) to `false` to remove the handle entirely. The sidebar then stays at its configured width and behaves exactly as it did before.
+Set [`sidebar[:resizable]`](./customization-api.html#sidebar) to `false` to remove the handle entirely. The sidebar then stays at its configured width and behaves exactly as it did before.
 
 ```ruby
 # config/initializers/avo.rb
 Avo.configure do |config|
-  config.sidebar_resizable = false # [!code focus]
+  config.sidebar = {resizable: false} # [!code focus]
 end
 ```
 

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -16,7 +16,7 @@ The sidebar is now [resizable](./customization.html#resizable-sidebar), and as p
 
 **Action required:** None for most apps. If your navigation relied on long labels wrapping, either shorten the labels or point users at the drag handle to widen the sidebar.
 
-Hosts with an accessibility conformance obligation can disable the drag handle with [`sidebar_resizable`](./customization-api.html#sidebar_resizable).
+Hosts with an accessibility conformance obligation can disable the drag handle with [`sidebar[:resizable]`](./customization-api.html#sidebar).
 
 </Option>
 


### PR DESCRIPTION
Follows avo-hq/avo#4671, which merges `sidebar_toggle_visible`, `sidebar_resizable` and `sidebar_default_width` into a single `config.sidebar` hash.

- `customization-api.md` — the three `<Option>` blocks become one `sidebar` option, with a note that `sidebar_toggle_visible` still works and writes into the hash.
- `customization.md` — the toggle-visibility and resizable-sidebar snippets and their anchor links.
- `upgrade.md` — the `sidebar_resizable` link in the sidebar-truncation entry.

Screenshot `alt`/`prompt` strings are left untouched so they stay in sync with `tools/screenshots/specs.mjs`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or application code impact.
> 
> **Overview**
> Documentation now treats **`config.sidebar`** as the single place for sidebar behavior, matching avo-hq/avo#4671.
> 
> **`customization-api.md`** replaces three separate `<Option>` entries (`sidebar_toggle_visible`, `sidebar_default_width`, `sidebar_resizable`) with one **`sidebar`** hash (`toggle_visible`, `resizable`, `default_width`) and notes that `config.sidebar_toggle_visible` still works as a backward-compatible alias.
> 
> **`customization.md`** updates initializer snippets and anchor links for hiding the toggle, setting default width, and disabling resize to use `config.sidebar = { ... }` instead of the old top-level keys.
> 
> **`upgrade.md`** points the accessibility note at `sidebar[:resizable]` on the unified option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c4ada2b514cd77f73f14ab4d6e850052fbb758c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->