### PR TITLE
docs: upgrade note for the opt-in card refresh control, and trial licensing state

### DIFF
--- a/docs/4.0/license-troubleshooting.md
+++ b/docs/4.0/license-troubleshooting.md
@@ -30,6 +30,14 @@ In order to check that, use the status page described above.
 
 </Option>
 
+<Option name="The sidebar status indicator is amber">
+
+Amber is not a license failure — it's a running trial that needs attention, either because no payment method is on file or because the subscription behind it was cancelled. Access continues until the date the status page reports.
+
+The status page names which of the two applies and lists the steps. See [Licensing → Fix a trial at risk](./licensing.html#fix-a-trial-at-risk) for the full picture.
+
+</Option>
+
 <Option name="License check blocked in the test suite">
 
 Avo 4 verifies the license through an outbound request to `clerk-1.avohq.io` (falling back to `clerk-2.avohq.io`). If your test suite disables outbound network connections (for example with WebMock or VCR `disable_net_connect!`), that request is blocked and unrelated tests fail with `WebMock::NetConnectNotAllowedError`.

--- a/docs/4.0/licensing.md
+++ b/docs/4.0/licensing.md
@@ -75,6 +75,25 @@ end
 
 You can purchase a license from the [pricing](https://avohq.io/pricing) page.
 
+## Trials
+
+A trial is a fully valid license. Every add-on it covers behaves exactly as it does on a paid license for as long as the trial runs, and nothing in your app is gated or degraded while it does.
+
+The [license status page](./license-troubleshooting.html#check-the-license-status-page) is where the trial reports itself: when access stops, and whether a payment method is on file. It also says when this app last checked in with Avo HQ, because the state you're reading is the one from that check.
+
+### Fix a trial at risk
+
+The **Avo Status** indicator in the sidebar footer is green while everything is in order, amber while a trial needs attention, and orange when the license is invalid. Amber means one of two things, and the remedy is different for each:
+
+- **No payment method on file.** Access stops on the trial's end date. Add a payment method on the [Avo HQ Licenses](https://avohq.io/licenses) page.
+- **The subscription behind the trial was cancelled.** Access stops on the cancellation date, which the status page reports as the trial's end date. Adding a payment method does not change that — resume the subscription, or resubscribe, on the same page.
+
+The status page spells out which of the two you're in and lists the steps for it. Once you've done them, press **Refresh license** on that page: Avo caches the license response between checks, so the app can show older billing state than avohq.io until it refreshes.
+
+:::info
+Trial state requires `avo-licensing` `4.0.10` or newer. The amber indicator requires Avo `4.0.20` or newer — an older Avo renders the dot without color rather than breaking.
+:::
+
 ## License validation
 
 ### "Phone home" mechanism

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -30,6 +30,32 @@ Hosts with an accessibility conformance obligation can disable the drag handle w
 
 </Option>
 
+## Upgrade to `avo-dashboards` `4.0.9`
+
+<Option name="The per-card refresh control is opt-in">
+
+### Breaking Change
+
+`avo-dashboards` `4.0.8` rendered a [refresh control](./cards.html#refresh-a-card-on-demand) on every card, with no way to remove it — including on `html` and static `partial` cards, where refreshing re-renders identical content. The control is now off by default and turns on per card with [`refresh_button`](./cards-api.html#self.refresh_button), the same name and the same default as the [dashboard-wide control](./dashboards-api.html#self.refresh_button) that shipped alongside it.
+
+**Action required:** None unless you were on `4.0.8` and want the control kept on a card.
+
+### Maintaining Previous Behavior
+
+Turn it back on for each card that should keep it:
+
+```ruby
+# app/avo/cards/users_metric.rb
+class Avo::Cards::UsersMetric < Avo::Cards::MetricCard
+  self.id = 'users_metric'
+  self.refresh_button = true # [!code ++]
+end
+```
+
+Setting it on a dashboard does not turn it on for that dashboard's cards — the two controls are independent opt-ins under the same name.
+
+</Option>
+
 ## Upgrade to 4.0.18
 
 <Option name="Resource and field translations are used verbatim">


### PR DESCRIPTION
Daily docs sweep over yesterday's `avo-hq/avo` and `avo-hq/workspace` commits. Most of the day was already documented — the sidebar `config.sidebar` collapse (#588), the per-card refresh control (#587), `cache_for` interaction (#586), and `display_header` (#585) all landed. Two things were left over.

## `avo-dashboards` 4.0.9 — the per-card refresh control is opt-in

[avo-hq/workspace#98](https://github.com/avo-hq/workspace/pull/98) made `refresh_button` default to `false` on cards after 4.0.8 shipped the control on every card with no way out. The commit says the upgrade-guide entry goes out with the docs; the cards and dashboards pages describe the new default, but `upgrade.md` never got the entry. An app on 4.0.8 loses its card controls on `bundle update` with no name to grep for.

Adds `## Upgrade to `avo-dashboards` `4.0.9`` with the restore snippet, and the note that the dashboard-wide control is a separate opt-in under the same name.

## `avo-licensing` 4.0.10 — trial state in the app

[avo-hq/workspace#94](https://github.com/avo-hq/workspace/pull/94) surfaces trial and payment status on the license status page, and [avo-hq/avo#4670](https://github.com/avo-hq/avo/pull/4670) added the amber variant of the sidebar status indicator that an at-risk trial turns on. The docs had no mention of trials at all, so an amber dot had no explanation anywhere.

Adds a `## Trials` section to `licensing.md` covering that a trial is a fully valid license, what the status page reports, and the two at-risk states with their distinct remedies — adding a payment method rescues an uncovered trial and does nothing for a cancelled one, which is the part worth getting right. Adds a matching entry under Frequent issues in `license-troubleshooting.md` pointing at it.

## Notes

- Version requirements verified against the gem sources: trial state needs `avo-licensing` 4.0.10, the amber indicator needs Avo 4.0.20 (an older Avo renders the dot unstyled rather than raising).
- Indicator colors read from `app/assets/stylesheets/css/sidebar.css` — green `ok`, amber `warning`, orange `error`.
- `vitepress build` passes; anchors verified in the built HTML.
- No doc impact from the rest of the day: the dashboard/card generator move to `avo-dashboards` (avo#4668) keeps the same generator names, and the card variant prop drop, Marksmith heading fix, Inter alternates fix, and `ws` release pre-flight are internal.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvNG3wH3wCGr4TubV7WXtR)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation with no runtime, security, or data-handling changes.
> 
> **Overview**
> Documentation-only updates for two product behaviors that shipped without matching upgrade/licensing guidance.
> 
> **`upgrade.md`** adds **`avo-dashboards` `4.0.9`**: per-card refresh is **opt-in** via `refresh_button` (default `false` after 4.0.8 showed it on every card), with a snippet to restore prior behavior and a note that dashboard-wide `refresh_button` is a separate opt-in.
> 
> **`licensing.md`** introduces a **Trials** section: trials are full licenses, what the status page reports, sidebar colors (green / amber / orange), and **Fix a trial at risk** — missing payment method vs cancelled subscription (different fixes), plus **Refresh license** for cached state and minimum gem versions (`avo-licensing` 4.0.10, Avo 4.0.20 for amber).
> 
> **`license-troubleshooting.md`** adds a **Frequent issues** entry for an **amber** sidebar indicator, linking to the licensing section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e979563a027b18a104588ce52167ba39ef520ca5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->