### PR TITLE
docs(intelligence): Avo Intelligence pages — prompt management and resource scoping

### DIFF
--- a/docs/4.0/intelligence-prompt-management.md
+++ b/docs/4.0/intelligence-prompt-management.md
@@ -1,0 +1,379 @@
+---
+license: addon
+betaStatus: Alpha
+outline: [2, 3]
+---
+
+<!--
+  Deliberately NOT registered in docs/.vitepress/config.js, for the same reason as
+  intelligence.md: avo-intelligence hasn't been announced, so this page stays off the sidebar,
+  out of llms.txt, and out of the docs map, while remaining reachable by direct URL.
+  Add the sidebar entry when the add-on goes public.
+-->
+
+# Prompt management
+
+The [Avo Intelligence](./intelligence.html) assistant is governed by a system prompt — the standing
+instructions that tell it what it is allowed to talk about, how to use its tools, and how to behave
+around your data. This page covers where that prompt lives and how your app can change it.
+
+## Requirements
+
+- `avo-intelligence` installed and working (see [Avo Intelligence](./intelligence.html))
+- `config/initializers/avo_intelligence.rb` for the configuration options below — you create it
+  yourself. Overriding a prompt file needs no configuration at all
+
+## The three ways to change the prompt
+
+Pick the smallest one that does the job.
+
+| You want to | Use | Own the shipped text? |
+| ----------- | --- | --------------------- |
+| Add house rules, tone, or domain vocabulary | `config.additional_instructions` | No — you keep getting our updates |
+| Replace what the assistant is *for* | `config.system_prompt` | Yes, but only the part you wrote |
+| Edit our wording, section by section | `rails g avo:intelligence:prompts`, then edit the copies | Yes — those files stop tracking ours |
+| Run with no system prompt at all | `config.system_prompt = nil` | n/a |
+| Replace the agent itself | `config.chat_agent_class` | Yes, and the tools and model config too |
+
+## What changed
+
+The assistant's prompt used to be a single Ruby heredoc constant
+(`ChatResponseJob::INSTRUCTIONS`) buried in a background job. There was no supported way to
+change it short of monkey-patching the job.
+
+| Before | Now |
+| ------ | --- |
+| One ~118-line heredoc constant inside `ChatResponseJob` | ERB files under `app/prompts/`, following ruby_llm's own convention |
+| The job hand-assembled instructions, tools, and model config | A `RubyLLM::Agent` subclass (`Avo::Intelligence::ChatAgent`) does it declaratively |
+| No way to change the prompt from your app | Drop a file with the same path into your app's `app/prompts/` |
+| The whole prompt was stored as a `role: :system` message and shown as a "System" bubble in the chat | Sent as a runtime instruction — never persisted, never displayed |
+
+The prompt **text itself is unchanged**. This was a move, not a rewrite: the wording the model
+receives today is byte-for-byte what it received before.
+
+## Configuration
+
+Both options live in `config/initializers/avo_intelligence.rb`. The install generator does not
+write that file — the gem runs on its defaults without it — so create it the first time you want
+to change something.
+
+Both accept either a String or a callable; a callable is resolved on every request and receives
+the acting user, so the prompt can differ per user.
+
+```ruby
+# config/initializers/avo_intelligence.rb
+Avo::Intelligence.configure do |config|
+  config.additional_instructions = nil # String, callable, or nil. Default: nil
+  config.system_prompt = "..."         # String, callable, or nil. Default: unset
+  config.chat_agent_class = "MyAgent"  # String (recommended) or Class.
+                                       # Default: "Avo::Intelligence::ChatAgent"
+end
+```
+
+### Adding to the prompt
+
+`config.additional_instructions` appends your text to the end of the system prompt, under a label
+that says it refines the rules above rather than replacing them.
+
+```ruby
+# config/initializers/avo_intelligence.rb
+Avo::Intelligence.configure do |config|
+  config.additional_instructions = <<~TEXT
+    Refer to "customers" as "clients".
+    Never quote figures from the Payroll resource, even to an administrator.
+  TEXT
+end
+```
+
+Per-user, with a callable:
+
+```ruby
+# config/initializers/avo_intelligence.rb
+config.additional_instructions = ->(user) do
+  "This user manages the #{user.region} region." if user.respond_to?(:region)
+end
+```
+
+This is the recommended option for most apps: you get the shipped prompt's improvements in future
+releases and only own the few lines you wrote.
+
+**It cannot widen the assistant's scope.** The shipped prompt's scope rule — the boundary that
+keeps the assistant about *this application's data* — is stated as overriding anything that
+conflicts with it, and your additions render below it labelled as subordinate to it. If you want a
+different scope, that is `config.system_prompt`'s job, not this one. (This is prompt wording, not
+enforcement. See the last gotcha below.)
+
+### Replacing the prompt
+
+`config.system_prompt` replaces the prompt we ship — the "constitution" that carries the
+assistant's scope rule, its inspect-before-acting workflow, and how it reports refused actions.
+Set it and none of that text is sent.
+
+```ruby
+# config/initializers/avo_intelligence.rb
+Avo::Intelligence.configure do |config|
+  config.system_prompt = <<~TEXT
+    You are a read-only reporting assistant for this admin panel. Answer questions about the
+    application's records using your tools, and nothing else.
+  TEXT
+end
+```
+
+Two things still happen when you set it:
+
+- **The identity note still renders**, first — the current date and time and who the assistant is
+  acting for. That is volatile fact rather than opinion, and every provider needs a ground-truth
+  current date.
+- **`additional_instructions` is still appended**, last. Setting both is taken to mean you want
+  both.
+
+Use this when your assistant is a different thing from ours. If you only want to reword our text,
+override the prompt file instead — you keep the structure and change the sentences.
+
+### Running with no system prompt
+
+Setting `config.system_prompt` to `nil` sends **no system prompt at all**: no constitution, no
+identity note, no additional instructions.
+
+```ruby
+# config/initializers/avo_intelligence.rb
+Avo::Intelligence.configure do |config|
+  config.system_prompt = nil
+end
+```
+
+`nil` and "not set" are deliberately different states. Leaving the option alone gives you the
+shipped prompt; setting it to `nil` is you asking for a blank slate.
+
+The tools still work — the assistant can still query, create, update, and delete through them, and
+every authorization check still applies. What it loses is everything the prompt was carrying: it
+no longer knows today's date, no longer knows who it is acting for (so "my drafts" means nothing
+to it), no longer inspects a resource before acting on it, and is no longer bounded to your app's
+data. Expect it to answer general-knowledge questions and to make more tool-call mistakes. This is
+a starting point for building your own prompt, not a mode to ship as-is.
+
+A callable that returns `nil` does the same thing, per request — so a blank slate can be scoped to
+some users:
+
+```ruby
+# config/initializers/avo_intelligence.rb
+# No prompt for the team building their own; everyone else gets ours.
+config.system_prompt = ->(user) { user.prompt_engineer? ? nil : House::PROMPT }
+```
+
+Note that once `system_prompt` is set at all, our shipped prompt is out of the picture — a
+callable cannot fall back to it. Read the file in if you want it as a base.
+
+## Where the prompts live
+
+Inside the gem, at `app/prompts/`:
+
+```
+app/prompts/avo/intelligence/
+  chat_agent/
+    instructions.txt.erb    # the main assistant prompt — scope, workflow, data rules, style
+    identity.txt.erb        # current date/time + who the assistant is acting for
+    custom.txt.erb          # the labelled wrapper around config.additional_instructions
+  conversation_renamer_agent/
+    instructions.txt.erb    # the titling rules for auto-naming a conversation
+```
+
+The path is derived from the agent class name: `Avo::Intelligence::ChatAgent` →
+`avo/intelligence/chat_agent/`. The file name is the prompt name, always `.txt.erb`.
+
+Three files rather than one for the chat agent, because they change at different rates.
+`identity.txt.erb` is rebuilt every request (the date has to be the real send-time date);
+`instructions.txt.erb` is the same bytes on every request. Keeping them apart is what will let
+us cache the large, stable half later.
+
+They are assembled in that order — identity, then the constitution (or your `system_prompt`), then
+`custom.txt.erb` — separated by blank lines. `custom.txt.erb` renders to nothing when
+`additional_instructions` is unset, so an app that configures nothing gets exactly the two-section
+prompt it got before these options existed.
+
+## Overriding a prompt
+
+Create the **same path** under your own app's `app/prompts/`. Your file wins.
+
+```
+your-app/
+  app/prompts/avo/intelligence/chat_agent/instructions.txt.erb
+```
+
+That is the whole mechanism. There is nothing to register, no initializer entry, no subclass.
+The lookup is: your app's file first, the gem's shipped default second.
+
+You can override one file and leave the others alone — the lookup runs per file, so overriding
+`instructions.txt.erb` still gets you the gem's `identity.txt.erb`.
+
+### Start from a copy, not a blank page
+
+The shipped prompt is load-bearing. It carries the assistant's scope rule (the boundary that
+stops it being a general-purpose chatbot), its inspect-before-acting workflow, and how it talks
+about refused actions. Start from our copy rather than a blank file:
+
+```bash
+bin/rails generate avo:intelligence:prompts
+```
+
+That writes all three chat-agent prompt files into your app:
+
+```
+app/prompts/avo/intelligence/chat_agent/instructions.txt.erb
+app/prompts/avo/intelligence/chat_agent/identity.txt.erb
+app/prompts/avo/intelligence/chat_agent/custom.txt.erb
+```
+
+Delete the ones you don't want to own — each file falls back to the gem's copy independently, so
+keeping only `instructions.txt.erb` is a perfectly good outcome.
+
+The generator **never overwrites a file you already have**. Re-running it after you've edited a
+prompt reports `skip` for that file and leaves it exactly as it is, so it is safe to run again to
+pick up a file you deleted earlier.
+
+It does not eject `conversation_renamer_agent/instructions.txt.erb` — the renamer only produces a
+conversation title, and there is rarely a reason to change it. If you want to, the lookup chain
+still honours a file you place there by hand.
+
+**Ejecting means you maintain it.** From that point the file is yours: improvements we make to the
+shipped prompt in future releases don't reach it. This is why `config.additional_instructions` is
+the better path for most apps.
+
+### What you can use inside a prompt file
+
+These are ERB templates. The chat agent's prompt files (`chat_agent/*.txt.erb`) receive:
+
+| Local | What it is |
+| ----- | ---------- |
+| `user` | The signed-in user the assistant is acting for |
+| `chat` | The `Avo::Intelligence::Chat` record for this conversation |
+
+`identity.txt.erb` additionally receives:
+
+| Local | What it is |
+| ----- | ---------- |
+| `now` | The current date and time, pre-formatted with the app's time zone |
+| `user_label` | A display string for the user — name, falling back to email, falling back to `Class#id` |
+
+The conversation renamer runs without a chat or a user, so its prompt file has neither local.
+
+So a house-rules addition to your `instructions.txt.erb` can be conditional:
+
+```erb
+<%# app/prompts/avo/intelligence/chat_agent/instructions.txt.erb %>
+<% if user.respond_to?(:admin?) && user.admin? %>
+This user is an administrator. Financial figures may be discussed in full.
+<% else %>
+Do not disclose revenue or payroll figures.
+<% end %>
+```
+
+Keep in mind that anything you put here is sent to the model on **every request** in the
+conversation — it is standing instruction, not a one-off.
+
+## Replacing the agent
+
+`config.chat_agent_class` is the last rung, and the one you should almost never need. It swaps the
+class that answers chats, so you own not just the prompt but the tools, the model configuration,
+and how the prompt is assembled.
+
+```ruby
+# app/agents/my_chat_agent.rb
+class MyChatAgent < Avo::Intelligence::ChatAgent
+  instructions { "You are a support triage assistant for this admin panel." }
+end
+```
+
+```ruby
+# config/initializers/avo_intelligence.rb
+Avo::Intelligence.configure do |config|
+  config.chat_agent_class = "MyChatAgent"
+end
+```
+
+Your class is instantiated with `chat:`, `user:` and `persist_instructions:`, so inheriting from
+`Avo::Intelligence::ChatAgent` is by far the easiest way to get one that works.
+
+**Give it as a String, not a Class.** Naming a constant directly in an initializer
+(`config.chat_agent_class = MyChatAgent`) autoloads one of your app's classes while Rails is still
+booting. That pins a single copy of it across code reloads in development and can raise outright
+during eager load in production. A String is looked up at the moment the agent is built, which is
+after boot and after any reload. A Class is accepted if you have a reason, but the String is the
+recommended form and the default.
+
+A subclass inherits our prompt files, so the common case — our assistant plus one of your own
+tools — is a few lines:
+
+```ruby
+# app/agents/my_chat_agent.rb
+class MyChatAgent < Avo::Intelligence::ChatAgent
+  def self.tools_for(chat:, user:)
+    super + [MyOwnTool.new(user: user)]
+  end
+end
+```
+
+Prompt lookup walks the chain, nearest class first: `app/prompts/my_chat_agent/instructions.txt.erb`
+in your app, then `app/prompts/avo/intelligence/chat_agent/instructions.txt.erb` in your app (what
+`rails g avo:intelligence:prompts` writes), then the gem's copy. So you can override one prompt file
+at your own class's path and inherit the rest, or declare `instructions` inline to replace them
+outright.
+
+## The "System" bubble is gone
+
+Previously the entire prompt was written to the database as a `role: :system` message, which
+meant the first thing a user saw when opening a chat was ~118 lines of internal instructions.
+
+New chats no longer persist it. The prompt is applied as a runtime instruction instead, so the
+model still receives it in full on every request — it just never becomes a message.
+
+**Conversations created before this change** still hold that stored system message, and it stays
+there — nothing deletes it and there is no migration to run. It is simply inert: the chat drops
+`role: :system` rows both from what it sends to the model and from what it renders, so the stored
+copy is neither seen nor used. An old chat and a new one behave identically.
+
+This matters most for [the blank slate](#running-with-no-system-prompt). Setting
+`config.system_prompt = nil` means no runtime instruction is applied at all — and with nothing to
+apply, nothing would have overwritten that stored row either. Left alone, an old conversation
+would have quietly kept sending the original constitution to a developer who asked for no prompt.
+Dropping the rows from the payload is what makes "none" actually mean none, in every chat.
+
+A chat whose only message is a stored system prompt therefore counts as empty, and shows the
+greeting below.
+
+## The empty state
+
+In place of the System bubble, a chat with no messages opens on a short greeting and three
+suggested prompts. Clicking one types it into the composer and sends it, exactly as if the user
+had typed it themselves.
+
+The suggestions are intentionally generic — they ask the assistant what it can do rather than
+naming any of your resources. Listing real resources would mean filtering them by what the
+signed-in user is allowed to see, and the chat view does not do authorization; the tools do.
+
+It is a view, not a message: nothing is persisted, and it disappears as soon as the first message
+arrives.
+
+## Gotchas
+
+- **Editing a prompt file needs no restart.** The file is read on every render and ruby_llm
+  re-evaluates the instructions block on every agent build, so nothing caches it anywhere — in
+  production either. Send the next message and you are looking at the new prompt.
+- **Test in a fresh chat.** An existing conversation replays its message history, which can mask
+  a changed instruction for several turns.
+- **An override replaces the whole file**, not part of it. When the gem's default prompt changes
+  in a future release, your copy does not — you own it from that point on. This is the main
+  reason `config.additional_instructions` is the better path for most apps.
+- **Restart the server after editing the initializer too.** `Avo::Intelligence.configure` runs at
+  boot; the callables inside it are what re-resolve per request, not the block itself.
+- **The assistant's real safety boundary is not the prompt.** Row and field authorization, the
+  inspect-first gate, and the write-confirmation flow are enforced in the tools, below the model.
+  Weakening a prompt rule does not grant the assistant access it did not have — and strengthening
+  one does not substitute for a policy.
+
+## See also
+
+[Resource scoping](./intelligence-resource-scoping.html) — keeping a resource out of the
+assistant's reach entirely. That is the enforced counterpart to this page: asking the prompt not to
+touch something is a request, and `config.excluded_resources` is a rule the tools apply whatever
+the model decides.

--- a/docs/4.0/intelligence-resource-scoping.md
+++ b/docs/4.0/intelligence-resource-scoping.md
@@ -1,0 +1,185 @@
+---
+license: addon
+betaStatus: Alpha
+outline: [2, 3]
+---
+
+<!--
+  Deliberately NOT registered in docs/.vitepress/config.js, for the same reason as
+  intelligence.md: avo-intelligence hasn't been announced, so this page stays off the sidebar,
+  out of llms.txt, and out of the docs map, while remaining reachable by direct URL.
+  Add the sidebar entry when the add-on goes public.
+-->
+
+# Resource scoping
+
+The [Avo Intelligence](./intelligence.html) assistant works through your Avo resources: it lists
+them, inspects their fields, queries them, and writes to them. `config.excluded_resources` decides
+which resources it is allowed to know about at all.
+
+## Requirements
+
+- `avo-intelligence` installed and working (see [Avo Intelligence](./intelligence.html))
+- `config/initializers/avo_intelligence.rb` — you create it yourself
+
+## This is not authorization
+
+The assistant already respects your policies. Every read starts from the acting user's Pundit
+scope, every write is authorized against the record, and a resource the user cannot `index?` is
+invisible to the chat — it reports as "not found", exactly like a resource that does not exist.
+None of that changes.
+
+Exclusion answers a different question:
+
+| | Question it answers | Varies by user |
+| --- | --- | --- |
+| Your policies | May **this user** see it? | Yes |
+| `config.excluded_resources` | Should the **assistant** deal with it at all? | No |
+
+An administrator passes every policy check. That is what an administrator is for — and it is
+precisely why a policy cannot express "keep the assistant out of this". A resource that should be
+invisible to the assistant *even for the person who is allowed to see everything* needs a rule
+that does not run through the user, which is what this is.
+
+## What is excluded by default
+
+Two groups, both hidden out of the box with no configuration:
+
+### This gem's own chat tables
+
+All six, named by **model**: `Avo::Intelligence::Chat`, `::Message`, `::ToolCall`, `::Model`,
+`::WriteLog` and `::PendingWrite`.
+
+Naming the model, not the resource class, is deliberate — it covers the table however it is
+exposed. The resources we ship are hidden, any resource *you* generate over the same tables is
+hidden too, and `WriteLog` / `PendingWrite` are reached even though we ship no resource for them.
+
+- **`Message` rows are other people's private conversations.** They hold what every user typed in
+  their own chats. An administrator asking the assistant to "summarise recent messages" would be
+  reading their colleagues' text.
+- **`ToolCall` and the write log are the audit trail.** They record what the assistant did to real
+  data. An assistant that can delete its own audit trail does not have one.
+- **Chat content is untrusted user-authored text.** If the assistant can query chat history, then
+  anything anyone types into any conversation becomes something the assistant can later read back
+  as *data* — which is a working prompt-injection channel between conversations, not a
+  hypothetical one.
+- **There is no use case on the other side.** These resources exist so that *humans* can browse
+  them in the Avo UI, and they still do.
+
+### ActiveStorage and ActionText plumbing
+
+Resources backed by `ActiveStorage::Attachment`, `ActiveStorage::Blob`,
+`ActiveStorage::VariantRecord`, or `ActionText::RichText`.
+
+Not dangerous, just noise: polymorphic join rows and internal storage. Listing them burns tokens
+on every request and invites the assistant to write queries that cannot mean anything.
+
+**Your own resources are never excluded by default.** Whatever your app registers stays available
+to the assistant, subject to your policies. If you want one hidden, that is what this option is
+for.
+
+## Configuration
+
+This lives in `config/initializers/avo_intelligence.rb`. The install generator does not write that
+file — the defaults below apply without it — so create it when you want to change the list.
+
+```ruby
+# config/initializers/avo_intelligence.rb
+Avo::Intelligence.configure do |config|
+  # An Array of Strings (recommended) or Classes.
+  # Default: Avo::Intelligence::Configuration::DEFAULT_EXCLUDED_RESOURCES
+  config.excluded_resources =
+    Avo::Intelligence::Configuration::DEFAULT_EXCLUDED_RESOURCES + ["Avo::Resources::Payroll"]
+end
+```
+
+### Assigning replaces the list
+
+There is no implicit merge. Whatever you assign *is* the list, which is why the defaults are a
+public constant you can add to:
+
+```ruby
+# config/initializers/avo_intelligence.rb
+# Keep ours, add yours.
+config.excluded_resources = Avo::Intelligence::Configuration::DEFAULT_EXCLUDED_RESOURCES + ["Avo::Resources::Payroll"]
+
+# Only yours — our defaults are gone. See the warning below.
+config.excluded_resources = ["Avo::Resources::Payroll"]
+
+# Nothing is excluded. The assistant can reach the chat's own tables.
+config.excluded_resources = []
+```
+
+Assign the whole list — appending to the current one does not work:
+
+```ruby
+# config/initializers/avo_intelligence.rb
+# Raises FrozenError. The matching set is derived when you assign, so a mutated list would
+# never reach it, and an exclusion that quietly does nothing is worse than a loud error.
+config.excluded_resources << "Avo::Resources::Payroll"
+```
+
+This is your app, so removing our defaults is allowed. It is worth being deliberate about it:
+re-exposing the chat resources hands the assistant every user's conversation history, the audit
+trail of its own writes, and a channel for text one user wrote to be read back into another
+user's conversation. If you need one of them for a specific reason, exclude the other three.
+
+### How names are matched
+
+An entry matches a resource when it equals any of:
+
+- the resource class name — `"Avo::Resources::Payroll"`
+- its short name, the one the chat uses — `"Payroll"`
+- the name of its model — `"Payroll"`, or `"ActiveStorage::Blob"`
+
+Model matching is how the ActiveStorage and ActionText defaults work at all: apps generate their
+own resources for those models and name them whatever they like, so the defaults name the model
+instead of guessing the resource.
+
+**Nothing in the list is ever constantized.** Names are compared as strings, so an entry for a
+class this app does not have — our ActiveStorage defaults in an app with no ActiveStorage
+resources, or a typo you have not noticed yet — is simply inert. It never matches, and it can
+never raise in the middle of a request. The flip side is that a typo fails silently: if a resource
+you excluded is still showing up, check the spelling first.
+
+Give names as Strings rather than Classes, for the same reason as `chat_agent_class`: naming a
+constant in an initializer autoloads it while Rails is still booting, which pins one copy across
+code reloads and can raise during eager load. A Class is accepted, but a String costs nothing.
+
+## What exclusion actually does
+
+An excluded resource is **indistinguishable from one that does not exist**, everywhere:
+
+| Path | Behaviour |
+| --- | --- |
+| Resource inspector, listing | Not in the list |
+| Resource inspector, by name | `Resource "X" not found.` — the same message a nonexistent name gets |
+| Query tool | `Resource "X" was not found.` — and it is not named among the suggested alternatives |
+| Create / update / delete | `Unknown resource "X".` |
+| Schema inspector, table list | Its table is not listed |
+| Schema inspector, by table name | `Table "x" does not exist` |
+
+The schema path matters as much as the resource path. The assistant can ask about raw tables, and
+that list is derived from the same resource authorization — if exclusion stopped at resources, the
+schema tool would leak exactly what the resource tool hides.
+
+There is deliberately **no prompt rule** about excluded resources. Enforcement lives in the tools,
+below the model, where instructions cannot argue with it. A prompt saying "do not query the chat
+tables" would be worthless against the injection case that motivates half this feature.
+
+## Gotchas
+
+- **Restart after editing the initializer.** `Avo::Intelligence.configure` runs at boot.
+- **Exclusion does not hide anything from the Avo UI.** The resources stay registered and humans
+  keep browsing them exactly as before. This only changes what the assistant can reach.
+- **Excluding a resource does not un-say what was already said.** A conversation that queried a
+  resource before you excluded it still has those results in its history. Exclusion stops new
+  reads; it does not rewrite past messages.
+- **It is not a substitute for a policy.** Exclusion is global and coarse — every user or none. If
+  the rule you want is "this user may not see these rows", that is a policy, and the assistant
+  already honours it.
+
+## See also
+
+[Prompt management](./intelligence-prompt-management.html) — what the assistant is told, as opposed
+to what it is allowed to touch.

--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -1,0 +1,221 @@
+---
+license: addon
+betaStatus: Alpha
+outline: [2, 3]
+---
+
+<!--
+  Deliberately NOT registered in docs/.vitepress/config.js.
+
+  avo-intelligence hasn't been announced, so this page must stay off the sidebar. VitePress
+  still builds it, and `scripts/generate-llms-txt.js` / `scripts/generate-docs-map.js` both walk
+  the sidebar rather than the filesystem — so the page is reachable by direct URL for the team
+  and for early customers we hand the link to, while staying out of the navigation, llms.txt,
+  and the docs map. Add the sidebar entry when the add-on goes public.
+-->
+
+# Avo Intelligence
+
+Avo Intelligence adds an AI assistant to your admin panel. It answers questions about the records
+behind your Avo resources, and — with your confirmation — creates, updates, and deletes them,
+through the same authorization rules the rest of Avo obeys.
+
+:::warning
+This add-on is a work in progress and isn't generally available yet. The API described here can
+still change between releases.
+:::
+
+## Requirements
+
+- Avo 4.x
+- The [`ruby_llm`](https://rubyllm.com) gem (installed automatically as a dependency)
+- An API key for at least one LLM provider (OpenAI, Anthropic, Gemini, OpenRouter, …)
+
+## Installation
+
+### 1. Install the gem
+
+```ruby
+# Gemfile
+gem "avo-intelligence", source: "https://packager.dev/avo-hq/"
+```
+
+```bash
+bundle install
+```
+
+### 2. Run the installer and migrate
+
+```bash
+bin/rails generate avo:intelligence install
+bin/rails db:migrate
+```
+
+This creates the add-on's tables and prints the next steps, including a menu snippet for
+`config/initializers/avo.rb`. The admin resources and controllers for browsing chats, messages,
+tool calls, and models ship inside the add-on itself — there's nothing to generate for those.
+
+### 3. Configure your provider
+
+```ruby
+# config/initializers/ruby_llm.rb
+RubyLLM.configure do |config|
+  config.openai_api_key = ENV.fetch("OPENAI_API_KEY", Rails.application.credentials.dig(:openai_api_key))
+  config.model_registry_class = "Avo::Intelligence::Model" # [!code focus]
+end
+```
+
+:::info
+You don't need to set `use_new_acts_as`. Avo Intelligence requires RubyLLM's new
+`acts_as_chat` / `acts_as_message` API to function at all, so it turns the flag on at require
+time, before Rails boots. That also means the install generator — and any other command that
+boots your app — works before this initializer exists.
+:::
+
+## Debug levels
+
+Everything the assistant does internally — the system prompt, its raw thinking trace, the tool
+calls with their arguments, and the raw tool output — is hidden by default. How much of it a
+person sees is decided **per viewer, on every render**, by your chat policy.
+
+| Level             | What the viewer sees                                                                                                                          |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `:off` (default)  | The conversation only: replies, record cards, write confirmations, the assistant's own questions, and the "Thinking…" indicator                |
+| `:tools`          | All of the above, plus the system prompt, the model's raw thinking trace, the tool calls with their arguments, and the raw tool output          |
+
+Answer `debug_level` in a policy for `Avo::Intelligence::Chat`:
+
+```ruby
+# app/policies/avo/intelligence/chat_policy.rb
+class Avo::Intelligence::ChatPolicy < ApplicationPolicy
+  def debug_level # [!code focus]
+    user.admin? ? :tools : :off # [!code focus]
+  end # [!code focus]
+end
+```
+
+There is no initializer setting and no in-app switcher, by design. Avo Intelligence is embedded in
+admin panels whose users may be *your* customers, so this is an authorization question about the
+viewer — not a preference. A switch in the UI would put the system prompt, including the rules that
+make the assistant refuse out-of-scope requests, one click away from the person those rules defend
+against.
+
+### It fails closed
+
+No policy, no `#debug_level`, an unrecognized value, or a policy that raises all resolve to `:off`.
+This deliberately departs from Avo's usual "no policy means fully open" rule — the safe default
+here is showing less, not more.
+
+### Nothing stops being recorded
+
+The level only decides what renders. Thinking traces and tool calls are still persisted, because
+the provider needs them to continue the conversation. Changing someone's level takes effect on
+their next page load; there's no migration and no backfill.
+
+:::warning
+Adding this policy also brings `Avo::Intelligence::Chat` under Avo's regular CRUD authorization for
+the add-on's own Chats admin resource. If you browse chats through those resources, answer the CRUD
+predicates too — otherwise those pages start returning 403 the moment the policy exists:
+
+```ruby
+class Avo::Intelligence::ChatPolicy < ApplicationPolicy
+  def debug_level = user.admin? ? :tools : :off
+
+  def index? = true
+  def show? = true
+  def create? = true
+  def update? = true
+  def destroy? = true
+
+  # Avo authorizes these two separately from CRUD. Without them the search box and the
+  # resource's actions quietly disappear.
+  def search? = true
+  def act_on? = true
+end
+```
+
+:::
+
+## Thinking output
+
+Assistant messages can display provider-returned thinking text, redacted thinking traces, and
+thinking token counts when RubyLLM exposes them — to viewers whose [debug level](#debug-levels) is
+`:tools`.
+
+To request thinking from providers that support it, set one or both of these environment variables
+before boot:
+
+```bash
+AVO_INTELLIGENCE_THINKING_EFFORT=medium
+AVO_INTELLIGENCE_THINKING_BUDGET=2048
+```
+
+RubyLLM forwards these through `with_thinking`. Provider behavior varies:
+
+- Anthropic requires a budget to return thinking.
+- Gemini and some OpenRouter models can return readable thinking text.
+- OpenAI reasoning models may report reasoning token usage without exposing readable thinking text.
+
+## Limiting the assistant to your application
+
+The assistant is meant to answer questions about **your app's data**, not to be a general-purpose
+chatbot. That boundary is set by the system prompt — `Avo::Intelligence::ChatResponseJob::INSTRUCTIONS`,
+the one place that governs what the assistant is willing to talk about. Its `Scope` section tells the
+model to only help with things one of its tools could serve — querying, creating, updating, and
+deleting the records exposed by your Avo resources — and to decline everything else (general
+knowledge, coding help, creative writing, math, opinions, role-play) in one sentence and redirect
+back to the app.
+
+:::warning
+This is a prompt-level (soft) boundary, not a hard gate. It reliably keeps the assistant on task for
+ordinary use, but a determined jailbreak can sometimes talk any model around a prompt rule.
+
+What it *cannot* get around is authorization: every data tool enforces per-user, row- and
+field-level access independently of the prompt. The worst realistic failure is the assistant
+answering an off-topic question — never a data leak.
+:::
+
+Worth knowing if you customize the prompt:
+
+- **The scope definition is tool-tied** ("in scope only if a tool could help"), so it stays correct
+  as you add or remove tools. There's no hardcoded topic list to maintain.
+- **Meta questions are carved in.** "What can you help me with?" counts as in scope, so the
+  assistant can explain itself instead of refusing.
+- **Watch for over-refusal on weaker models.** A firmer scope rule can make weak tool-followers
+  (for example `gpt-4o-mini`) reject legitimate data questions. Confirm behavior on a capable model
+  before assuming the prompt is wrong.
+- If you need a *hard* guarantee, add a classification step before the chat call — a cheap model
+  call that gates out-of-scope prompts with a canned reply. The prompt alone can't promise it.
+
+:::info
+The response job runs `:async` — inside the web process by default — so **restart the server** after
+editing the instructions, and test the change in a **fresh chat**. An existing thread replays its
+history and can mask the new behavior.
+:::
+
+## What you get
+
+The add-on ships these models and their tables:
+
+| Constant                       | Backing table                 |
+| ------------------------------ | ----------------------------- |
+| `Avo::Intelligence::Chat`      | `avo_intelligence_chats`      |
+| `Avo::Intelligence::Message`   | `avo_intelligence_messages`   |
+| `Avo::Intelligence::ToolCall`  | `avo_intelligence_tool_calls` |
+| `Avo::Intelligence::Model`     | `avo_intelligence_models`     |
+
+Plus controllers, views, a response job, and routes — all namespaced under `Avo::Intelligence` and
+exposed through the engine.
+
+Admin CRUD resources for browsing that data ship in the add-on too, namespaced under
+`Avo::Resources::AvoIntelligence` so they don't collide with the engine's own chat controllers:
+
+| Resource                                  | Model                         |
+| ----------------------------------------- | ----------------------------- |
+| `Avo::Resources::AvoIntelligence::Chat`     | `Avo::Intelligence::Chat`     |
+| `Avo::Resources::AvoIntelligence::Message`  | `Avo::Intelligence::Message`  |
+| `Avo::Resources::AvoIntelligence::ToolCall` | `Avo::Intelligence::ToolCall` |
+| `Avo::Resources::AvoIntelligence::Model`    | `Avo::Intelligence::Model`    |
+
+They aren't added to your `main_menu` automatically — the install generator prints a snippet for
+that.

--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -159,12 +159,13 @@ RubyLLM forwards these through `with_thinking`. Provider behavior varies:
 ## Limiting the assistant to your application
 
 The assistant is meant to answer questions about **your app's data**, not to be a general-purpose
-chatbot. That boundary is set by the system prompt — `Avo::Intelligence::ChatResponseJob::INSTRUCTIONS`,
-the one place that governs what the assistant is willing to talk about. Its `Scope` section tells the
-model to only help with things one of its tools could serve — querying, creating, updating, and
-deleting the records exposed by your Avo resources — and to decline everything else (general
-knowledge, coding help, creative writing, math, opinions, role-play) in one sentence and redirect
-back to the app.
+chatbot. That boundary is set by the `Scope` section of the system prompt, which tells the model to
+only help with things one of its tools could serve — querying, creating, updating, and deleting the
+records exposed by your Avo resources — and to decline everything else (general knowledge, coding
+help, creative writing, math, opinions, role-play) in one sentence and redirect back to the app.
+
+See [Prompt management](./intelligence-prompt-management.html) for how to change that text: append
+to it, replace it, eject the file and edit it, or run with no prompt at all.
 
 :::warning
 This is a prompt-level (soft) boundary, not a hard gate. It reliably keeps the assistant on task for
@@ -188,9 +189,10 @@ Worth knowing if you customize the prompt:
   call that gates out-of-scope prompts with a canned reply. The prompt alone can't promise it.
 
 :::info
-The response job runs `:async` — inside the web process by default — so **restart the server** after
-editing the instructions, and test the change in a **fresh chat**. An existing thread replays its
-history and can mask the new behavior.
+Editing a prompt file needs **no restart** — it is read on every render, and nothing in the chain
+caches it. Do test changes in a **fresh chat** though: an existing thread replays its history and
+can mask the new behavior. Editing the *initializer* does need a restart, since
+`Avo::Intelligence.configure` only runs at boot.
 :::
 
 ## What you get
@@ -219,3 +221,13 @@ Admin CRUD resources for browsing that data ship in the add-on too, namespaced u
 
 They aren't added to your `main_menu` automatically — the install generator prints a snippet for
 that.
+
+## Customizing the assistant
+
+Two parts of the add-on carry enough configuration to have their own pages:
+
+- [Prompt management](./intelligence-prompt-management.html) — appending to the system prompt,
+  replacing it, ejecting the ERB files to edit our wording, or swapping the agent class outright.
+- [Resource scoping](./intelligence-resource-scoping.html) — `config.excluded_resources`, which
+  takes a resource off the assistant's map entirely. Enforced in the tools, not asked for in the
+  prompt.


### PR DESCRIPTION
Documentation for the Avo Intelligence add-on. Pairs with [avo-hq/workspace#99](https://github.com/avo-hq/workspace/pull/99), which deletes the equivalent in-gem guides and the commented initializer they duplicated.

Supersedes #590 — same two commits, rebranched onto `avo-1538/feature/prompt-management-for-avo-intelligence` to match the workspace branch.

## Pages

| Page | Covers |
|------|--------|
| `4.0/intelligence.md` | The add-on itself — install, models, thinking output, scope boundary, what ships |
| `4.0/intelligence-prompt-management.md` | The four levels of prompt customization |
| `4.0/intelligence-resource-scoping.md` | `config.excluded_resources` |

**Prompt management** walks the four levels, cheapest first: `config.additional_instructions`, `config.system_prompt` (including `nil` — the blank slate, which sends no system prompt at all and is a different state from leaving it unset), ejecting the ERB files with `rails g avo:intelligence:prompts`, and replacing the agent class outright.

**Resource scoping** covers `config.excluded_resources` and why it is a separate axis from authorization rather than something a policy could express — an administrator passes every policy check, so policy cannot say "keep the assistant out of these tables".

## Corrections to `intelligence.md`

- It pointed at `Avo::Intelligence::ChatResponseJob::INSTRUCTIONS` as the home of the system prompt. The prompt no longer lives there — it is three ERB files owned by `ChatAgent`.
- It told readers to restart the server after editing the instructions. Prompt files are read on every render and need **no** restart; only the initializer does, since `Avo::Intelligence.configure` runs at boot.

## Sidebar

All three pages stay **unregistered** in `.vitepress/config.js`, matching how `intelligence.md` already shipped — the add-on's API is still moving between releases. Each page carries a comment saying so, so the omission doesn't read as an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
