### PR TITLE
docs(intelligence): add the page the gem's README points at

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -349,6 +349,10 @@ const config = {
               text: "Collaboration",
               link: "/4.0/collaboration.html",
             },
+            {
+              text: "Intelligence",
+              link: "/4.0/intelligence.html",
+            },
           ]
         },
         {

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -349,10 +349,6 @@ const config = {
               text: "Collaboration",
               link: "/4.0/collaboration.html",
             },
-            {
-              text: "Intelligence",
-              link: "/4.0/intelligence.html",
-            },
           ]
         },
         {

--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -1,0 +1,200 @@
+---
+license: addon
+addon_link: https://avohq.io/addons/intelligence
+betaStatus: "Alpha 🧪 (experimental)"
+outline: [2, 3]
+---
+
+# Intelligence
+
+Adds an AI assistant to your Avo panel. Users ask questions in plain language ("which orders shipped late last week?", "set this project's status to archived") and the assistant answers them by querying and writing the records your Avo resources already expose.
+
+It is backed by [RubyLLM](https://rubyllm.com), so you bring your own provider and API key. Every tool the assistant uses runs through Avo's authorization, so a user can only ever see and change what they could see and change by clicking through the panel themselves.
+
+```ruby
+# config/initializers/ruby_llm.rb
+RubyLLM.configure do |config|
+  config.openai_api_key = ENV.fetch("OPENAI_API_KEY", Rails.application.credentials.dig(:openai_api_key))
+  config.model_registry_class = "Avo::Intelligence::Model"
+end
+```
+
+Out of the box the chat shows the conversation and nothing else — no system prompt, no thinking trace, no tool calls. See [Show the agent's internals to developers](#show-the-agent-s-internals-to-developers) to open that up for the people who need it.
+
+:::warning
+This add-on is in **alpha**. The engine, models, and chat UI ship today; agent and tool wiring is still landing. Expect breaking changes between releases.
+:::
+
+## Installation
+
+1. **Add the gem** to your `Gemfile`:
+
+  ```ruby
+  # Gemfile
+  gem "avo-intelligence", source: "https://packager.dev/avo-hq"
+  ```
+
+2. **Bundle:**
+
+  ```bash
+  bundle
+  ```
+
+3. **Run the install generator:**
+
+  ```bash
+  bin/rails generate avo:intelligence install
+  ```
+
+  This writes the migration and, unless you already have one, a `config/initializers/ruby_llm.rb`.
+
+4. **Run the migrations:**
+
+  ```bash
+  bin/rails db:migrate
+  ```
+
+5. **Add your provider API key** — see [Configuration](#configuration).
+
+6. **Add a menu section** for the admin resources in `config/initializers/avo.rb`:
+
+  ```ruby
+  # config/initializers/avo.rb
+  section "Intelligence", icon: "heroicons/outline/sparkles" do
+    resource "avo_intelligence/chats"
+    resource "avo_intelligence/messages"
+    resource "avo_intelligence/tool_calls"
+    resource "avo_intelligence/models"
+  end
+  ```
+
+## Configuration
+
+Point RubyLLM at your provider and tell it to read models from this gem's table:
+
+```ruby
+# config/initializers/ruby_llm.rb
+RubyLLM.configure do |config|
+  config.openai_api_key = ENV.fetch("OPENAI_API_KEY", Rails.application.credentials.dig(:openai_api_key))
+  config.model_registry_class = "Avo::Intelligence::Model"
+end
+```
+
+:::info
+You don't need to set `use_new_acts_as`. The gem's models require RubyLLM's newer `acts_as_chat`/`acts_as_message` API to work at all, so it forces the flag on at require time — before Rails boots. That also means the install generator works before you've written this initializer.
+:::
+
+## Show the agent's internals to developers
+
+By default a chat renders only the conversation: the assistant's replies, record cards, confirm buttons, the questions the assistant asks back, and the "Thinking…" indicator. The system prompt, the raw thinking trace, the tool calls, and the raw tool output are hidden from everyone.
+
+To open those up, define `debug_level` on your policy for `Avo::Intelligence::Chat`:
+
+```ruby
+# app/policies/avo/intelligence/chat_policy.rb
+class Avo::Intelligence::ChatPolicy < ApplicationPolicy
+  def debug_level
+    user.admin? ? :tools : :off
+  end
+end
+```
+
+| Level    | What renders                                                                                     |
+| -------- | ------------------------------------------------------------------------------------------------ |
+| `:off`   | The conversation only — replies, record cards, confirm buttons, the assistant's questions, the "Thinking…" indicator. **The default.** |
+| `:tools` | All of the above, plus the system prompt, the raw thinking trace, the tool calls, and the raw tool output. |
+
+The gem asks this method on every render and hands it the person looking at the chat, so you can drive the answer from data — a role, a per-user flag — and turn debugging on for one person without a deploy. Because the level only decides what renders, a change takes effect on the next page load. Nothing is migrated, and nothing stops being recorded at `:off` — the provider still needs the traces to continue the conversation.
+
+:::warning
+There is deliberately **no switcher in the chat UI**. This add-on runs inside your admin panel, where the people chatting may be your own customers, so who sees the internals is an authorization question about the viewer rather than a preference. A toggle would put the system prompt — including the rules that make the assistant refuse jailbreaks — one click away from the person those rules defend against.
+:::
+
+Resolution fails closed. No policy, no `debug_level` method, an unrecognized return value, or a raise inside your policy all mean `:off`; a raise is logged and the plain conversation renders as usual.
+
+### Policy methods to keep open
+
+Avo authorizes `search?` and `act_on?` separately from CRUD. The moment a `ChatPolicy` exists, the search box and the resource's actions disappear unless you allow them explicitly:
+
+```ruby
+# app/policies/avo/intelligence/chat_policy.rb
+class Avo::Intelligence::ChatPolicy < ApplicationPolicy
+  def debug_level
+    user.admin? ? :tools : :off
+  end
+
+  def search?
+    true
+  end
+
+  def act_on?
+    true
+  end
+end
+```
+
+## Thinking output
+
+Assistant messages can display provider-returned thinking text, redacted thinking traces, and thinking token counts when RubyLLM exposes them — to viewers at [`:tools`](#show-the-agent-s-internals-to-developers).
+
+To request thinking from providers that support it, set one or both of these environment variables before boot:
+
+```bash
+AVO_INTELLIGENCE_THINKING_EFFORT=medium
+AVO_INTELLIGENCE_THINKING_BUDGET=2048
+```
+
+RubyLLM forwards these through `with_thinking`. Provider behavior still varies:
+
+- **Anthropic** requires a budget to return thinking.
+- **Gemini** and some **OpenRouter** models can return readable thinking text.
+- **OpenAI** reasoning models may report reasoning token usage without exposing readable thinking text.
+
+## Keep the assistant on your app's data
+
+The assistant is meant to answer questions about **your app's data**, not to be a general-purpose chatbot. That boundary is set by the system prompt in `ChatResponseJob::INSTRUCTIONS` (`app/jobs/avo/intelligence/chat_response_job.rb`), the one place that governs what the assistant will talk about.
+
+Its `Scope` section tells the model to only help with things one of its tools could serve — querying, creating, updating, and deleting the records your Avo resources expose — and to decline everything else (general knowledge, coding help, creative writing, math, opinions, role-play) in one sentence and redirect back to the app.
+
+:::warning
+**This is a prompt-level boundary, not a hard gate.** It reliably keeps the assistant on task for ordinary use, but a determined jailbreak can sometimes talk any model around a prompt rule.
+
+What it cannot get around is authorization: every data tool enforces per-user, row- and field-level access independently of the prompt. The worst realistic failure is the assistant answering an off-topic question — never a data leak.
+:::
+
+A few things worth knowing if you customize the prompt:
+
+- **The scope definition is tool-tied** ("in scope only if a tool could help"), so it stays correct as you add or remove tools. There's no hardcoded topic list to maintain.
+- **Meta questions are carved in.** "What can you help me with?" counts as in scope, so the assistant can explain itself instead of refusing.
+- **Watch for over-refusal on weaker models.** A firmer scope rule can make weak tool-followers (`gpt-4o-mini`, for instance) reject legitimate data questions. Confirm the behavior on a capable model before assuming the prompt is wrong.
+- **If you need a hard guarantee**, add a classification step before `chat.ask` — a cheap model call that gates out-of-scope prompts with a canned reply. The prompt alone cannot promise it.
+
+`ChatResponseJob` runs `:async` (inside the web process by default), so **restart the server** after editing `INSTRUCTIONS`, and test your change in a **fresh chat** — an existing thread replays its history and can mask the new behavior.
+
+## What you get
+
+The engine ships these models, all namespaced under `Avo::Intelligence`:
+
+| Model                                | Backing table                     |
+| ------------------------------------ | --------------------------------- |
+| `Avo::Intelligence::Chat`            | `avo_intelligence_chats`          |
+| `Avo::Intelligence::Message`         | `avo_intelligence_messages`       |
+| `Avo::Intelligence::ToolCall`        | `avo_intelligence_tool_calls`     |
+| `Avo::Intelligence::Model`           | `avo_intelligence_models`         |
+| `Avo::Intelligence::WriteLog`        | `avo_intelligence_write_logs`     |
+| `Avo::Intelligence::PendingWrite`    | `avo_intelligence_pending_writes` |
+
+Plus controllers, views, a `ChatResponseJob`, and routes — all exposed through the engine.
+
+Admin resources for browsing that data ship in the gem too, namespaced under `Avo::Resources::AvoIntelligence` so they don't collide with the engine's own chat controllers:
+
+| Resource                                  | Model                         |
+| ----------------------------------------- | ----------------------------- |
+| `Avo::Resources::AvoIntelligence::Chat`     | `Avo::Intelligence::Chat`     |
+| `Avo::Resources::AvoIntelligence::Message`  | `Avo::Intelligence::Message`  |
+| `Avo::Resources::AvoIntelligence::ToolCall` | `Avo::Intelligence::ToolCall` |
+| `Avo::Resources::AvoIntelligence::Model`    | `Avo::Intelligence::Model`    |
+
+They aren't added to your menu automatically — the install generator prints the snippet, and it's step 6 of [Installation](#installation).
+
+The Chats resource is scoped to the signed-in user out of the box, so one admin never sees another's conversations without you writing a policy. It's also read-only by design: a chat is a transcript, started and continued from the chat UI, so the write controls are stripped from the resource.


### PR DESCRIPTION
Daily docs sweep over yesterday's (2026-07-29) commits.

## What prompted this

[avo-hq/workspace#86](https://github.com/avo-hq/workspace/pull/86) (`feat(avo-intelligence): hide agent internals behind a per-viewer debug level`) trimmed the gem's README, with this in the commit message:

> The README had grown into a docs site — thinking output, the prompt scope boundary, and the models/resources tables all lived there. That content now has a real home at docs.avohq.io/4.0/intelligence.html, so drop it here [...] Also removes the debug-level section this branch added, for the same reason.

That page was never created. So as of yesterday:

- `gems/avo-intelligence/README.md:7` links to `docs.avohq.io/4.0/intelligence.html`, which **404s**
- the thinking-output, prompt-scope, and models/resources docs exist **nowhere** — they were deleted from the README on the strength of a page that doesn't exist
- the **debug level** the same PR shipped is undocumented, including the `search?`/`act_on?` gotcha its own reference policy calls out

`avo-intelligence` had no page on the docs site at all, and no sidebar entry.

## What's here

A new guide at `docs/4.0/intelligence.md`, plus an **Add-ons** sidebar entry.

Content is the material the README dropped — recovered from `17281f2^`, re-verified line by line against the gem at `4.0.0.alpha.8` rather than pasted — plus the new debug level:

| Section | Source |
| --- | --- |
| Installation / Configuration | install generator + `ruby_llm.rb` template |
| Show the agent's internals to developers | `DebugLevel`, `Chat#debug_level`, `MessagesHelper#show_agent_internals?` |
| Policy methods to keep open | the dummy's reference `ChatPolicy` |
| Thinking output | recovered README §, env vars re-checked in `ChatResponseJob` |
| Keep the assistant on your app's data | recovered README §, checked against `INSTRUCTIONS` |
| What you get | recovered README §, **refreshed** |

Two things I corrected rather than carried over:

- the models table gained `WriteLog` and `PendingWrite`, which postdate the README's version — confirmed against the migration template's `create_table` calls
- the thinking section now says it renders for `:tools` viewers, which only became true yesterday

Guide only, no `-api.md`: the whole configuration surface is one policy method and two env vars, under the ~3-option bar in `AGENTS.md`.

## Verification

- `npx vitepress build docs` — clean, no dead links
- every in-page anchor confirmed against the generated `dist/4.0/intelligence.html`
- `package-lock.json` / `yarn.lock` touched by a local install were reverted; the diff is the page and the sidebar line

## Two things worth a maintainer's eye

1. **`addon_link: https://avohq.io/addons/intelligence`** — `AGENTS.md` requires the key on every `license: addon` page and every existing one has it, so I followed the `avo-collaboration` → `/addons/collaboration` slug rule. But this gem is alpha and I couldn't verify the page exists. **If it doesn't, the license pill links to a 404** — drop the key or fix the slug.
2. **`betaStatus: "Alpha 🧪 (experimental)"`**, matching `avo-meta.md`, since the gem is `4.0.0.alpha.8` and its README says WIP. Bump it if the add-on is further along than the version suggests.

Also note license gating isn't wired yet (`base_controller.rb:4`: "License gating [...] will be wired in once that integration lands"), so `license: addon` describes intent, not an enforced check today.

## Not changed

The other 2026-07-29 commits need no docs: three CI/lockfile commits (`#100`, `#101`, `#103`, `09f980e`, `ab4d575`) are internal to the workspace, and `#102` is a spec-timing fix. **avo core had no commits yesterday** — its 07-28 sidebar and card changes are already covered by docs #587–#589.

I did not edit the gem's README; its link becomes correct once this merges and deploys.

---
_Generated by [Claude Code](https://claude.ai/code/session_015dHAWH9YBdq8vf8cL85JDL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or application code impact.
> 
> **Overview**
> Introduces **`docs/4.0/intelligence.md`**, the documentation home for the **avo-intelligence** add-on that the gem README already links to but that did not exist yet.
> 
> The page covers **installation** (gem, generator, migrations, Avo menu snippet), **RubyLLM configuration**, and the new **per-viewer `debug_level`** policy (`:off` vs `:tools`) for showing system prompts, tool calls, and traces—plus the **`search?` / `act_on?`** policy gotcha when a `ChatPolicy` is defined.
> 
> It also restores guide content that was removed from the README: **thinking output** (`AVO_INTELLIGENCE_THINKING_*` env vars), **keeping the assistant scoped to app data** via `ChatResponseJob::INSTRUCTIONS`, and an updated **models/resources** table (including `WriteLog` and `PendingWrite`). Front matter marks it as an alpha add-on with `license: addon` and `betaStatus`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0b9299036e2536b2412a471a8af139289cbef92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->