### PR TITLE
docs(plugins): document Avo.plugin_manager.register_configuration

### DIFF
--- a/docs/4.0/plugins.md
+++ b/docs/4.0/plugins.md
@@ -97,7 +97,7 @@ We don't use it as much in our plugins as we do in the `avo_boot` hook.
 
 ## Registration API
 
-Everything a plugin contributes is registered through `Avo.plugin_manager`, from inside the [`avo_boot`](#hooks) hook so it runs once on boot.
+Everything a plugin contributes is registered through `Avo.plugin_manager`, from inside the [`avo_boot`](#hooks) hook so it runs once on boot. The one exception is `register_configuration`, which has to run before the app's initializers — see [Let apps configure your plugin](#let-apps-configure-your-plugin).
 
 <Option name="`register(name, priority: 10)`">
 
@@ -140,6 +140,18 @@ end
 
 </Option>
 
+<Option name="`register_configuration(name, klass)`">
+
+Adds a `config.<name>` namespace to `Avo::Configuration`, backed by an instance of `klass`, so apps configure your plugin from their own `config/initializers/avo.rb`. See [Let apps configure your plugin](#let-apps-configure-your-plugin) for the full pattern.
+
+```ruby
+Avo.plugin_manager.register_configuration :feed_view, Avo::FeedView::Configuration
+```
+
+Unlike the rest of this API, it must run *before* the app's initializers — from an engine initializer ordered `before: :load_config_initializers`, not from the `avo_boot` hook.
+
+</Option>
+
 <Option name="`installed?(name)`">
 
 Returns whether a plugin registered under `name` is present. Use it to make your plugin adapt to what else is installed.
@@ -161,6 +173,74 @@ Avo.plugin_manager.mount_engine Avo::FeedView::Engine, at: "/feed_view"
 ```
 
 </Option>
+
+## Let apps configure your plugin
+
+Register a configuration namespace and your plugin's settings live on Avo's own configuration object, so an app configures it from the same `config/initializers/avo.rb` it already uses for everything else — no second initializer, no extra constant to remember.
+
+Start with a plain configuration class. It's yours, so it can hold defaults, coerce values, or fall back to environment variables.
+
+```ruby
+# lib/avo/feed_view/configuration.rb
+module Avo
+  module FeedView
+    class Configuration
+      attr_accessor :items_per_page
+      attr_writer :api_key
+
+      def initialize
+        @items_per_page = 25
+      end
+
+      # Falling back to an env var keeps deployments that never touch the
+      # initializer working.
+      def api_key
+        @api_key || ENV["AVO_FEED_VIEW_API_KEY"]
+      end
+    end
+  end
+end
+```
+
+Register it under a namespace from an engine initializer:
+
+```ruby
+# lib/avo/feed_view/engine.rb
+module Avo
+  module FeedView
+    class Engine < ::Rails::Engine
+      isolate_namespace Avo::FeedView
+
+      initializer "avo-feed-view.register_configuration", before: :load_config_initializers do
+        Avo.plugin_manager.register_configuration :feed_view, Avo::FeedView::Configuration
+      end
+    end
+  end
+end
+```
+
+Apps now set your options alongside Avo's:
+
+```ruby
+# config/initializers/avo.rb
+Avo.configure do |config|
+  config.feed_view.items_per_page = 50
+end
+```
+
+And your plugin reads them back off `Avo.configuration`:
+
+```ruby
+Avo.configuration.feed_view.items_per_page # => 50
+```
+
+:::warning
+Register the configuration from an engine initializer ordered `before: :load_config_initializers` (or at require time) — **not** from the `avo_boot` hook. The app's `config/initializers/avo.rb` reads the accessor while initializers run, which is before Avo boots, so registering any later blows up in the app's own initializer.
+:::
+
+Namespaces are exclusive. `register_configuration` raises an `ArgumentError` if the name collides with a method `Avo::Configuration` already defines, or with a namespace another plugin took first. Re-registering the same name with the same class is fine, so a boot that happens more than once is harmless.
+
+Instances are memoized per configuration object, which means replacing `Avo.configuration` resets your plugin's config along with everything else — useful when you need a clean slate in tests.
 
 ## Add asset files
 


### PR DESCRIPTION
Daily docs sweep over yesterday's (2026-07-30) changes in `avo-hq/avo` and `avo-hq/workspace`.

`Avo.plugin_manager.register_configuration` shipped yesterday (avo-hq/avo#4676, with the call-site guidance corrected in avo-hq/avo#4677) and had no documentation. It's the API `avo-intelligence` uses to expose `config.intelligence.*`, so plugin authors will look for it.

## Changes

`docs/4.0/plugins.md`:

- **`<Option>` block** in the Registration API list — signature, one-line snippet, and the note that it's the exception to the "call it from `avo_boot`" rule.
- **New `## Let apps configure your plugin` section** with the full pattern: a plain configuration class (defaults + env-var fallback), the engine initializer ordered `before: :load_config_initializers`, how the app writes options inside `Avo.configure`, and how the plugin reads them back off `Avo.configuration`.
- A `:::warning` on the ordering requirement — the host's `avo.rb` reads the accessor while initializers run, so an `avo_boot` registration is too late.
- Notes on namespace exclusivity (`ArgumentError` on collision with a core `Avo::Configuration` method or another plugin's namespace; same-name/same-class re-registration is a no-op) and per-configuration-object memoization.
- Qualified the Registration API intro sentence, which previously said *everything* is registered from `avo_boot`.

## Reviewed and intentionally not documented

| Change | Why no docs |
| --- | --- |
| avo-hq/avo#4679 — host app's Tailwind build wins `avo/application.css` under Sprockets | Silent bug fix, no user-facing action or option |
| avo-hq/avo#4675 — trust resource name on the index create/attach button | i18n bug fix; no documented behavior changed |
| avo-hq/avo#4680 — inline search for popover dropdowns | Internal `DropdownComponent` API, not a documented surface |
| workspace avo-intelligence (#105, #109, #113, #114) | Already covered by #593/#594 (configuration, prompt customization, empty-state suggestions) |
| workspace avo-intelligence (#115, #116) — chat history search, chat menu & window management | UI behavior on an alpha gem whose page is deliberately out of the sidebar |

The Intelligence page is still unlinked from the sidebar — left as-is, since #593 stated that was intentional.

## Verification

`npx vitepress build docs` completes clean; the `#let-apps-configure-your-plugin` anchor renders and both in-page links resolve.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhuVC2rGscHTQbcE9LNTvW)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> Documents **`Avo.plugin_manager.register_configuration`** for plugin authors so apps can configure gems via `config/initializers/avo.rb`.
> 
> The Registration API intro now notes that **`register_configuration`** is the exception to registering everything from **`avo_boot`**. A new **`<Option>`** block describes the API, and a **Let apps configure your plugin** section walks through a configuration class, an engine initializer with **`before: :load_config_initializers`**, app-side **`Avo.configure`** usage, and reading **`Avo.configuration`**.
> 
> Also covers the **initializer ordering** warning (not **`avo_boot`**), **namespace collision** behavior, and **memoization** when **`Avo.configuration`** is replaced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89972b1b4f69cc28f0c25de491990459c5a72588. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->