### PR TITLE
docs(4.0): require Ruby >= 3.2

### DIFF
--- a/docs/4.0/avo-3-avo-4-upgrade.md
+++ b/docs/4.0/avo-3-avo-4-upgrade.md
@@ -31,7 +31,7 @@ Inventory before editing
 - Many chapters won't apply. Mark each APPLIES / NOT USED / NEEDS REVIEW. Never apply a change for an API the app doesn't use.
 
 Gems first
-- Avo 4 requires Ruby >= 3.3. Check the app's Ruby version and bump it if needed before updating the gems.
+- Avo 4 requires Ruby >= 3.2. Check the app's Ruby version and bump it if needed before updating the gems.
 - Update the Gemfile to >= 4.0.0 for `avo` and every `avo-*` gem in use (check for avo-nested, avo-rhino_field, avo-dynamic_filters, etc.), move private gems under the packager.dev source block, run bundle, and boot the app before touching app code.
 - Nested forms now need the separate avo-nested gem — add it if has_many/has_one/habtm use `nested`.
 
@@ -72,14 +72,18 @@ Assuming you are upgrading your Avo 3 app, you need to do three things:
 
 ### Upgrade your Ruby version
 
-Avo 4 requires **Ruby 3.3 or newer**.
+Avo 4 requires **Ruby 3.2 or newer**, up from 3.1 in Avo 3.
 
-Avo 4 depends on [`pagy`](https://rubygems.org/gems/pagy) `>= 43.0` for pagination, and `pagy` requires Ruby `>= 3.3` from `43.5.0` onwards.
+Avo 4 depends on [`pagy`](https://rubygems.org/gems/pagy) `>= 43.0` for pagination, and every `pagy 43` release requires Ruby `>= 3.2`.
 
 ```ruby
 # .ruby-version
-3.3.1
+3.2.0
 ```
+
+:::info
+On Ruby 3.2 you get the `43.4.x` line of `pagy` — `pagy 43.5.0` and later require Ruby `>= 3.3`. Both work with Avo 4; run Ruby 3.3 or newer if you want the latest `pagy`.
+:::
 
 ### Upgrade your gems
 
@@ -755,7 +759,7 @@ If you customized the v3 picker via CSS targeting Algolia's class names (`.aa-In
 
 ## Pagination
 
-Avo 4 runs on `pagy 43`, which is what moves the minimum Ruby version to 3.3 — see [Upgrade your Ruby version](#upgrade-your-ruby-version).
+Avo 4 runs on `pagy 43`, which is what moves the minimum Ruby version to 3.2 — see [Upgrade your Ruby version](#upgrade-your-ruby-version).
 
 ### Replace `size` with `slots`
 

--- a/docs/4.0/avo-3-avo-4-upgrade.md
+++ b/docs/4.0/avo-3-avo-4-upgrade.md
@@ -31,7 +31,7 @@ Inventory before editing
 - Many chapters won't apply. Mark each APPLIES / NOT USED / NEEDS REVIEW. Never apply a change for an API the app doesn't use.
 
 Gems first
-- Avo 4 requires Ruby >= 3.3. Check the app's Ruby version and bump it BEFORE bundling — on an older Ruby, Bundler silently resolves `pagy` back to a pre-43.5 release instead of failing.
+- Avo 4 requires Ruby >= 3.3. Check the app's Ruby version and bump it if needed before updating the gems.
 - Update the Gemfile to >= 4.0.0 for `avo` and every `avo-*` gem in use (check for avo-nested, avo-rhino_field, avo-dynamic_filters, etc.), move private gems under the packager.dev source block, run bundle, and boot the app before touching app code.
 - Nested forms now need the separate avo-nested gem — add it if has_many/has_one/habtm use `nested`.
 
@@ -72,26 +72,14 @@ Assuming you are upgrading your Avo 3 app, you need to do three things:
 
 ### Upgrade your Ruby version
 
-Avo 4 requires **Ruby 3.3 or newer**. Avo 3 required 3.1.
+Avo 4 requires **Ruby 3.3 or newer**.
 
-The driver is [`pagy`](https://rubygems.org/gems/pagy), which Avo uses for pagination. Avo 3 depended on `pagy >= 7.0.0, < 43`; Avo 4 moved to `pagy >= 43.0`. `pagy 43.0.0` requires Ruby `>= 3.2`, and from `pagy 43.5.0` onwards the floor is Ruby `>= 3.3`.
+Avo 4 depends on [`pagy`](https://rubygems.org/gems/pagy) `>= 43.0` for pagination, and `pagy` requires Ruby `>= 3.3` from `43.5.0` onwards.
 
 ```ruby
 # .ruby-version
 3.3.1
 ```
-
-:::warning Bump Ruby before you bundle
-Because Avo's constraint is a range and not a pin, Bundler doesn't fail on an older Ruby — it resolves `pagy` backwards until it finds a version your interpreter accepts.
-
-| Your Ruby | The `pagy` you get                            |
-| --------- | --------------------------------------------- |
-| 3.1       | none — no `pagy 43.x` is installable           |
-| 3.2       | `43.4.4`, the last release before the bump     |
-| 3.3+      | the current release                            |
-
-On Ruby 3.2 the app boots and the tests pass while pinned to a stale pagination gem, so the problem surfaces much later. Bump Ruby first, then run the gem upgrade below.
-:::
 
 ### Upgrade your gems
 

--- a/docs/4.0/avo-3-avo-4-upgrade.md
+++ b/docs/4.0/avo-3-avo-4-upgrade.md
@@ -72,7 +72,7 @@ Assuming you are upgrading your Avo 3 app, you need to do three things:
 
 ### Upgrade your Ruby version
 
-Avo 4 requires **Ruby 3.2 or newer**, up from 3.1 in Avo 3.
+Avo 4 requires **Ruby 3.2 or newer**.
 
 Avo 4 depends on [`pagy`](https://rubygems.org/gems/pagy) `>= 43.0` for pagination, and every `pagy 43` release requires Ruby `>= 3.2`.
 

--- a/docs/4.0/avo-3-avo-4-upgrade.md
+++ b/docs/4.0/avo-3-avo-4-upgrade.md
@@ -72,18 +72,12 @@ Assuming you are upgrading your Avo 3 app, you need to do three things:
 
 ### Upgrade your Ruby version
 
-Avo 4 requires **Ruby 3.2 or newer**.
-
-Avo 4 depends on [`pagy`](https://rubygems.org/gems/pagy) `>= 43.0` for pagination, and every `pagy 43` release requires Ruby `>= 3.2`.
+Avo 4 requires **Ruby 3.2 or newer**, following the minimum its dependencies support.
 
 ```ruby
 # .ruby-version
 3.2.0
 ```
-
-:::info
-On Ruby 3.2 you get the `43.4.x` line of `pagy` — `pagy 43.5.0` and later require Ruby `>= 3.3`. Both work with Avo 4; run Ruby 3.3 or newer if you want the latest `pagy`.
-:::
 
 ### Upgrade your gems
 
@@ -758,8 +752,6 @@ The searchable association picker was rewritten in Avo 4 using Hotwire (Stimulus
 If you customized the v3 picker via CSS targeting Algolia's class names (`.aa-Input`, `.aa-Panel`, etc.), those selectors no longer match anything — the v4 picker uses Avo's own markup, and the Algolia stylesheet is no longer bundled.
 
 ## Pagination
-
-Avo 4 runs on `pagy 43`, which is what moves the minimum Ruby version to 3.2 — see [Upgrade your Ruby version](#upgrade-your-ruby-version).
 
 ### Replace `size` with `slots`
 

--- a/docs/4.0/avo-3-avo-4-upgrade.md
+++ b/docs/4.0/avo-3-avo-4-upgrade.md
@@ -31,6 +31,7 @@ Inventory before editing
 - Many chapters won't apply. Mark each APPLIES / NOT USED / NEEDS REVIEW. Never apply a change for an API the app doesn't use.
 
 Gems first
+- Avo 4 requires Ruby >= 3.3. Check the app's Ruby version and bump it BEFORE bundling — on an older Ruby, Bundler silently resolves `pagy` back to a pre-43.5 release instead of failing.
 - Update the Gemfile to >= 4.0.0 for `avo` and every `avo-*` gem in use (check for avo-nested, avo-rhino_field, avo-dynamic_filters, etc.), move private gems under the packager.dev source block, run bundle, and boot the app before touching app code.
 - Nested forms now need the separate avo-nested gem — add it if has_many/has_one/habtm use `nested`.
 
@@ -68,6 +69,29 @@ Assuming you are upgrading your Avo 3 app, you need to do three things:
 2. Upgrade your Avo gems
 
 3. Use this guide to upgrade your app to Avo 4.
+
+### Upgrade your Ruby version
+
+Avo 4 requires **Ruby 3.3 or newer**. Avo 3 required 3.1.
+
+The driver is [`pagy`](https://rubygems.org/gems/pagy), which Avo uses for pagination. Avo 3 depended on `pagy >= 7.0.0, < 43`; Avo 4 moved to `pagy >= 43.0`. `pagy 43.0.0` requires Ruby `>= 3.2`, and from `pagy 43.5.0` onwards the floor is Ruby `>= 3.3`.
+
+```ruby
+# .ruby-version
+3.3.1
+```
+
+:::warning Bump Ruby before you bundle
+Because Avo's constraint is a range and not a pin, Bundler doesn't fail on an older Ruby — it resolves `pagy` backwards until it finds a version your interpreter accepts.
+
+| Your Ruby | The `pagy` you get                            |
+| --------- | --------------------------------------------- |
+| 3.1       | none — no `pagy 43.x` is installable           |
+| 3.2       | `43.4.4`, the last release before the bump     |
+| 3.3+      | the current release                            |
+
+On Ruby 3.2 the app boots and the tests pass while pinned to a stale pagination gem, so the problem surfaces much later. Bump Ruby first, then run the gem upgrade below.
+:::
 
 ### Upgrade your gems
 
@@ -742,6 +766,8 @@ The searchable association picker was rewritten in Avo 4 using Hotwire (Stimulus
 If you customized the v3 picker via CSS targeting Algolia's class names (`.aa-Input`, `.aa-Panel`, etc.), those selectors no longer match anything — the v4 picker uses Avo's own markup, and the Algolia stylesheet is no longer bundled.
 
 ## Pagination
+
+Avo 4 runs on `pagy 43`, which is what moves the minimum Ruby version to 3.3 — see [Upgrade your Ruby version](#upgrade-your-ruby-version).
 
 ### Replace `size` with `slots`
 

--- a/docs/4.0/installation.md
+++ b/docs/4.0/installation.md
@@ -8,7 +8,7 @@ prompt: Use this page (${link}) to install Avo in my Ruby on Rails app.
 ## Requirements
 
 - Ruby on Rails >= 6.1
-- Ruby >= 3.3
+- Ruby >= 3.2
 - `api_only` set to `false`. More [here](./guides/api-only-app).
 - `propshaft` or `sprockets` gem
 - Have the `secret_key_base` defined in any of the following `ENV["SECRET_KEY_BASE"]`, `Rails.application.credentials.secret_key_base`, or `Rails.application.secrets.secret_key_base`

--- a/docs/4.0/installation.md
+++ b/docs/4.0/installation.md
@@ -8,7 +8,7 @@ prompt: Use this page (${link}) to install Avo in my Ruby on Rails app.
 ## Requirements
 
 - Ruby on Rails >= 6.1
-- Ruby >= 3.1
+- Ruby >= 3.3
 - `api_only` set to `false`. More [here](./guides/api-only-app).
 - `propshaft` or `sprockets` gem
 - Have the `secret_key_base` defined in any of the following `ENV["SECRET_KEY_BASE"]`, `Rails.application.credentials.secret_key_base`, or `Rails.application.secrets.secret_key_base`

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -6,6 +6,42 @@ If you're looking for the Avo 3 to Avo 4 upgrade guide, please visit [the dedica
 
 Migrating to TailwindCSS 4? See the [TailwindCSS 4 Migration Guide](./tailwind-4-migration).
 
+## Unreleased — minimum Ruby version
+
+<Option name="Avo requires Ruby >= 3.3">
+
+### Breaking Change
+
+Avo's minimum supported Ruby version moves from `3.1` to `3.3`.
+
+The driver is [`pagy`](https://rubygems.org/gems/pagy), which Avo depends on for pagination. `pagy` `43.0.0` already requires Ruby `>= 3.2`, and starting with `pagy` `43.5.0` the floor is Ruby `>= 3.3`. Avo depends on `pagy >= 43.0`, so on anything older than Ruby 3.3 Bundler silently resolves `pagy` back to a `43.4.x` release instead of the current one — you keep booting, but you're pinned to a stale pagination gem and drift further behind with every Avo release.
+
+### Action Required
+
+Run Avo on Ruby `3.3` or newer.
+
+```ruby
+# .ruby-version
+3.3.1
+```
+
+```ruby
+# Gemfile
+ruby ">= 3.3" # [!code ++]
+```
+
+Then re-resolve so `pagy` picks up the current release:
+
+```bash
+bundle update pagy
+```
+
+:::info
+Ruby 3.1 reached end-of-life in March 2025 and Ruby 3.2 in March 2026, so 3.3 is the oldest version still receiving security fixes.
+:::
+
+</Option>
+
 ## Unreleased — resizable sidebar
 
 <Option name="Sidebar labels truncate instead of wrapping">

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -6,42 +6,6 @@ If you're looking for the Avo 3 to Avo 4 upgrade guide, please visit [the dedica
 
 Migrating to TailwindCSS 4? See the [TailwindCSS 4 Migration Guide](./tailwind-4-migration).
 
-## Unreleased — minimum Ruby version
-
-<Option name="Avo requires Ruby >= 3.3">
-
-### Breaking Change
-
-Avo's minimum supported Ruby version moves from `3.1` to `3.3`.
-
-The driver is [`pagy`](https://rubygems.org/gems/pagy), which Avo depends on for pagination. `pagy` `43.0.0` already requires Ruby `>= 3.2`, and starting with `pagy` `43.5.0` the floor is Ruby `>= 3.3`. Avo depends on `pagy >= 43.0`, so on anything older than Ruby 3.3 Bundler silently resolves `pagy` back to a `43.4.x` release instead of the current one — you keep booting, but you're pinned to a stale pagination gem and drift further behind with every Avo release.
-
-### Action Required
-
-Run Avo on Ruby `3.3` or newer.
-
-```ruby
-# .ruby-version
-3.3.1
-```
-
-```ruby
-# Gemfile
-ruby ">= 3.3" # [!code ++]
-```
-
-Then re-resolve so `pagy` picks up the current release:
-
-```bash
-bundle update pagy
-```
-
-:::info
-Ruby 3.1 reached end-of-life in March 2025 and Ruby 3.2 in March 2026, so 3.3 is the oldest version still receiving security fixes.
-:::
-
-</Option>
-
 ## Unreleased — resizable sidebar
 
 <Option name="Sidebar labels truncate instead of wrapping">


### PR DESCRIPTION
Documents Avo 4's real minimum Ruby version: **3.2**, up from the 3.1 we still advertise.

## Why

Avo 4 raised its own `pagy` constraint, and that moved the Ruby floor:

| Avo | `pagy` constraint |
|-----|-------------------|
| 3.x (`v3.32.1`) | `>= 7.0.0, < 43` |
| 4.x | `>= 43.0` |

Every version satisfying `>= 43.0` requires Ruby `>= 3.2`, so the floor moves from 3.1 to 3.2. This is the only dependency that binds — every other gem in the gemspec has a 3.1-compatible version Bundler can still resolve:

| Dep | Avo's constraint | Oldest allowed version's Ruby floor |
|-----|------------------|-------------------------------------|
| `pagy` | `>= 43.0` | `43.0.0` → **`>= 3.2`** |
| `zeitwerk` | `>= 2.6.12` | `2.6.12` → `>= 2.5` |
| `view_component` | `>= 3.7.0` | `3.7.0` → `>= 2.7` |
| `activerecord` | `>= 6.1` | 6.1 → `>= 2.5` |

Within the 43.x line pagy later raised its own floor again:

| pagy version | Required Ruby |
|--------------|---------------|
| `43.0.0` – `43.4.4` | `>= 3.2` |
| [`43.5.0`](https://rubygems.org/gems/pagy/versions/43.5.6) and up (currently `43.6.1`) | `>= 3.3` |

**That second bump does not bind Avo.** Avo asks for `pagy >= 43.0`, and every pagy API Avo touches — `Pagy::Method`, `series_nav`, `querify`, `raise_range_error`, `slots` — is already present in `43.0.0`. Verified by unpacking the gem.

So on Ruby 3.2 Bundler resolving to `pagy 43.4.4` is a **working install**, not a silent failure. Ruby 3.3+ gets `43.6.1`. Both are supported.

The switch to `pagy 43` landed in [#4315](https://github.com/avo-hq/avo/pull/4315), before `v4.0.0.beta.1`. So `Ruby >= 3.1` was right for Avo 3 and has been wrong for Avo 4 since the first beta.

## Changes

- `docs/4.0/installation.md` — Requirements now says `Ruby >= 3.2`.
- `docs/4.0/avo-3-avo-4-upgrade.md` — new **"Upgrade your Ruby version"** step, placed immediately before "Upgrade your gems". The coding-agent prompt at the top of the page now checks Ruby before updating the gems.

The dependency analysis above is **reviewer context and stays out of the docs**. The page states the requirement as Avo's own — "Avo 4 requires Ruby 3.2 or newer, following the minimum its dependencies support" — because that is what it is. Naming the gem reads as deflection, invites workarounds we don't support (pinning an older pagy), and goes stale on every dependency bump. It also runs against this repo's own guidance for guide pages: *"Don't teach the internals. A guide gives directions to a goal."*

Deliberately **not** in `upgrade.md`. The gemspec claiming `>= 3.0.0` is a metadata bug that no Avo 4 release could honor, not a new requirement being introduced — a reader on a supported Ruby has nothing to do. The release upgrade log is for changes that ask something of the reader.

## Follow-up

`avo.gemspec` still declares `spec.required_ruby_version = ">= 3.0.0"`. Until that says `>= 3.2.0`, an app on Ruby 3.1 gets a successful bundle and a runtime failure instead of a clear resolver error — the docs are carrying enforcement the gemspec should do. That fix belongs in [avo-hq/avo](https://github.com/avo-hq/avo). Avo's CI currently only tests Ruby 3.3 and 3.4 — claiming 3.2 support warrants adding it to the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
