### PR TITLE
docs(intelligence): model switching, provider pinning, and dictation scope

### DIFF
--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -303,12 +303,20 @@ class Avo::Intelligence::ChatPolicy < ApplicationPolicy
   def available_models
     return nil if user.admin? # every model in the registry
 
-    ["gpt-4o-mini", "claude-haiku-4-5", "gemini-2.5-flash"]
+    [
+      {model: "claude-haiku-4-5", provider: :anthropic},
+      {model: "claude-sonnet-5", provider: :anthropic},
+      {model: "gpt-4o-mini", provider: :openai},
+      {model: "claude-opus-4-8", provider: :anthropic},
+      {model: "gemini-2.5-flash", provider: :gemini}
+    ]
   end
 end
 ```
 
-Entries are RubyLLM registry model ids. Browse the ones your app knows about through the **Models** resource in the sidebar, or in the console with `RubyLLM.models.chat_models.all.map(&:id)`.
+Each entry names a RubyLLM registry model, and `provider:` says which provider serves it. Browse what your app knows about through the **Models** resource in the sidebar, or in the console with `RubyLLM.models.chat_models.all.map { |m| [m.id, m.provider] }`.
+
+A bare id works too — `"gpt-4o-mini"` instead of the pair — and is the shorter thing to write when the id is unambiguous. Naming the provider is worth the extra keys anyway: several ids are served by more than one provider, and [pinning](#pinning-the-provider) is how you say which one your app talks to.
 
 | Return value                        | What happens                                                                  |
 | ----------------------------------- | ----------------------------------------------------------------------------- |
@@ -328,16 +336,15 @@ The list is enforced on every chat create **and** every message, not just in the
 
 ### Pinning the provider
 
-Some models are served by more than one provider — `gemini-2.5-flash` comes through both Gemini and VertexAI, and much of Anthropic's catalog is also on Bedrock and VertexAI. A bare id resolves to whichever provider RubyLLM itself would pick (its own preference order: OpenAI, Anthropic, Gemini, VertexAI, Bedrock, OpenRouter, …), exactly as if you had handed that id to `RubyLLM.chat`.
+`provider:` is what makes the pair worth writing. Several ids are served by more than one provider — `gemini-2.5-flash` comes through both Gemini and VertexAI, and much of Anthropic's catalog is also on Bedrock and VertexAI — and the key says which one your app talks to.
 
-To say which one your app talks to, give a `{model:, provider:}` pair instead of a plain string:
+Leave it off and the id still resolves, just not to a provider you chose: RubyLLM picks by its own preference order (OpenAI, Anthropic, Gemini, VertexAI, Bedrock, OpenRouter, …), exactly as if you had handed the bare id to `RubyLLM.chat`.
 
 ```ruby
 def available_models
   [
-    "gpt-4o-mini",
-    "claude-haiku-4-5",
-    {model: "gemini-2.5-flash", provider: :vertexai} # [!code focus]
+    "gpt-4o-mini", # whichever provider RubyLLM prefers for this id
+    {model: "gemini-2.5-flash", provider: :vertexai} # [!code focus] VertexAI's, not Gemini's
   ]
 end
 ```

--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -269,7 +269,23 @@ The microphone in every composer — the bar, the new-chat page, and open conver
 
 Minimizing the chat window ends an open session, so the mic never keeps listening behind a closed window.
 
-It uses the browser's built-in speech recognition, so it needs no API key and sends nothing to your provider. The button only appears in browsers that support the Web Speech API — Chrome, Edge, and Safari today; in Firefox there's no microphone in the toolbar.
+It dictates in your admin's language: the recognizer follows the page's `lang` attribute, falling back to the browser's own language setting.
+
+### Browser support, and where the audio goes
+
+Dictation is the browser's built-in [Web Speech API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API), not something the assistant does. There's no API key to set, and neither Avo nor your LLM provider ever sees the audio — they only get the finished text, and only when you send the message. Who *does* see it depends entirely on the browser, and they don't answer alike:
+
+| Browser         | Support                | Where recognition runs                                                                                                                                     |
+| --------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Safari          | 14.1+ macOS, 14.5+ iOS | Apple's speech stack — on device where the language and hardware allow it, Apple's servers otherwise. Safari asks the first time, and the prompt says as much. |
+| Chrome, Edge    | Yes                    | Google's speech service: the audio is uploaded, so dictation needs a connection. Chrome 139 added an opt-in on-device mode, which Avo doesn't request.        |
+| Firefox         | No                     | Nowhere — unimplemented, behind a disabled `dom.webspeech.recognition.enable` flag.                                                                          |
+
+The microphone only renders where the API exists, so Firefox users get a composer with no mic rather than a button that does nothing.
+
+:::warning
+In Chrome and Edge, dictating means uploading admin-panel audio to Google. If that doesn't fit your compliance story, tell your admins to dictate in Safari — there's no gem setting that changes it, because the browser owns the audio path.
+:::
 
 ## Copy a message
 

--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -265,7 +265,9 @@ The list is scoped to the signed-in user. It's not an admin view of everyone's c
 
 ## Dictate a message
 
-The microphone in the composer transcribes speech into the message box: click to start, click to stop. Pauses don't end the session, and the text lands on top of whatever draft is already there, so you can type half a message and speak the rest.
+The microphone in every composer — the bar, the new-chat page, and open conversations — transcribes speech into the message box: click to start, click to stop. Pauses don't end the session, and the text lands on top of whatever draft is already there, so you can type half a message and speak the rest.
+
+Minimizing the chat window ends an open session, so the mic never keeps listening behind a closed window.
 
 It uses the browser's built-in speech recognition, so it needs no API key and sends nothing to your provider. The button only appears in browsers that support the Web Speech API — Chrome, Edge, and Safari today; in Firefox there's no microphone in the toolbar.
 
@@ -275,9 +277,9 @@ Hover any message and a copy button appears beneath it. It copies the raw text t
 
 ## Choose which models people can use
 
-By default a new chat runs on the model you configured in `config/initializers/ruby_llm.rb`, and there is no model picker — the RubyLLM registry is thousands of models long, which is not a dropdown.
+By default a chat runs on the model you configured in `config/initializers/ruby_llm.rb`, and there is no model picker — the RubyLLM registry is thousands of models long, which is not a dropdown.
 
-Give your `Avo::Intelligence::ChatPolicy` an `#available_models` method to curate a shortlist. The composer then shows a picker with exactly those models:
+Give your `Avo::Intelligence::ChatPolicy` an `#available_models` method to curate a shortlist. Every composer — the bar, the new-chat page, and open conversations — then shows a picker with exactly those models:
 
 ```ruby
 # app/policies/avo/intelligence/chat_policy.rb
@@ -290,20 +292,61 @@ class Avo::Intelligence::ChatPolicy < ApplicationPolicy
 end
 ```
 
-The values are RubyLLM registry model ids. Browse the ones your app knows about through the **Models** resource in the sidebar, or in the console with `RubyLLM.models.chat_models.all`.
+Entries are RubyLLM registry model ids. Browse the ones your app knows about through the **Models** resource in the sidebar, or in the console with `RubyLLM.models.chat_models.all.map(&:id)`.
 
-| Return value                   | What happens                                                                  |
-| ------------------------------ | ----------------------------------------------------------------------------- |
-| `nil`, or no method at all     | Every model in the registry, no picker, new chats use the configured default.  |
-| A list of two or more ids      | The picker offers exactly those.                                              |
-| A list of one id               | No picker — there's no choice to make — and every new chat runs on that model. |
-| A list matching no known model | Ignored, with a warning in the logs, so a typo can't lock the assistant up.    |
+| Return value                        | What happens                                                                  |
+| ----------------------------------- | ----------------------------------------------------------------------------- |
+| `nil`, or no method at all          | Every model in the registry, no picker, chats use the configured default.      |
+| Two or more entries                 | The picker offers exactly those, in the order you listed them.                 |
+| One entry                           | No picker — there's no choice to make — and every chat runs on that model.     |
+| A list containing an unknown entry  | That entry is dropped; the rest of the list stands. The log names it.          |
+| A list of nothing but unknown entries | No model to start a chat on, and chat creation is refused.                   |
 
-The list is enforced when the chat is created, not just in the picker — a user can't start a chat on a model you withheld by crafting the request themselves. The configured default model stays available only if your list includes it.
+Your list is taken **exactly**. Three things follow from that, and they're the ones worth knowing:
+
+- **Order is yours.** The picker reads back in the order you wrote, not alphabetically, and **the first entry is what a new chat starts on**. Put the model you want people reaching for at the top. There's no "the configured default" entry in the picker — it would only ever name a model already in your list.
+- **Ids must match character for character.** No aliases, no near matches. `claude-sonnet-4-8` doesn't become `claude-sonnet-4-6` because you meant it to.
+- **An unknown entry is simply absent.** It doesn't widen the catalog back to the whole registry — the log names it (`ChatPolicy#available_models lists unknown chat models: …`) and the rest of your list stands. A list of nothing but typos leaves no model to chat on, and chat creation is refused rather than quietly falling back to one you never granted.
+
+The list is enforced on every chat create **and** every message, not just in the picker — the picker is UI, the server re-checks. A user can't start a chat on, or switch a chat onto, a model you withheld by crafting the request themselves.
+
+### Pinning the provider
+
+Some models are served by more than one provider — `gemini-2.5-flash` comes through both Gemini and VertexAI, and much of Anthropic's catalog is also on Bedrock and VertexAI. A bare id resolves to whichever provider RubyLLM itself would pick (its own preference order: OpenAI, Anthropic, Gemini, VertexAI, Bedrock, OpenRouter, …), exactly as if you had handed that id to `RubyLLM.chat`.
+
+To say which one your app talks to, give a `{model:, provider:}` pair instead of a plain string:
+
+```ruby
+def available_models
+  [
+    "gpt-4o-mini",
+    "claude-haiku-4-5",
+    {model: "gemini-2.5-flash", provider: :vertexai} # [!code focus]
+  ]
+end
+```
+
+Provider is its own key rather than part of the string — the same shape RubyLLM uses everywhere (`RubyLLM.chat(model:, provider:)`), and the only workable one here, since real model ids already contain both `/` (OpenRouter) and `@` (VertexAI).
+
+Each id appears once in the picker either way: pinned, it's the provider you named; unpinned, it's the one RubyLLM prefers. Both the chat and each of its messages store the provider alongside the model, so the transcript says where every answer came from.
 
 :::info
-This governs which models a chat can be *started* on. It doesn't re-home existing conversations: a chat already running on a model keeps running on it, even if you later drop that model from the list.
+A pinned pair whose provider doesn't carry that model is dropped like any other unknown entry, and the log names both halves — `model-id (provider)`.
 :::
+
+:::warning
+Pin only a provider you have configured. RubyLLM validates the provider's credentials when the chat is created, so pinning `provider: :vertexai` without VertexAI keys in `config/initializers/ruby_llm.rb` raises `RubyLLM::ConfigurationError` on the first chat rather than at boot.
+:::
+
+### Switching model mid-conversation
+
+The picker stays in the composer once the chat exists, so a conversation can change models partway through: pick another model and send.
+
+The switch takes effect from that message on. The transcript so far is replayed to the new model — nothing is lost, and the new model answers with the whole conversation in view — and each message records which model wrote it.
+
+The picker is disabled while the assistant is responding; the model is yours to change on your turn.
+
+A chat keeps running on its model even if you later drop that model from `#available_models`. Its own picker still lists it — otherwise the dropdown would misreport what the next message runs on — and re-picking it is a no-op, so the conversation is never stranded. But nobody can switch a chat *onto* a model you've withdrawn.
 
 ## Who can delete a chat
 


### PR DESCRIPTION
Follows #595, covering what the model policy grew into on the gem side.

### Switching model mid-conversation

`#available_models` no longer governs only chat creation — the picker stays in the composer, so a conversation can change models partway through. Documents that the switch takes effect from the next message, the transcript so far is replayed to the new model, each message records which model wrote it, and the picker is disabled while the assistant is responding.

A chat keeps running on its model even after you drop that model from the list. Its own picker still lists it — otherwise the dropdown would misreport what the next message runs on — and re-picking it is a no-op, so the conversation is never stranded. Nobody can switch a chat *onto* a withdrawn model.

### Pinning the provider

New `{model:, provider:}` entry shape for ids served by more than one provider (`gemini-2.5-flash` through both Gemini and VertexAI). Provider is its own key rather than part of the string — the shape RubyLLM uses, and the only workable one, since real ids already contain `/` and `@`. Includes a warning that RubyLLM validates the pinned provider's credentials at chat creation, so pinning a provider you haven't configured raises on the first chat rather than at boot.

### The list is taken exactly

Rewrote the return-value table around that: order is the running order, the first entry is what a new chat starts on, an unknown entry is dropped (and named in the log) rather than widening the catalog back to the whole registry, and a list of nothing but typos refuses chat creation instead of quietly falling back to a model you never granted. Also notes the list is enforced on every create *and* every message — the picker is UI, the server re-checks.

### Composer surfaces

The picker and the microphone appear in every composer now — the bar, the new-chat page, and open conversations — not just the bar. Minimizing the chat window ends an open dictation session, so the mic never keeps listening behind a closed window.

---

Known gap, not in this PR: the **Models** resource is documented only as a place to browse ids. It doesn't yet say the resource is read-only, that the catalog is synced by the standalone **Refresh models** action (the first run fetches every provider's full catalog and is slow), or that the gem ships an `Avo::Intelligence::ModelPolicy` closing the write routes which a host can shadow with its own.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Expands **`docs/4.0/intelligence.md`** to match current Intelligence behavior around model policy, composers, and dictation—no application code changes.
> 
> **Dictation** is documented for every composer (bar, new-chat, open chats), with minimize ending an active session, `lang`-based recognition, and a new subsection on Web Speech API browser support and where audio is processed (including a Chrome/Edge compliance warning).
> 
> **`ChatPolicy#available_models`** is rewritten: `{model:, provider:}` entries with pinning semantics, an updated return-value table (exact list order, first entry as default, unknown entries dropped, all-typos refuses creation), and enforcement on every create **and** message—not only the picker.
> 
> New sections cover **pinning the provider** (RubyLLM resolution, stored provider on chats/messages, credential validation warning) and **switching model mid-conversation** (transcript replay, per-message model, picker disabled while streaming, withdrawn models still visible on existing chats but not switchable onto).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 392ebd2d851748d8b6e29e9bb65455e2740e6c24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->