### PR TITLE
docs(skills): document the gem-shipped skills loader

### DIFF
--- a/docs/4.0/agentic-engineering.md
+++ b/docs/4.0/agentic-engineering.md
@@ -34,8 +34,10 @@ Run `bundle update avo` and the skills update with it. There is nothing to copy 
 
 Re-run `rails g avo:skills` after upgrading Avo to refresh the loader itself; it warns when its own copy is older than the gem.
 
-:::warning Remove any older global install
-If you previously installed the skills with `npx skills add avo-hq/skills`, a Claude Code plugin, or a manual symlink, remove that copy. It can shadow the gem-shipped skills and silently serve instructions for a different Avo version.
+:::warning Older global installs
+If you previously installed the skills with `npx skills add avo-hq/skills`, a Claude Code plugin, or a manual symlink, that copy can shadow the gem-shipped skills and silently serve instructions for a different Avo version.
+
+`rails g avo:skills` detects those leftovers and asks whether to remove the ones in your project. Pass `--clean-legacy` to skip the prompt, or `--no-clean-legacy` to keep them. Anything in `~/.claude/skills` is reported but never deleted — that directory is shared with your other projects.
 :::
 
 :::info Avo 3

--- a/docs/4.0/agentic-engineering.md
+++ b/docs/4.0/agentic-engineering.md
@@ -20,75 +20,33 @@ AI agents generate better code when they have up-to-date Avo documentation in th
 
 Skills are pre-built instruction sets that teach your agent how to perform specific Avo workflows. Instead of prompting from scratch each time, you install a skill and the agent follows a proven, repeatable process.
 
-The skills ship **inside the `avo` gem**, so they describe the version your app has locked rather than whatever version a globally-installed copy happened to be written for. Install the loader that finds them:
+The skills ship **inside the `avo` gem**, so they describe the version your app has locked rather than whatever version a globally-installed copy happened to be written for.
+
+Install the loader that finds them with **`rails g avo:skills`**:
 
 <CustomCode content="rails g avo:skills" />
 
-An install panel asks one question at a time. Arrow keys move, <kbd>enter</kbd> continues, <kbd>←</kbd> goes back to change an earlier answer:
+That starts a short interactive installer. It explains each choice as you go and shows you exactly what it will do before writing anything. It:
 
-```
-  Where should the Avo skills loader go?
-  It finds the gem from the working directory, so one copy serves every project correctly.
-
-  › (•) This app (recommended)  commit it, your team gets it
-    ( ) This machine            one install, every Avo project
-
-  ↑↓ move   enter continue   q cancel
-```
-
-```
-  Which agents should read it?
-
-  › [x] .agents/skills  Codex, Gemini CLI, Goose, Amp, OpenCode
-    [x] .claude/skills  Claude Code
-    [x] .cursor/skills  Cursor
-
-  ↑↓ move   space toggle   enter continue   ← back   q cancel
-```
-
-Nothing is written until the last screen shows what it is about to do:
-
-```
-  Run the installation?
-
-    Install to    this app
-    Directories   .agents/skills, .claude/skills, .cursor/skills
-    Extra copies  symlinked to .agents/skills
-
-  › (•) Yes, install (recommended)
-    ( ) No, cancel
-
-  ↑↓ move   enter continue   ← back   q cancel
-```
+- installs into this app, or into your home directory so one copy serves every Avo project
+- sets up any of `.agents/skills`, `.claude/skills`, and `.cursor/skills`
+- writes one real file and symlinks the others to it, so they cannot drift apart
+- offers to remove skills left behind by an older, unversioned install
 
 It writes one small markdown file. The skills themselves are never copied into your repo — the loader resolves them from the installed gem when a task actually needs them.
-
-Pick more than one agent directory and you get **one real file, symlinked from the rest**, so updating the loader is a single edit and the directories cannot drift apart. `.agents/skills` holds the file. On a filesystem without symlinks the generator notices and writes copies instead.
 
 Skills are organized by **vertical** — a whole feature area, not a single task — so one skill covers creating, configuring, and troubleshooting that part of Avo.
 
 ### Keeping them current
 
-Run `bin/rails avo:update` and the skills update with the gems. There is nothing to copy and nothing that can drift out of sync with your app.
+They are always current. The skills come from the gem your app has locked, so there is nothing to copy and nothing that can fall behind.
 
-Use that task rather than `bundle update avo`: skills ship in every Avo gem, not just core, so bumping core alone leaves each add-on's skills behind. `avo:update` resolves every installed Avo gem and updates them together, conservatively — and the [`avo-update` skill](#skills) walks the upgrade guide for the versions you crossed.
-
-Re-run `rails g avo:skills` after upgrading Avo to refresh the loader itself; it warns when its own copy is older than the gem.
+Update your Avo gems with `bin/rails avo:update` and the skills come with them. Use that task rather than `bundle update avo`, which moves core alone and leaves each add-on's skills on the version they were already pinned to.
 
 :::warning Older global installs
 If you previously installed the skills with `npx skills add avo-hq/skills`, a Claude Code plugin, or a manual symlink, that copy can shadow the gem-shipped skills and silently serve instructions for a different Avo version.
 
-`rails g avo:skills` finds those leftovers and offers to remove them — screens you only see when there is actually something to remove:
-
-```
-  Remove the 2 skills left by an earlier install?
-  They are not version-pinned and can shadow the skills that ship with your gem.
-
-  › (•) Yes, remove them (recommended)
-    ( ) No, leave them
-```
-
-Your project and `~/.claude/skills` are asked separately, since that second directory is shared with every other project on the machine. Decline either and the generator prints the `rm -rf` you would need to do it later.
+The installer finds those leftovers and offers to remove them, asking about your project and `~/.claude/skills` separately — that second directory is shared with every other project on your machine. Decline either and it prints the `rm -rf` you would need to do it later.
 :::
 
 :::info Avo 3
@@ -151,7 +109,7 @@ Paid add-on skills arrive with their gems — install `avo-kanban` and its skill
 
 ### One loader for every project
 
-Answer **This machine** on the first screen.
+Choose **This machine** when the installer asks where the loader should go.
 
 The loader carries no version knowledge — it finds the app by walking up from the working directory and reads that app's `Gemfile.lock` — so a single copy serves every Avo project on the machine, each resolving its own version. Install once and you are done.
 

--- a/docs/4.0/agentic-engineering.md
+++ b/docs/4.0/agentic-engineering.md
@@ -24,22 +24,46 @@ The skills ship **inside the `avo` gem**, so they describe the version your app 
 
 <CustomCode content="rails g avo:skills" />
 
-An install panel asks where it should go and which agents to set up:
+An install panel asks one question at a time. Arrow keys move, <kbd>enter</kbd> continues, <kbd>←</kbd> goes back to change an earlier answer:
 
 ```
-  Where
-    (•) This app         committed, so the whole team gets it
-    ( ) This machine     one install, every Avo project
+  Where should the Avo skills loader go?
+  It finds the gem from the working directory, so one copy serves every project correctly.
 
-  Which agents
-    [x] .claude/skills   Claude Code
-    [x] .agents/skills   Codex, Gemini CLI, Goose, Amp, OpenCode
-    [x] .cursor/skills   Cursor
+  › (•) This app (recommended)  commit it, your team gets it
+    ( ) This machine            one install, every Avo project
 
-  ↑↓ move   space select   enter install   q cancel
+  ↑↓ move   enter continue   q cancel
 ```
 
-It writes one small markdown file per agent directory you pick. The skills themselves are never copied into your repo — the loader resolves them from the installed gem when a task actually needs them.
+```
+  Which agents should read it?
+
+  › [x] .agents/skills  Codex, Gemini CLI, Goose, Amp, OpenCode
+    [x] .claude/skills  Claude Code
+    [x] .cursor/skills  Cursor
+
+  ↑↓ move   space toggle   enter continue   ← back   q cancel
+```
+
+Nothing is written until the last screen shows what it is about to do:
+
+```
+  Run the installation?
+
+    Install to    this app
+    Directories   .agents/skills, .claude/skills, .cursor/skills
+    Extra copies  symlinked to .agents/skills
+
+  › (•) Yes, install (recommended)
+    ( ) No, cancel
+
+  ↑↓ move   enter continue   ← back   q cancel
+```
+
+It writes one small markdown file. The skills themselves are never copied into your repo — the loader resolves them from the installed gem when a task actually needs them.
+
+Pick more than one agent directory and you get **one real file, symlinked from the rest**, so updating the loader is a single edit and the directories cannot drift apart. `.agents/skills` holds the file. On a filesystem without symlinks the generator notices and writes copies instead.
 
 Skills are organized by **vertical** — a whole feature area, not a single task — so one skill covers creating, configuring, and troubleshooting that part of Avo.
 
@@ -54,7 +78,17 @@ Re-run `rails g avo:skills` after upgrading Avo to refresh the loader itself; it
 :::warning Older global installs
 If you previously installed the skills with `npx skills add avo-hq/skills`, a Claude Code plugin, or a manual symlink, that copy can shadow the gem-shipped skills and silently serve instructions for a different Avo version.
 
-`rails g avo:skills` detects those leftovers and asks whether to remove the ones in your project. Pass `--clean-legacy` to skip the prompt, or `--no-clean-legacy` to keep them. Anything in `~/.claude/skills` is reported but never deleted — that directory is shared with your other projects.
+`rails g avo:skills` finds those leftovers and offers to remove them — screens you only see when there is actually something to remove:
+
+```
+  Remove the 2 skills left by an earlier install?
+  They are not version-pinned and can shadow the skills that ship with your gem.
+
+  › (•) Yes, remove them (recommended)
+    ( ) No, leave them
+```
+
+Your project and `~/.claude/skills` are asked separately, since that second directory is shared with every other project on the machine. Decline either and the generator prints the `rm -rf` you would need to do it later.
 :::
 
 :::info Avo 3
@@ -115,13 +149,9 @@ Separately-licensed gems (paid add-on or Enterprise). `avo-media-library` is Com
 
 Paid add-on skills arrive with their gems — install `avo-kanban` and its skill comes with it. The loader lists what your app actually has, and names the add-on for anything it does not, so an agent never describes a feature you cannot use.
 
-Pick the agent directories in the panel, or skip it with flags: `--only claude`, `--only cursor`, `--only agents`, or `--path` to install somewhere else. Any flag, or a non-interactive shell, skips the panel and installs the defaults.
-
 ### One loader for every project
 
-Choose **This machine** in the panel, or pass the flag:
-
-<CustomCode content="rails g avo:skills --global" />
+Answer **This machine** on the first screen.
 
 The loader carries no version knowledge — it finds the app by walking up from the working directory and reads that app's `Gemfile.lock` — so a single copy serves every Avo project on the machine, each resolving its own version. Install once and you are done.
 

--- a/docs/4.0/agentic-engineering.md
+++ b/docs/4.0/agentic-engineering.md
@@ -35,15 +35,71 @@ That starts a short interactive installer. It explains each choice as you go and
 
 It writes one small markdown file. The skills themselves are never copied into your repo — the loader resolves them from the installed gem when a task actually needs them.
 
-Skills are organized by **vertical** — a whole feature area, not a single task — so one skill covers creating, configuring, and troubleshooting that part of Avo. Together they span resources, fields, actions, filters, authorization, custom UI, i18n, performance, testing, and every paid add-on.
-
-Paid add-on skills arrive with their gems — install `avo-kanban` and its skill comes with it. The loader lists what your app actually has, and names the add-on for anything it does not, so an agent never describes a feature you cannot use.
+Skills are organized by **vertical** — a whole feature area, not a single task — so one skill covers creating, configuring, and troubleshooting that part of Avo.
 
 ### Keeping them current
 
 They are always current. The skills come from the gem your app has locked, so there is nothing to copy and nothing that can fall behind.
 
 Update your Avo gems with `bin/rails avo:update` and the skills come with them. Use that task rather than `bundle update avo`, which moves core alone and leaves each add-on's skills on the version they were already pinned to.
+
+### Core
+
+- `avo-resources` — generate and configure resources — title, includes, sorting, pagination, cover/avatar, array (non-DB) resources
+- `avo-fields` — add and configure fields in `def fields` — pick the `as:` type, options, formatting, layout
+- `avo-associations` — wire `belongs_to` / `has_many` / `has_one` / HABTM fields, searchable pickers, polymorphism, STI
+- `avo-actions` — build actions that run Ruby on selected, single, or no records — bulk ops, forms, modals, responses
+- `avo-filters` — filter and segment the index — basic filters, dynamic filters, and scopes
+- `avo-index-views` — control how the index renders — table styling, grid cards, map markers, view types
+- `avo-menu-icons` — auto-populate menu items with semantically appropriate Tabler icons
+
+### Config & ops
+
+- `avo-setup` — install Avo, mount it, authenticate the private gem server, and set the license key
+- `avo-update` — bump the Avo gems and apply every upgrade-guide step for the versions crossed, with a log
+- `avo-authentication` — tell Avo who the current user is, gate access, and wire roles / profile / sign-out
+- `avo-authorization` — restrict who sees and does what with Pundit policies — resources, actions, associations, files
+- `avo-admin-config` — global initializer knobs — app name, per-page, container width, density, home path
+- `avo-performance` — caching and stale-row fixes to make the admin fast
+- `avo-testing` — unblock the license check in the test suite and use Avo's test helpers
+
+### Customization
+
+- `avo-branding-appearance` — make the admin look like the product — logo, favicon, color scheme, palettes, CSS re-skin, icons
+- `avo-navigation-search` — menus, breadcrumbs, keyboard shortcuts, per-resource search, and the <kbd>Cmd</kbd> + <kbd>K</kbd> global search palette
+- `avo-custom-ui` — build custom pages, embedded panels, dynamic/nested forms, eject views, JS/Stimulus, Tailwind
+- `avo-custom-fields` — build a brand-new field type — generator plus its Edit/Show/Index view components
+- `avo-i18n` — translate and localize the admin — labels, locale switching, RTL
+- `avo-multitenancy` — scope the admin per tenant — route- or session-based, with an account switcher
+- `avo-record-reordering` — persistent up/down and drag-and-drop record ordering
+- `avo-custom-controls` — take over the show/edit/index/row button bars — relabel, remove, add links/actions/dropdowns
+- `avo-controllers` — override per-resource CRUD controller hooks and safely extend Avo's `ApplicationController`
+- `avo-engine-internals` — engine plumbing for custom Ruby — `main_app`/`avo` helpers, `Avo::Current`, `ExecutionContext`, reserved names
+
+### Add-ons
+
+Separately-licensed gems (paid add-on or Enterprise). `avo-media-library` is Community but off by default.
+
+- `avo-dashboards-cards` — dashboards (grids of cards) and the six card types — metrics, charts, tables, lists
+- `avo-notifications` — in-app notifications — bell dropdown, levels, action buttons, optional realtime
+- `avo-rest-api` — JSON REST API over every resource, with token auth and a per-token permission matrix
+- `avo-forms-and-pages` — model-agnostic forms (settings, imports, workflows) and sidebar page hierarchies
+- `avo-kanban` — DB-backed drag-and-drop boards across resources
+- `avo-audit-logging` — track who changed and viewed what — timeline, diffs, revert
+- `avo-collaboration` — comments, reactions, and an automatic change-log on a record
+- `avo-media-library` — central asset browser and a picker inside rich-text editors
+- `avo-http-resource` — back a resource with an external HTTP API instead of Active Record
+- `avo-menu` — build the sidebar with the menu editor DSL — sections, dividers, links, icons, per-user visibility
+- `avo-scopes` — one-click segment tabs above the index, with counts and a default view
+- `avo-dynamic-filters` — let end users build their own ad-hoc filters from a filters bar
+- `avo-advanced-search` — the <kbd>Cmd</kbd> + <kbd>K</kbd> global search palette, and type-to-search association pickers
+
+### Cross-cutting
+
+- `avo-aware` — keep the admin in sync when you change a Rails model, even when the request never mentions Avo
+- `avo-troubleshoot` — diagnose a broken or misbehaving Avo app, organized by symptom
+
+Paid add-on skills arrive with their gems — install `avo-kanban` and its skill comes with it. The loader lists what your app actually has, and names the add-on for anything it does not, so an agent never describes a feature you cannot use.
 
 ### One loader for every project
 

--- a/docs/4.0/agentic-engineering.md
+++ b/docs/4.0/agentic-engineering.md
@@ -24,7 +24,22 @@ The skills ship **inside the `avo` gem**, so they describe the version your app 
 
 <CustomCode content="rails g avo:skills" />
 
-That writes one small file into `.claude/skills/avo/`, `.agents/skills/avo/`, and `.cursor/skills/avo/`. The skills themselves are never copied into your repo — the loader resolves them from the installed gem when a task actually needs them.
+An install panel asks where it should go and which agents to set up:
+
+```
+  Where
+    (•) This app         committed, so the whole team gets it
+    ( ) This machine     one install, every Avo project
+
+  Which agents
+    [x] .claude/skills   Claude Code
+    [x] .agents/skills   Codex, Gemini CLI, Goose, Amp, OpenCode
+    [x] .cursor/skills   Cursor
+
+  ↑↓ move   space select   enter install   q cancel
+```
+
+It writes one small markdown file per agent directory you pick. The skills themselves are never copied into your repo — the loader resolves them from the installed gem when a task actually needs them.
 
 Skills are organized by **vertical** — a whole feature area, not a single task — so one skill covers creating, configuring, and troubleshooting that part of Avo.
 
@@ -100,17 +115,17 @@ Separately-licensed gems (paid add-on or Enterprise). `avo-media-library` is Com
 
 Paid add-on skills arrive with their gems — install `avo-kanban` and its skill comes with it. The loader lists what your app actually has, and names the add-on for anything it does not, so an agent never describes a feature you cannot use.
 
-The loader is installed for Claude Code, Cursor, and any agent that reads `.agents/skills/`. Use `--only claude`, `--only cursor`, or `--only agents` to install just one, or `--path` to install somewhere else.
+Pick the agent directories in the panel, or skip it with flags: `--only claude`, `--only cursor`, `--only agents`, or `--path` to install somewhere else. Any flag, or a non-interactive shell, skips the panel and installs the defaults.
 
 ### One loader for every project
 
-Pass `--global` to install into your home directory instead:
+Choose **This machine** in the panel, or pass the flag:
 
 <CustomCode content="rails g avo:skills --global" />
 
 The loader carries no version knowledge — it finds the app by walking up from the working directory and reads that app's `Gemfile.lock` — so a single copy serves every Avo project on the machine, each resolving its own version. Install once and you are done.
 
-The per-app install is still worth it for a team: the loader is two small files you commit, so everyone gets it on `git pull` rather than each person installing it themselves.
+The per-app install is still worth it for a team: the loader is one small file you commit, so everyone gets it on `git pull` rather than each person installing it themselves.
 
 ## MCP server
 

--- a/docs/4.0/agentic-engineering.md
+++ b/docs/4.0/agentic-engineering.md
@@ -35,77 +35,15 @@ That starts a short interactive installer. It explains each choice as you go and
 
 It writes one small markdown file. The skills themselves are never copied into your repo — the loader resolves them from the installed gem when a task actually needs them.
 
-Skills are organized by **vertical** — a whole feature area, not a single task — so one skill covers creating, configuring, and troubleshooting that part of Avo.
+Skills are organized by **vertical** — a whole feature area, not a single task — so one skill covers creating, configuring, and troubleshooting that part of Avo. Together they span resources, fields, actions, filters, authorization, custom UI, i18n, performance, testing, and every paid add-on.
+
+Paid add-on skills arrive with their gems — install `avo-kanban` and its skill comes with it. The loader lists what your app actually has, and names the add-on for anything it does not, so an agent never describes a feature you cannot use.
 
 ### Keeping them current
 
 They are always current. The skills come from the gem your app has locked, so there is nothing to copy and nothing that can fall behind.
 
 Update your Avo gems with `bin/rails avo:update` and the skills come with them. Use that task rather than `bundle update avo`, which moves core alone and leaves each add-on's skills on the version they were already pinned to.
-
-:::warning Older global installs
-If you previously installed the skills with `npx skills add avo-hq/skills`, a Claude Code plugin, or a manual symlink, that copy can shadow the gem-shipped skills and silently serve instructions for a different Avo version.
-
-The installer finds those leftovers and offers to remove them, asking about your project and `~/.claude/skills` separately — that second directory is shared with every other project on your machine. Decline either and it prints the `rm -rf` you would need to do it later.
-:::
-
-:::info Avo 3
-Older versions of Avo do not ship skills. If yours predates them the loader says so and stops rather than guessing — run `bin/rails avo:update` to get a version that has them, or use the [docs](https://docs.avohq.io) directly in the meantime.
-:::
-
-### Core
-
-- `avo-resources` — generate and configure resources — title, includes, sorting, pagination, cover/avatar, array (non-DB) resources
-- `avo-fields` — add and configure fields in `def fields` — pick the `as:` type, options, formatting, layout
-- `avo-associations` — wire `belongs_to` / `has_many` / `has_one` / HABTM fields, searchable pickers, polymorphism, STI
-- `avo-actions` — build actions that run Ruby on selected, single, or no records — bulk ops, forms, modals, responses
-- `avo-filters` — filter and segment the index — basic filters, dynamic filters, and scopes
-- `avo-index-views` — control how the index renders — table styling, grid cards, map markers, view types
-- `avo-menu-icons` — auto-populate menu items with semantically appropriate Tabler icons
-
-### Config & ops
-
-- `avo-setup` — install Avo, mount it, authenticate the private gem server, and set the license key
-- `avo-update` — bump the Avo gems and apply every upgrade-guide step for the versions crossed, with a log
-- `avo-authentication` — tell Avo who the current user is, gate access, and wire roles / profile / sign-out
-- `avo-authorization` — restrict who sees and does what with Pundit policies — resources, actions, associations, files
-- `avo-admin-config` — global initializer knobs — app name, per-page, container width, density, home path
-- `avo-performance` — caching and stale-row fixes to make the admin fast
-- `avo-testing` — unblock the license check in the test suite and use Avo's test helpers
-
-### Customization
-
-- `avo-branding-appearance` — make the admin look like the product — logo, favicon, color scheme, palettes, CSS re-skin, icons
-- `avo-navigation-search` — menus, breadcrumbs, keyboard shortcuts, per-resource search, and the <kbd>Cmd</kbd> + <kbd>K</kbd> global search palette
-- `avo-custom-ui` — build custom pages, embedded panels, dynamic/nested forms, eject views, JS/Stimulus, Tailwind
-- `avo-custom-fields` — build a brand-new field type — generator plus its Edit/Show/Index view components
-- `avo-i18n` — translate and localize the admin — labels, locale switching, RTL
-- `avo-multitenancy` — scope the admin per tenant — route- or session-based, with an account switcher
-- `avo-record-reordering` — persistent up/down and drag-and-drop record ordering
-- `avo-custom-controls` — take over the show/edit/index/row button bars — relabel, remove, add links/actions/dropdowns
-- `avo-controllers` — override per-resource CRUD controller hooks and safely extend Avo's `ApplicationController`
-- `avo-engine-internals` — engine plumbing for custom Ruby — `main_app`/`avo` helpers, `Avo::Current`, `ExecutionContext`, reserved names
-
-### Add-ons
-
-Separately-licensed gems (paid add-on or Enterprise). `avo-media-library` is Community but off by default.
-
-- `avo-dashboards-cards` — dashboards (grids of cards) and the six card types — metrics, charts, tables, lists
-- `avo-notifications` — in-app notifications — bell dropdown, levels, action buttons, optional realtime
-- `avo-rest-api` — JSON REST API over every resource, with token auth and a per-token permission matrix
-- `avo-forms-and-pages` — model-agnostic forms (settings, imports, workflows) and sidebar page hierarchies
-- `avo-kanban` — DB-backed drag-and-drop boards across resources
-- `avo-audit-logging` — track who changed and viewed what — timeline, diffs, revert
-- `avo-collaboration` — comments, reactions, and an automatic change-log on a record
-- `avo-media-library` — central asset browser and a picker inside rich-text editors
-- `avo-http-resource` — back a resource with an external HTTP API instead of Active Record
-
-### Cross-cutting
-
-- `avo-aware` — keep the admin in sync when you change a Rails model, even when the request never mentions Avo
-- `avo-troubleshoot` — diagnose a broken or misbehaving Avo app, organized by symptom
-
-Paid add-on skills arrive with their gems — install `avo-kanban` and its skill comes with it. The loader lists what your app actually has, and names the add-on for anything it does not, so an agent never describes a feature you cannot use.
 
 ### One loader for every project
 

--- a/docs/4.0/agentic-engineering.md
+++ b/docs/4.0/agentic-engineering.md
@@ -1,5 +1,5 @@
 ---
-prompt: Use this page (${link}) to set up my AI coding agent to work with Avo — add the LLM docs context, install the Avo skills, and connect the MCP server.
+prompt: Use this page (${link}) to set up my AI coding agent to work with Avo — add the LLM docs context, install the Avo skills loader, and connect the MCP server.
 ---
 
 # Agentic engineering
@@ -20,15 +20,27 @@ AI agents generate better code when they have up-to-date Avo documentation in th
 
 Skills are pre-built instruction sets that teach your agent how to perform specific Avo workflows. Instead of prompting from scratch each time, you install a skill and the agent follows a proven, repeatable process.
 
-The [avo-hq/skills](https://github.com/avo-hq/skills) repository contains the official skill collection. Install all of them with:
+The skills ship **inside the `avo` gem**, so they describe the version your app has locked rather than whatever version a globally-installed copy happened to be written for. Install the loader that finds them:
 
-<CustomCode content="npx skills add avo-hq/skills" />
+<CustomCode content="rails g avo:skills" />
 
-Or install just one, for example:
-
-<CustomCode content="npx skills add avo-hq/avo-menu-icons" />
+That writes one small file into `.claude/skills/avo/`, `.agents/skills/avo/`, and `.cursor/skills/avo/`. The skills themselves are never copied into your repo — the loader resolves them from the installed gem when a task actually needs them.
 
 Skills are organized by **vertical** — a whole feature area, not a single task — so one skill covers creating, configuring, and troubleshooting that part of Avo.
+
+### Keeping them current
+
+Run `bundle update avo` and the skills update with it. There is nothing to copy and nothing that can drift out of sync with your app.
+
+Re-run `rails g avo:skills` after upgrading Avo to refresh the loader itself; it warns when its own copy is older than the gem.
+
+:::warning Remove any older global install
+If you previously installed the skills with `npx skills add avo-hq/skills`, a Claude Code plugin, or a manual symlink, remove that copy. It can shadow the gem-shipped skills and silently serve instructions for a different Avo version.
+:::
+
+:::info Avo 3
+Gem-shipped skills start in Avo 4.1.0. On an earlier version the loader tells you so and stops rather than guessing — use the [docs](https://docs.avohq.io) directly.
+:::
 
 ### Core
 
@@ -82,7 +94,9 @@ Separately-licensed gems (paid add-on or Enterprise). `avo-media-library` is Com
 - `avo-aware` — keep the admin in sync when you change a Rails model, even when the request never mentions Avo
 - `avo-troubleshoot` — diagnose a broken or misbehaving Avo app, organized by symptom
 
-Skills work with Claude Code, Cursor, Windsurf, Goose, and any other agent that supports a skills/rules system. See the [repo README](https://github.com/avo-hq/skills) for installation instructions for each tool.
+Paid add-on skills arrive with their gems — install `avo-kanban` and its skill comes with it. The loader lists what your app actually has, and names the add-on for anything it does not, so an agent never describes a feature you cannot use.
+
+The loader is installed for Claude Code, Cursor, and any agent that reads `.agents/skills/`. Use `--only claude`, `--only cursor`, or `--only agents` to install just one, or `--path` to install somewhere else.
 
 ## MCP server
 
@@ -97,6 +111,6 @@ Each editor's [setup page](#pick-your-tool) covers how to add it to that tool. T
 ## Suggested workflow
 
 1. Set up your editor with the Avo LLM context — [see above](#code-editors-and-llm-setup).
-2. Install the Avo skills from [github.com/avo-hq/skills](https://github.com/avo-hq/skills).
+2. Install the Avo skills loader — run `rails g avo:skills` in your app.
 3. Describe what you want to build. The agent will follow the skill workflow and reference the docs automatically.
 4. Optionally connect the [Context7 MCP server](#mcp-server) so the agent can query Avo's docs directly.

--- a/docs/4.0/agentic-engineering.md
+++ b/docs/4.0/agentic-engineering.md
@@ -43,7 +43,7 @@ If you previously installed the skills with `npx skills add avo-hq/skills`, a Cl
 :::
 
 :::info Avo 3
-Gem-shipped skills start in Avo 4.1.0. On an earlier version the loader tells you so and stops rather than guessing — use the [docs](https://docs.avohq.io) directly.
+Older versions of Avo do not ship skills. If yours predates them the loader says so and stops rather than guessing — run `bin/rails avo:update` to get a version that has them, or use the [docs](https://docs.avohq.io) directly in the meantime.
 :::
 
 ### Core

--- a/docs/4.0/agentic-engineering.md
+++ b/docs/4.0/agentic-engineering.md
@@ -102,6 +102,16 @@ Paid add-on skills arrive with their gems — install `avo-kanban` and its skill
 
 The loader is installed for Claude Code, Cursor, and any agent that reads `.agents/skills/`. Use `--only claude`, `--only cursor`, or `--only agents` to install just one, or `--path` to install somewhere else.
 
+### One loader for every project
+
+Pass `--global` to install into your home directory instead:
+
+<CustomCode content="rails g avo:skills --global" />
+
+The loader carries no version knowledge — it finds the app by walking up from the working directory and reads that app's `Gemfile.lock` — so a single copy serves every Avo project on the machine, each resolving its own version. Install once and you are done.
+
+The per-app install is still worth it for a team: the loader is two small files you commit, so everyone gets it on `git pull` rather than each person installing it themselves.
+
 ## MCP server
 
 For agents that support MCP, the [Context7](https://context7.com/) [MCP server](https://github.com/upstash/context7-mcp) serves up-to-date docs for many libraries, including Avo. The agent queries it for the exact docs it needs while building features, instead of relying on stale training data.

--- a/docs/4.0/agentic-engineering.md
+++ b/docs/4.0/agentic-engineering.md
@@ -45,59 +45,69 @@ Update your Avo gems with `bin/rails avo:update` and the skills come with them. 
 
 ### Core
 
-- `avo-resources` — generate and configure resources — title, includes, sorting, pagination, cover/avatar, array (non-DB) resources
-- `avo-fields` — add and configure fields in `def fields` — pick the `as:` type, options, formatting, layout
-- `avo-associations` — wire `belongs_to` / `has_many` / `has_one` / HABTM fields, searchable pickers, polymorphism, STI
-- `avo-actions` — build actions that run Ruby on selected, single, or no records — bulk ops, forms, modals, responses
-- `avo-filters` — filter and segment the index — basic filters, dynamic filters, and scopes
-- `avo-index-views` — control how the index renders — table styling, grid cards, map markers, view types
-- `avo-menu-icons` — auto-populate menu items with semantically appropriate Tabler icons
+| Skill                     | What it covers                                                                                                  |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `avo-resources`           | generate and configure resources — title, includes, sorting, pagination, cover/avatar, array (non-DB) resources |
+| `avo-fields`              | add and configure fields in `def fields` — pick the `as:` type, options, formatting, layout                     |
+| `avo-associations`        | wire `belongs_to` / `has_many` / `has_one` / HABTM fields, searchable pickers, polymorphism, STI                |
+| `avo-actions`             | build actions that run Ruby on selected, single, or no records — bulk ops, forms, modals, responses             |
+| `avo-filters`             | filter and segment the index — basic filters, dynamic filters, and scopes                                       |
+| `avo-index-views`         | control how the index renders — table styling, grid cards, map markers, view types                              |
+| `avo-menu-icons`          | auto-populate menu items with semantically appropriate Tabler icons                                             |
 
 ### Config & ops
 
-- `avo-setup` — install Avo, mount it, authenticate the private gem server, and set the license key
-- `avo-update` — bump the Avo gems and apply every upgrade-guide step for the versions crossed, with a log
-- `avo-authentication` — tell Avo who the current user is, gate access, and wire roles / profile / sign-out
-- `avo-authorization` — restrict who sees and does what with Pundit policies — resources, actions, associations, files
-- `avo-admin-config` — global initializer knobs — app name, per-page, container width, density, home path
-- `avo-performance` — caching and stale-row fixes to make the admin fast
-- `avo-testing` — unblock the license check in the test suite and use Avo's test helpers
+| Skill                     | What it covers                                                                                 |
+| ------------------------- | ---------------------------------------------------------------------------------------------- |
+| `avo-setup`               | install Avo, mount it, authenticate the private gem server, and set the license key            |
+| `avo-update`              | bump the Avo gems and apply every upgrade-guide step for the versions crossed, with a log      |
+| `avo-authentication`      | tell Avo who the current user is, gate access, and wire roles / profile / sign-out             |
+| `avo-authorization`       | restrict who sees and does what with Pundit policies — resources, actions, associations, files |
+| `avo-admin-config`        | global initializer knobs — app name, per-page, container width, density, home path             |
+| `avo-performance`         | caching and stale-row fixes to make the admin fast                                             |
+| `avo-testing`             | unblock the license check in the test suite and use Avo's test helpers                         |
 
 ### Customization
 
-- `avo-branding-appearance` — make the admin look like the product — logo, favicon, color scheme, palettes, CSS re-skin, icons
-- `avo-navigation-search` — menus, breadcrumbs, keyboard shortcuts, per-resource search, and the <kbd>Cmd</kbd> + <kbd>K</kbd> global search palette
-- `avo-custom-ui` — build custom pages, embedded panels, dynamic/nested forms, eject views, JS/Stimulus, Tailwind
-- `avo-custom-fields` — build a brand-new field type — generator plus its Edit/Show/Index view components
-- `avo-i18n` — translate and localize the admin — labels, locale switching, RTL
-- `avo-multitenancy` — scope the admin per tenant — route- or session-based, with an account switcher
-- `avo-record-reordering` — persistent up/down and drag-and-drop record ordering
-- `avo-custom-controls` — take over the show/edit/index/row button bars — relabel, remove, add links/actions/dropdowns
-- `avo-controllers` — override per-resource CRUD controller hooks and safely extend Avo's `ApplicationController`
-- `avo-engine-internals` — engine plumbing for custom Ruby — `main_app`/`avo` helpers, `Avo::Current`, `ExecutionContext`, reserved names
+| Skill                     | What it covers                                                                                                           |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `avo-branding-appearance` | make the admin look like the product — logo, favicon, color scheme, palettes, CSS re-skin, icons                         |
+| `avo-navigation-search`   | menus, breadcrumbs, keyboard shortcuts, per-resource search, and the <kbd>Cmd</kbd> + <kbd>K</kbd> global search palette |
+| `avo-custom-ui`           | build custom pages, embedded panels, dynamic/nested forms, eject views, JS/Stimulus, Tailwind                            |
+| `avo-custom-fields`       | build a brand-new field type — generator plus its Edit/Show/Index view components                                        |
+| `avo-i18n`                | translate and localize the admin — labels, locale switching, RTL                                                         |
+| `avo-multitenancy`        | scope the admin per tenant — route- or session-based, with an account switcher                                           |
+| `avo-record-reordering`   | persistent up/down and drag-and-drop record ordering                                                                     |
+| `avo-custom-controls`     | take over the show/edit/index/row button bars — relabel, remove, add links/actions/dropdowns                             |
+| `avo-controllers`         | override per-resource CRUD controller hooks and safely extend Avo's `ApplicationController`                              |
+| `avo-engine-internals`    | engine plumbing for custom Ruby — `main_app`/`avo` helpers, `Avo::Current`, `ExecutionContext`, reserved names           |
 
 ### Add-ons
 
 Separately-licensed gems (paid add-on or Enterprise). `avo-media-library` is Community but off by default.
 
-- `avo-dashboards-cards` — dashboards (grids of cards) and the six card types — metrics, charts, tables, lists
-- `avo-notifications` — in-app notifications — bell dropdown, levels, action buttons, optional realtime
-- `avo-rest-api` — JSON REST API over every resource, with token auth and a per-token permission matrix
-- `avo-forms-and-pages` — model-agnostic forms (settings, imports, workflows) and sidebar page hierarchies
-- `avo-kanban` — DB-backed drag-and-drop boards across resources
-- `avo-audit-logging` — track who changed and viewed what — timeline, diffs, revert
-- `avo-collaboration` — comments, reactions, and an automatic change-log on a record
-- `avo-media-library` — central asset browser and a picker inside rich-text editors
-- `avo-http-resource` — back a resource with an external HTTP API instead of Active Record
-- `avo-menu` — build the sidebar with the menu editor DSL — sections, dividers, links, icons, per-user visibility
-- `avo-scopes` — one-click segment tabs above the index, with counts and a default view
-- `avo-dynamic-filters` — let end users build their own ad-hoc filters from a filters bar
-- `avo-advanced-search` — the <kbd>Cmd</kbd> + <kbd>K</kbd> global search palette, and type-to-search association pickers
+| Skill                     | What it covers                                                                                     |
+| ------------------------- | -------------------------------------------------------------------------------------------------- |
+| `avo-dashboards-cards`    | dashboards (grids of cards) and the six card types — metrics, charts, tables, lists                |
+| `avo-notifications`       | in-app notifications — bell dropdown, levels, action buttons, optional realtime                    |
+| `avo-rest-api`            | JSON REST API over every resource, with token auth and a per-token permission matrix               |
+| `avo-forms-and-pages`     | model-agnostic forms (settings, imports, workflows) and sidebar page hierarchies                   |
+| `avo-kanban`              | DB-backed drag-and-drop boards across resources                                                    |
+| `avo-audit-logging`       | track who changed and viewed what — timeline, diffs, revert                                        |
+| `avo-collaboration`       | comments, reactions, and an automatic change-log on a record                                       |
+| `avo-media-library`       | central asset browser and a picker inside rich-text editors                                        |
+| `avo-http-resource`       | back a resource with an external HTTP API instead of Active Record                                 |
+| `avo-menu`                | build the sidebar with the menu editor DSL — sections, dividers, links, icons, per-user visibility |
+| `avo-scopes`              | one-click segment tabs above the index, with counts and a default view                             |
+| `avo-dynamic-filters`     | let end users build their own ad-hoc filters from a filters bar                                    |
+| `avo-advanced-search`     | the <kbd>Cmd</kbd> + <kbd>K</kbd> global search palette, and type-to-search association pickers    |
 
 ### Cross-cutting
 
-- `avo-aware` — keep the admin in sync when you change a Rails model, even when the request never mentions Avo
-- `avo-troubleshoot` — diagnose a broken or misbehaving Avo app, organized by symptom
+| Skill                     | What it covers                                                                                 |
+| ------------------------- | ---------------------------------------------------------------------------------------------- |
+| `avo-aware`               | keep the admin in sync when you change a Rails model, even when the request never mentions Avo |
+| `avo-troubleshoot`        | diagnose a broken or misbehaving Avo app, organized by symptom                                 |
 
 Paid add-on skills arrive with their gems — install `avo-kanban` and its skill comes with it. The loader lists what your app actually has, and names the add-on for anything it does not, so an agent never describes a feature you cannot use.
 

--- a/docs/4.0/agentic-engineering.md
+++ b/docs/4.0/agentic-engineering.md
@@ -30,7 +30,9 @@ Skills are organized by **vertical** — a whole feature area, not a single task
 
 ### Keeping them current
 
-Run `bundle update avo` and the skills update with it. There is nothing to copy and nothing that can drift out of sync with your app.
+Run `bin/rails avo:update` and the skills update with the gems. There is nothing to copy and nothing that can drift out of sync with your app.
+
+Use that task rather than `bundle update avo`: skills ship in every Avo gem, not just core, so bumping core alone leaves each add-on's skills behind. `avo:update` resolves every installed Avo gem and updates them together, conservatively — and the [`avo-update` skill](#skills) walks the upgrade guide for the versions you crossed.
 
 Re-run `rails g avo:skills` after upgrading Avo to refresh the loader itself; it warns when its own copy is older than the gem.
 


### PR DESCRIPTION
Part of AVO-1576. Pairs with avo-hq/avo#4689 and avo-hq/workspace#122.

**Merge after avo-hq/avo#4689 releases**, so the documented `rails g avo:skills` actually exists.

## Why

Skills used to be installed globally from [avo-hq/skills](https://github.com/avo-hq/skills), with no relationship to the `avo` version an app had locked. They now ship inside the gems, so they update with the gems and nothing can drift. This page documented three install paths the new model supersedes.

## What changed

- **`## Skills`** — `npx skills add` / plugin marketplace / manual symlink replaced with `rails g avo:skills`, plus what it writes and what it deliberately does not copy.
- **Frontmatter `prompt:`** — named the loader.
- **Step 2 of `## Suggested workflow`** — this sits *outside* the Skills section and would otherwise have kept telling readers to install from the repo.

Added, because the new model needs the reader to know them:

- **Upgrades go through `bin/rails avo:update`, not `bundle update avo`.** Skills now ship in fifteen gems, not just core, so bumping core alone leaves each add-on's skills on the version it was already pinned to — silently. `avo:update` resolves every installed Avo gem and updates them together.
- **Older global installs** can shadow the gem-shipped skills. `rails g avo:skills` detects them and asks before removing the ones in the project; `~/.claude/skills` is reported but never deleted, since it is shared with the reader's other projects.
- **Avo 3 is out of scope** for gem-shipped skills; the loader says so and stops rather than guessing.
- Paid add-on skills arrive with their gems, and the loader names the add-on for anything the app does not have.

The only surviving `npx skills add avo-hq/skills` mention is inside the "remove your old install" warning, where it belongs.

## Verification

```
npx vitepress build docs   # build complete
```

Existing sidebar entry unchanged — this edits the page already linked under Avo 4 rather than adding one beside a now-wrong page.

## Noted, not changed

`docs/4.0/index.md` and the 2.0/3.0 pages also recommend `bundle update avo` in general upgrade copy. The same argument now applies to them since add-ons exist, but that is outside this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)