### PR TITLE
docs(associations): document has_one :through attach/detach

### DIFF
--- a/docs/4.0/associations.md
+++ b/docs/4.0/associations.md
@@ -18,6 +18,7 @@ end
 | --- | --- |
 | `belongs_to` | [Belongs to](./associations/belongs_to) |
 | `has_one` | [Has one](./associations/has_one) |
+| `has_one :through` | [Has one](./associations/has_one#has-one-through) |
 | `has_many` | [Has many](./associations/has_many) |
 | `has_many :through` | [Has many](./associations/has_many#has-many-through) |
 | `has_and_belongs_to_many` | [Has and belongs to many](./associations/has_and_belongs_to_many) |
@@ -47,13 +48,13 @@ Association fields share most of their options. Each ✓ links to that option's 
 | `reloadable` | – | [✓](./associations/has_one#Reloadable) | [✓](./associations/has_many#Reloadable) | [✓](./associations/has_and_belongs_to_many#Reloadable) |
 | `nested` | – | [✓](./associations/has_one#nested) | [✓](./associations/has_many#nested) | [✓](./associations/has_and_belongs_to_many#nested) |
 | `attach_using` | – | – | [✓](./associations/has_many#attach_using) | [✓](./associations/has_and_belongs_to_many#attach_using) |
-| `attach_fields` | – | – | [✓](./associations/has_many#attach_fields) | – |
+| `attach_fields` | – | [✓](./associations/has_one#attach_fields) | [✓](./associations/has_many#attach_fields) | – |
 | `discreet_pagination` | – | – | [✓](./associations/has_many#discreet_pagination) | [✓](./associations/has_and_belongs_to_many#discreet_pagination) |
 | `hide_search_input` | – | – | [✓](./associations/has_many#hide_search_input) | [✓](./associations/has_and_belongs_to_many#hide_search_input) |
 | `hide_filter_button` | – | – | [✓](./associations/has_many#hide_filter_button) | [✓](./associations/has_and_belongs_to_many#hide_filter_button) |
 | `link_to_child_resource` | [✓](./associations/belongs_to#link_to_child_resource) | – | [✓](./associations/has_many#link_to_child_resource) | [✓](./associations/has_and_belongs_to_many#link_to_child_resource) |
 
-A few options belong to a single field type: [`polymorphic_as` + `types`](./associations/belongs_to#polymorphic_as), [`polymorphic_help`](./associations/belongs_to#polymorphic_help), [`can_create`](./associations/belongs_to#can_create), [`allow_via_detaching`](./associations/belongs_to#allow_via_detaching), and [`link_to_record`](./associations/belongs_to#link_to_record) are all on `belongs_to`. `attach_fields` only persists its values on `has_many :through` associations, so it's documented there.
+A few options belong to a single field type: [`polymorphic_as` + `types`](./associations/belongs_to#polymorphic_as), [`polymorphic_help`](./associations/belongs_to#polymorphic_help), [`can_create`](./associations/belongs_to#can_create), [`allow_via_detaching`](./associations/belongs_to#allow_via_detaching), and [`link_to_record`](./associations/belongs_to#link_to_record) are all on `belongs_to`. `attach_fields` only persists its values on `:through` associations, where there's a join record to write to — see [`has_many`](./associations/has_many#attach_fields) and [`has_one`](./associations/has_one#attach_fields).
 
 ## Show or hide the association buttons
 

--- a/docs/4.0/associations/has_many.md
+++ b/docs/4.0/associations/has_many.md
@@ -40,6 +40,18 @@ field :members,
   as: :has_many,
   through: :memberships
 ```
+
+Attach and detach go through the association itself, so a scope on the through association is respected: attaching stamps the scope's attributes on the new join record, and detaching destroys only the join record that association points at, leaving other rows linking the same two records alone.
+
+```ruby{2}
+class Team < ApplicationRecord
+  has_many :admin_memberships, -> { where level: :admin }, class_name: "TeamMembership"
+  has_many :admins, through: :admin_memberships, source: :user
+end
+```
+
+With the association above, attaching a user writes `level: "admin"` on the join record, and detaching them removes that row without touching a `level: "member"` row for the same user.
+
 <Option name="`attach_fields`">
 
 If you have extra fields defined in the through table and would like to display them when attaching use the `attach_fields` option.

--- a/docs/4.0/associations/has_one.md
+++ b/docs/4.0/associations/has_one.md
@@ -24,6 +24,54 @@ field :admin, as: :has_one
 <!-- @include: ./../common/associations_use_resource_option_common.md-->
 <!-- @include: ./../common/associations_linkable_option_common.md-->
 
+## Has One Through
+
+The `HasOne` association also works when the underlying Rails association goes through a join model. There's no `through` option on the field — Avo reads it off the association itself.
+
+```ruby
+# app/models/team.rb
+class Team < ApplicationRecord
+  has_one :admin_membership, -> { where level: :admin }, class_name: "TeamMembership"
+  has_one :admin, through: :admin_membership, source: :user
+end
+```
+
+```ruby
+# app/avo/resources/team.rb
+field :admin, as: :has_one
+```
+
+`Attach` and `Detach` operate on the join record for you, always through the association itself, so any scope you put on it is respected:
+
+- **Attaching** creates the join record through the association, which stamps the scope's attributes on it — the example above writes `level: "admin"` without you having to say so.
+- **Attaching over an existing record** replaces the join record instead of adding a second one, matching how Rails treats a singular association.
+- **Detaching** destroys only the join record the association points at. Other join rows linking the same two records — a `level: "member"` row for the same user, say — are left alone.
+
+:::info
+Because a singular association owns exactly one join record, detaching is checked against the record named in the URL. If the page you're looking at is stale and someone else has attached a different record in the meantime, the detach is a no-op rather than removing whatever happens to be attached now.
+:::
+
+<Option name="`attach_fields`">
+
+<VersionReq version="4.0.25" />
+
+If the join model has extra columns you want to fill in while attaching, declare them with `attach_fields` and they'll show up in the attach modal.
+
+```ruby{3,4,5}
+field :admin,
+  as: :has_one,
+  attach_fields: -> {
+    field :notes, as: :text
+  }
+```
+
+The values land on the join record (`TeamMembership` above), alongside anything the association's scope writes. When you attach over an existing record, the fields are written to the same join row that gets replaced.
+
+:::warning
+`attach_fields` only persists on a `has_one :through` association. On a plain `has_one` there's no join record to write to, so the fields have nowhere to land.
+:::
+</Option>
+
 <!-- @include: ./../common/show_on_edit_common.md-->
 <!-- @include: ./../common/nested_common.md-->
 <!-- @include: ./../common/reloadable.md-->


### PR DESCRIPTION
Daily docs sweep over yesterday's (2026-07-31) changes in `avo-hq/avo` and `avo-hq/workspace`.

The one change that left a documentation gap is [avo-hq/avo#4678](https://github.com/avo-hq/avo/pull/4678) — attach and detach on a `has_one :through` association, shipped in Avo `4.0.25`. `has_one :through` wasn't mentioned anywhere in `docs/4.0/`, and the overview page still said `attach_fields` persists only on `has_many :through`.

## Changes

**`docs/4.0/associations/has_one.md`** — new `## Has One Through` section:

- the association shape (no `through` option on the field; Avo reads it off the reflection)
- attaching creates the join record *through* the association, so a scope like `-> { where level: :admin }` stamps its attributes on the new row
- attaching over an existing record replaces the join record instead of adding a second one
- detaching destroys only the join record the association points at, leaving sibling rows between the same pair alone
- an `:::info` note on the stale-page case (detach is a no-op when the URL names a record that isn't the attached one)
- an `<Option name="attach_fields">` block carrying `<VersionReq version="4.0.25" />`, with a `:::warning` that it only persists on a `:through` — a plain `has_one` has no join record to write to

**`docs/4.0/associations/has_many.md`** — the same scope-awareness now applies to `has_many :through`: a short paragraph plus a scoped-association example in the *Has Many Through* section.

**`docs/4.0/associations.md`**:

- added the `has_one :through` row to the Rails-association → Avo-field table
- ticked `attach_fields` for *Has one* in the common-options matrix
- rewrote the sentence that claimed `attach_fields` only persists on `has_many :through`

## Checked, no change needed

| Change | Verdict |
| --- | --- |
| [avo#4688](https://github.com/avo-hq/avo/pull/4688) — Cmd/Ctrl+J in the shortcuts modal | Already documented — `keyboard-shortcuts.md` has an *Assistant* section, `intelligence.md` line 246 |
| [avo#4686](https://github.com/avo-hq/avo/pull/4686) — panel card spacing | Internal CSS, no customer-facing surface |
| workspace #117 / #118 — avo-intelligence chat surfaces, model policy, dictation | Already covered by #594, #595, #598 the same day |
| workspace #120 — dummy resource tools | Test fixture only |

## Verification

`npx vitepress build docs` completes clean. Confirmed in the built output that `#has-one-through` and `#attach_fields` anchors are generated on the has_one page (the overview's new links resolve) and that the version badge renders as "Since v4.0.25".

---
_Generated by [Claude Code](https://claude.ai/code/session_018NTojB371QX6PXh6aPjdB9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime or security impact.
> 
> **Overview**
> Documents **Avo 4.0.25** behavior for **`has_one :through`** attach/detach and corrects how **`attach_fields`** is described across the associations docs.
> 
> **`has_one.md`** adds a **Has One Through** section: use `as: :has_one` with no field-level `through`, scoped join creation/replacement on attach, targeted detach (and stale-page no-op), plus **`attach_fields`** on the join model with a version badge and a warning that plain `has_one` has no join row.
> 
> **`has_many.md`** extends **Has Many Through** with the same scope-aware attach/detach semantics and a scoped `Team` example.
> 
> **`associations.md`** adds a **`has_one :through`** mapping row, marks **`attach_fields`** for Has one in the options matrix, and updates the note so **`attach_fields`** applies to any **`:through`** association (both has_one and has_many), not only has_many.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4461e7201169987869d2eca5aa682c048fd59c8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->