### PR TITLE
docs(intelligence): Active Storage file reports, showing files, and attach/detach

### DIFF
--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -186,6 +186,29 @@ No policy, no `#debug_level` method, an unrecognized value, or any error inside 
 
 The assistant works through tools that run against your actual data: querying records, inspecting them, and creating, updating, or deleting them. Writes go through a confirmation flow — the assistant shows a card describing the pending change and only executes after you confirm. Every executed write is recorded in an audit log with undo support.
 
+### Files and attachments
+
+The assistant reports on your Active Storage usage, so you can ask about files the way you ask about records:
+
+| Ask                              | What you get                                                      |
+| -------------------------------- | ----------------------------------------------------------------- |
+| "How much storage are we using?" | Totals by storage service, content type, and resource             |
+| "Any orphaned uploads?"          | Blobs attached to nothing — count, bytes, and the oldest one      |
+| "Do we have duplicate files?"    | Files sharing a checksum, and the bytes de-duplicating would free |
+| "Is storage growing?"            | Uploads per month                                                 |
+| "What are the biggest files?"    | The largest files and which records they belong to                |
+| "Which products have no image?"  | Records missing an attachment                                     |
+
+Ask it to **show** a file — "show me this post's cover", "what's on this product?" — and the reply carries the file itself: images render inline, video and audio get a player, and anything else comes back as a link that opens in a new tab.
+
+You can also name the file instead of the record — "show me dummy-video.mp4", or just "show me the beach photo". The assistant searches for it across everything you're allowed to see and tells you which record each match belongs to, so you never have to know where a file lives before asking for it. Every file comes back with its blob id, which is what you reference when asking for a change.
+
+It can also attach and detach files on a record — "attach blob 42 to this post's cover", "take the cover off this post". Files are referenced by their blob id, so the assistant only ever links something already in your Media Library: it never uploads bytes and never fetches a file from a URL.
+
+Attach and detach apply immediately rather than through the confirmation card that record writes use. Detaching only unlinks the file — the blob stays in the Media Library and the assistant can re-attach it with the same id. Purging a file is never something the assistant can do; deleting the file itself stays a manual action.
+
+Both respect your policies: file reports only count blobs attached to resources you are allowed to list, and attaching or detaching goes through the same `upload_<name>?` and `delete_<name>?` policy methods the Avo UI checks.
+
 A new conversation opens with a short greeting and a few suggested prompts. Clicking a suggestion types it into the composer and submits it — it takes exactly the same path as a typed message.
 
 Tool calls respect your Avo authorization setup: per-resource and per-field policies apply to what the assistant can read and write, scoped to the signed-in user who owns the chat.


### PR DESCRIPTION
Documents the Active Storage capabilities the assistant gained in avo-intelligence: file reports, showing a file, and attaching/detaching one.

Added to the **What the assistant can do** section of `4.0/intelligence.md`, under a new "Files and attachments" heading:

- The six things the file reports answer (storage totals, orphaned uploads, duplicates, growth, largest files, records missing an attachment), as a question → answer table.
- Showing a file — by record ("this post's cover") or by name ("show me dummy-video.mp4"). Images render inline, video and audio get a player, anything else is a link.
- Attaching and detaching by blob id, and why neither needs the confirmation card that record writes use: a detach only unlinks, so the file stays in the Media Library and can be re-attached.
- That the assistant can never purge a file, and never uploads bytes or fetches from a URL.
- How authorization applies: reports only count blobs on resources you may list, and attach/detach go through the same `upload_<name>?` / `delete_<name>?` policy methods the Avo UI checks.

Pairs with avo-hq/workspace (avo-intelligence), which ships the tools themselves.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security logic modified.
> 
> **Overview**
> Documents **Active Storage** capabilities for the Avo Intelligence assistant in `docs/4.0/intelligence.md`, inserted before **Customize the assistant's instructions**.
> 
> The new **Files and attachments** section explains six report-style questions (storage totals, orphans, duplicates, growth, largest files, missing attachments), how to **show** files by record or filename (inline media vs links), and **attach/detach** by blob id without uploads or URL fetches.
> 
> It clarifies that attach/detach run **immediately** (no confirm card), detach does not purge blobs, and authorization follows the same `upload_<name>?` / `delete_<name>?` policy checks as the Avo UI, with reports scoped to listable resources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c5f365881ac4a557b85b7d6d2e08a752f95c0e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->