### PR TITLE
Intelligence: document running a resource's actions from the chat

### DIFF
--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -129,7 +129,56 @@ Every message you send starts a fresh turn against the provider, built from thre
 
 **Writing.** Updates and deletes show you a card describing the change and run only when you click Confirm; the click applies the change, not the model. Those two work one record at a time — ask for a bulk change and the assistant will say so and ask you to pick. Creates apply immediately, since there's nothing to preview for a record that doesn't exist yet, and creating is the one write it will repeat: "add 15 cities" creates fifteen without stopping between them. Every executed write is recorded in an audit log, and the assistant can undo one through the same confirmation card.
 
+**Running your actions.** The assistant can also run the [actions](./actions.html) a resource registers, not just write columns — see [Your actions, from the chat](#your-actions-from-the-chat).
+
 **Authorization is enforced at the tool layer, on every call.** Each read and write goes through your Avo policies for the signed-in user who owns the chat — per-resource and per-field. Instructions are guidance for the model; your policies are what actually decides. A resource the user can't list is invisible to the assistant rather than refused, so it can't be used to probe for what exists.
+
+## Your actions, from the chat
+
+Setting `published_at` is not the same as publishing. Your [actions](./actions.html) are where the operation actually lives — the notification it sends, the record it stamps, the service it calls — so the assistant runs them rather than reconstructing their effect field by field.
+
+It works from the actions each resource registers. Nothing is exposed by default beyond what you already declare in `def actions`, and nothing extra is needed to opt in:
+
+```ruby
+class Avo::Resources::Project < Avo::BaseResource
+  def actions
+    action Avo::Actions::ArchiveProject
+  end
+end
+```
+
+Ask for it in whatever words you'd use with a colleague — "archive the Orbit project" — and the assistant finds the matching action, reads the inputs it declares, and shows you a confirmation card naming the action, the record, and the exact values it will be handed. Nothing runs until you click **Run**; the click executes it, not the model, exactly as with updates and deletes.
+
+**It asks rather than guesses.** An input your action marks `required: true` is one the assistant will ask you for if you didn't say. It never fills one in — an action does real work with that value. Inputs you leave out fall back to the action's own `default`, and the value that will be used is on the card before you confirm.
+
+[Actions that run without records](./actions.html#run-an-action-without-records) work too — the assistant runs them with no record at all.
+
+### What it's allowed to run
+
+Two gates, both yours, both checked when the run is proposed and again when you confirm it:
+
+- **`act_on?` on the record**, the same policy method that decides whether the Actions dropdown appears in the UI. It's checked per record, so an owner-gated policy behaves in the chat exactly as it does on the page.
+- **The action's own `self.authorize` block**, evaluated with the record in place.
+
+:::warning A policy with no `act_on?` refuses every action
+`act_on?` fails closed. If a resource has a policy that doesn't define it, the assistant can't run that resource's actions — the same way Avo hides the Actions dropdown. Add `act_on?` to the policy to allow it.
+:::
+
+A record id the signed-in user can't reach reports as "not found", never as "not allowed", so the chat can't be used to discover which records exist.
+
+### Undoing a run
+
+Every run against a record is written to the same audit log as the assistant's other writes, and whether it can be undone is decided by what it actually left behind, not by what it claimed:
+
+| The run… | In the history | Undo |
+| ------------------------------- | -------------------------------- | ----------------------------------------- |
+| changed columns on the record | recorded with a before/after diff | restores those columns |
+| deleted the record | recorded as a delete | re-creates it |
+| changed nothing you store | recorded, marked not undoable | not offered |
+
+That last row is the point. An action that emails a customer or calls another service leaves nothing to restore, and the assistant says so plainly instead of offering an undo it can't honour. Even where an undo *is* offered, it restores the columns and nothing else — the card says as much before you confirm.
+
+Standalone runs aren't written to the audit log at all: it records what happened to a record, and a standalone action has none. The card in the conversation is the record of it.
 
 ## Customize the assistant's instructions
 

--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -147,9 +147,11 @@ class Avo::Resources::Project < Avo::BaseResource
 end
 ```
 
-Ask for it in whatever words you'd use with a colleague — "archive the Orbit project" — and the assistant finds the matching action, reads the inputs it declares, and shows you a confirmation card naming the action, the record, and the exact values it will be handed. Nothing runs until you click **Run**; the click executes it, not the model, exactly as with updates and deletes.
+Ask for it in whatever words you'd use with a colleague — "archive the Orbit project" — and the assistant finds the matching action, reads the inputs it declares, and shows you a confirmation card naming the action and the record, with the action's own fields rendered right on the card. They're the same fields its modal would show — a tags field is a tags field here too — prefilled with the values the assistant took from your message and the action's own `default`s, and every one of them is editable before you run. Nothing runs until you click **Run**, and what runs is exactly what the fields hold at that moment; the click executes it, not the model, exactly as with updates and deletes.
 
-**It asks rather than guesses.** An input your action marks `required: true` is one the assistant will ask you for if you didn't say. It never fills one in — an action does real work with that value. Inputs you leave out fall back to the action's own `default`, and the value that will be used is on the card before you confirm.
+**It collects rather than guesses.** An input your action marks `required: true` that you didn't mention arrives on the card as an empty field for you to fill — the assistant never invents a value, because an action does real work with it. A run submitted with a required field still blank isn't performed; the card simply asks for it again.
+
+**The action's messages are the outcome.** Whatever your action reports — `succeed`, `warn`, `inform`, `error` — lands on the card once it has run, each with its severity, the same messages the Avo UI would toast. An action may report several at once, and an `error` message is part of the outcome, not a failure of the run. The values the action was handed stay on the settled card too, folded behind a click.
 
 [Actions that run without records](./actions.html#run-an-action-without-records) work too — the assistant runs them with no record at all.
 


### PR DESCRIPTION
Companion to avo-hq/workspace#126 (AVO-1606) — the chat can now list and run a resource's registered Avo Actions.

Updates the `Intelligence` page with:

- **Your actions, from the chat** — how the assistant discovers and proposes action runs
- **What it's allowed to run** — `act_on?` + the action's own `authorize` block, checked at propose time and re-checked on Confirm
- **Undoing a run** — runs that changed columns can be reverted from chat; side-effect-only runs (e.g. sending email) are logged but not offered for undo

Round 2 (matching the workspace PR): the confirmation card now renders the action's **own fields** — editable, prefilled — so a missing required input is collected on the card rather than asked in prose, and the outcome card shows the action's typed `succeed`/`warn`/`inform`/`error` messages.

Hold merging until avo-hq/workspace#126 ships.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown documentation only; no application or security behavior changes in this repo.
> 
> **Overview**
> **Documentation-only** expansion of the Intelligence guide for the upcoming chat action-runner (companion to workspace AVO-1606).
> 
> Adds a cross-link under **How the assistant works** and a new **Your actions, from the chat** section: actions come from each resource’s `def actions` (no extra opt-in), runs use a **Run** confirmation card with the action’s own fields (editable, prefilled; required inputs collected on the card, not invented), and outcomes show the action’s `succeed`/`warn`/`inform`/`error` messages. Standalone actions without records are covered.
> 
> **What it's allowed to run** documents dual gates at propose and confirm: Pundit `act_on?` (fails closed if undefined) plus the action’s `self.authorize` block, with inaccessible records reported as “not found.”
> 
> **Undoing a run** ties action runs to the same audit log as other writes, with a table for column changes vs deletes vs side-effect-only runs, and notes that standalone runs are not audited.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79b5a524f941ff46968a74ad4dc61ece381c248a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

