### PR TITLE
intelligence: rich composer, file attachments, image lightbox

### DIFF
--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -275,10 +275,6 @@ The files stay attached to the message and the model sees them again on every la
 
 The one thing to check is the model: reading an image takes a vision model. The current Claude, GPT, and Gemini families all read images and PDFs; sending a file to a model that can't read it fails at request time with the provider's error rather than silently dropping the file.
 
-## View an image larger
-
-Click any image in a conversation — one you attached or one the assistant rendered — and it opens centered over the page. Click anywhere, or press Escape, to close it. Other attachment types don't get the treatment: their chips are download links.
-
 ## Dictate a message
 
 The microphone in every composer — the bar, the new-chat page, and open conversations — transcribes speech into the message box: click to start, click to stop. Pauses don't end the session, and the text lands on top of whatever draft is already there, so you can type half a message and speak the rest.

--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -263,6 +263,22 @@ Chats are also real pages, at `/chats` under your Avo mount point (`/avo/chats` 
 
 The list is scoped to the signed-in user. It's not an admin view of everyone's conversations — for that, browse the `Avo::Intelligence::Chat` resource from the sidebar.
 
+## Write a message
+
+The composer is a rich text box, not a bare textarea. The usual markdown shortcuts work as you type — `**bold**`, `# heading`, `- list`, backticks for code — and formatting survives a paste. **Enter** sends the message, **Shift+Enter** starts a new line, and on an empty composer **Up** recalls your previously sent messages, shell-style. The assistant receives the message as markdown, structure intact.
+
+## Send files with a message
+
+Every composer takes files: click the paperclip, drag them in, or paste them from the clipboard. Files upload as you add them — through Active Storage's direct upload, into the storage service your app already uses — preview in the draft, and go to the model with the message, so "summarize the attached CSV" and "what's in this screenshot?" work the way you'd expect.
+
+The files stay attached to the message and the model sees them again on every later turn — you can keep asking about a file for the rest of the conversation, not just in the message it rode in on.
+
+The one thing to check is the model: reading an image takes a vision model. The current Claude, GPT, and Gemini families all read images and PDFs; sending a file to a model that can't read it fails at request time with the provider's error rather than silently dropping the file.
+
+## View an image larger
+
+Click any image in a conversation — one you attached or one the assistant rendered — and it opens centered over the page. Click anywhere, or press Escape, to close it. Other attachment types don't get the treatment: their chips are download links.
+
 ## Dictate a message
 
 The microphone in every composer — the bar, the new-chat page, and open conversations — transcribes speech into the message box: click to start, click to stop. Pauses don't end the session, and the text lands on top of whatever draft is already there, so you can type half a message and speak the rest.


### PR DESCRIPTION
Documents three composer features shipping in avo-hq/workspace#127 ([AVO-1626](https://linear.app/avo-hq/issue/AVO-1626/avo-intelligence-lexxy-composer-rich-prompt-input-file-uploads-to-the)):

- **Write a message** — the composer is now a rich text box (Lexxy): markdown shortcuts, Enter/Shift+Enter, Up-arrow message history.
- **Send files with a message** — paperclip / drag-drop / paste, direct upload, files go to the model and replay on later turns; vision-model requirement called out.
- **View an image larger** — the conversation's image lightbox; other attachment types stay download links.

Three new sections on `4.0/intelligence.md`, placed between "Full-page chats" and "Dictate a message". Site builds clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, security, or data-handling impact.
> 
> **Overview**
> Documents two Intelligence composer capabilities that ship with the Lexxy-based prompt UI, inserted in **`docs/4.0/intelligence.md`** between **Full-page chats** and **Dictate a message**.
> 
> **Write a message** explains that the composer is rich text (not a plain textarea): markdown shortcuts while typing, paste preserving structure, **Enter** / **Shift+Enter** send vs newline, **Up** for shell-style message history, and markdown sent to the model.
> 
> **Send files with a message** covers paperclip, drag-and-drop, and paste; Active Storage direct upload; draft previews; files included with the message for the model; persistence across later turns in the same chat; and that vision-capable models are required for images/PDFs, with a clear provider error if the model cannot read attachments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ccc2326bdc4f2980d2c3f3de42cf377faf7863. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->