### PR TITLE
docs(intelligence): list run_action in the tools reference

### DIFF
--- a/docs/4.0/intelligence-agents-and-tools.md
+++ b/docs/4.0/intelligence-agents-and-tools.md
@@ -43,6 +43,7 @@ Tool names below are how calls appear in the Tool calls resource and in the chat
 | `create_record`              | Creates a record                                                                                                     | immediately       |
 | `update_record`              | Changes a record's attributes                                                                                        | after you confirm |
 | `delete_record`              | Deletes a record                                                                                                     | after you confirm |
+| `run_action`                 | Lists the [actions](./actions.html) a resource registers, and proposes running one on the records you name           | after you confirm |
 | `write_history`              | Lists the writes made earlier in the conversation and proposes undoing one                                           | after you confirm |
 | `rename_conversation`        | Renames the current conversation — with your exact title, or by regenerating one                                     | immediately       |
 
@@ -57,6 +58,8 @@ That is a deliberate security boundary. There is no argument the model could inv
 ### The inspection gate
 
 The query and write tools refuse to touch a resource until `resource_inspector` has run for it in the conversation. The gate is enforced in the tools — not merely requested in the prompt — and is what makes the assistant work from your real columns and scopes instead of guessed ones.
+
+`run_action` sits behind the same gate, and adds two of its own: the resource's `act_on?` policy method and the action's `self.authorize` block, both checked when the run is proposed and again when you confirm it. See [What it's allowed to run](./intelligence.html#what-it-s-allowed-to-run).
 
 ## Renaming conversations
 


### PR DESCRIPTION
Daily docs sweep over yesterday's code changes in `avo-hq/avo` and `avo-hq/workspace`.

Everything shipped on Aug 1 was already documented within the hour — Active Storage tools (#602), the shared rename tool (#603), running a resource's actions (#604), and the Lexxy composer / file uploads / lightbox (#605). One gap survived: the guide got a full "Your actions, from the chat" section for `RunActionTool` (avo-hq/workspace#126), but `intelligence-agents-and-tools.md` — the page that promises "every tool and its gates" — never got the row, so the roster table still listed 11 of the chat agent's 12 tools.

## Changes

- Add `run_action` to the tools table, positioned to match the chat agent's roster order (between `delete_record` and `write_history`), with "after you confirm" in the writes column since a run goes through the same PendingWrite → Confirm boundary as updates and deletes.
- Add a one-line gates note under **The inspection gate**: `run_action` sits behind the same inspection gate as the other write tools, and adds the resource's `act_on?` plus the action's own `self.authorize` block, both checked at propose time and again at confirm. Links to the guide rather than restating it.

## Verification

- `npx vitepress build docs` — clean (VitePress fails the build on dead links, so both new anchors resolve).
- Gate claims checked against `gems/avo-intelligence/app/tools/run_action_tool.rb` and the roster in `app/agents/avo/intelligence/chat_agent.rb`.

No changes needed for `avo-hq/avo` — its most recent commits (the assistant's Cmd/Ctrl+J shortcut) are already in `keyboard-shortcuts.md`; the rest were internal CSS and association bug fixes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMXwVF7vFSquEziDYQywC3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to the tools table and gate section; no application or security behavior changes.
> 
> **Overview**
> Closes a documentation gap: the agents-and-tools reference now lists all **12** chat agent tools by adding **`run_action`** to the roster table (between `delete_record` and `write_history`), with **after you confirm** in the writes column to match updates/deletes.
> 
> Under **The inspection gate**, a short note explains that `run_action` uses the same `resource_inspector` gate plus **`act_on?`** and the action’s **`self.authorize`** checks at propose and confirm, with a link to the main intelligence guide instead of duplicating that section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20e5b42ad2f095955c3271d57fea6cbc294a25bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->