### PR TITLE
Intelligence: the full-page button works from a new chat window too (AVO-1619)

### DIFF
--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -325,7 +325,7 @@ Every chat you open becomes a pill in the dock, newest first, so several convers
 
 Clicking the window's own title bar minimizes it — the conversation stays in the dock, it just gets out of your way.
 
-To give a conversation the whole window, use **Open in full page** in the title bar. It's a normal link, so cmd-click opens it in a new tab. From that page, **Back to chat window** hands the conversation back to the floating bar and returns you to the page you opened it from. It only appears when there's somewhere to go back to — open a chat page directly, from a link or a bookmark, and there's no back control.
+To give a conversation the whole window, use **Open in full page** in the title bar. It's a normal link, so cmd-click opens it in a new tab. It's there on a brand-new chat too — before the first message, it lands on the full-page compose form, so a conversation can start with the whole window instead of moving to it later. From that page, **Back to chat window** hands the conversation back to the floating bar and returns you to the page you opened it from. It only appears when there's somewhere to go back to — open a chat page directly, from a link or a bookmark, and there's no back control.
 
 A new conversation opens with a short greeting and a few suggested prompts. Clicking a suggestion types it into the composer and submits it — it takes exactly the same path as a typed message.
 


### PR DESCRIPTION
The chat window's **Open in full page** button now also shows on a brand-new chat (avo-hq/workspace#129), landing on the full-page compose form. One sentence added where the button is introduced in the intelligence page.

Related to AVO-1619

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> Documents that **Open in full page** in the floating chat title bar is available on a **brand-new** conversation too—not only after messages exist. Before the first send, that link opens the full-page compose form so users can start in the full window instead of switching later.
> 
> The update is a single addition in the **Open the chat** section of `intelligence.md`, aligned with the product change (AVO-1619).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 560cdbd860b4b90e639ac2acc492c658237b52da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->