### PR TITLE
docs(intelligence): file ingestion — chat uploads and attach-from-URL (AVO-1623)

### DIFF
--- a/docs/4.0/intelligence-agents-and-tools.md
+++ b/docs/4.0/intelligence-agents-and-tools.md
@@ -39,7 +39,7 @@ Tool names below are how calls appear in the Tool calls resource and in the chat
 | `resource_inspector`         | Reads one resource's real columns, associations, and scopes; unlocks querying and writing that resource              | read-only         |
 | `active_record_query`        | Runs read-only, paginated, policy-scoped queries against a resource                                                  | read-only         |
 | `active_storage_insights`    | Storage reports — totals, orphans, duplicates, growth, biggest files — and finding/showing files                     | read-only         |
-| `active_storage_attachment`  | Attaches or detaches a Media Library blob on a record's attachment                                                   | immediately       |
+| `active_storage_attachment`  | Attaches or detaches a Media Library blob (or a chat upload) on a record's attachment; can also fetch a URL onto one | immediately¹      |
 | `create_record`              | Creates a record                                                                                                     | immediately       |
 | `update_record`              | Changes a record's attributes                                                                                        | after you confirm |
 | `delete_record`              | Deletes a record                                                                                                     | after you confirm |
@@ -47,6 +47,8 @@ Tool names below are how calls appear in the Tool calls resource and in the chat
 | `rename_conversation`        | Renames the current conversation — with your exact title, or by regenerating one                                     | immediately       |
 
 "After you confirm" means the tool call produces a card describing the pending change; your click applies it, not the model. "Immediately" is reserved for actions that are reversible (a detached file can be re-attached, a conversation can be renamed again) or additive (creating a record).
+
+¹ Attaching and detaching existing blobs apply immediately; the `attach_from_url` operation is the exception — a server-side download always goes through a confirmation card showing the URL, and nothing is fetched until you click **Attach**. See [Getting new files in](./intelligence.html#getting-new-files-in).
 
 ### Where tools get their context
 

--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -106,9 +106,15 @@ Avo.configure do |config|
   # Token budget for the model's thinking trace (positive integer).
   config.intelligence.thinking_budget = 2048
 
-  # Ceiling on a file downloaded from a URL (see "Getting new files in").
-  # Defaults to 25 megabytes.
-  config.intelligence.max_remote_file_size = 25.megabytes
+  # What a download from a URL may cost (see "Getting new files in").
+  # Set only the keys you want to change; the rest keep their defaults.
+  config.intelligence.remote_file = {
+    max_size: 25.megabytes, # ceiling on the downloaded file
+    open_timeout: 5,        # seconds to connect
+    read_timeout: 10,       # seconds per read
+    deadline: 30,           # seconds for the whole download
+    max_redirects: 3
+  }
 end
 ```
 
@@ -168,7 +174,7 @@ Two paths bring a file that isn't in your Media Library yet onto a record:
 
 **Give it a link.** Ask the assistant to attach a file by URL — "attach https://example.com/logo.png as this post's cover" — and it proposes the download on a confirmation card showing the URL, the filename, and the record. When the link points at an image the card previews it, so you are approving a picture you have seen rather than an address you had to read. Nothing is fetched until you click **Attach**; the assistant can't fetch anything on its own, which is what keeps a malicious link that slipped into your data from ever being followed unseen.
 
-The download itself is hardened: only public `https://` URLs are accepted (private and internal addresses are rejected, on every redirect too), the file's content type is read from its bytes rather than trusted from the server, and anything over `config.intelligence.max_remote_file_size` (25 MB by default) is refused mid-download. The undo is the same as for any attachment — detach it; the file stays in the Media Library.
+The download itself is hardened: only public `https://` URLs are accepted (private and internal addresses are rejected, on every redirect too), the file's content type is read from its bytes rather than trusted from the server, and anything over the configured size ceiling (25 MB by default) is refused mid-download rather than after it. If your files are bigger than that, or your source is slow, raise the matching keys under `config.intelligence.remote_file` — see [Configuration](#configuration). The undo is the same as for any attachment — detach it; the file stays in the Media Library.
 
 ## Customize the assistant's instructions
 

--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -105,10 +105,14 @@ Avo.configure do |config|
 
   # Token budget for the model's thinking trace (positive integer).
   config.intelligence.thinking_budget = 2048
+
+  # Ceiling on a file downloaded from a URL (see "Getting new files in").
+  # Defaults to 25 megabytes.
+  config.intelligence.max_remote_file_size = 25.megabytes
 end
 ```
 
-Each option falls back to an environment variable when unset, so you can configure through the environment instead:
+The thinking options each fall back to an environment variable when unset, so you can configure them through the environment instead:
 
 | Option | Environment variable | Default |
 | ----------------- | ---------------------------------- | ------- |
@@ -162,9 +166,9 @@ Two paths bring a file that isn't in your Media Library yet onto a record:
 
 **Upload it in the chat.** Drop a file into the composer and send it — the assistant sees the file and knows its blob id, so "attach the file I just sent to this post's cover" is a one-step ask. Files uploaded this way are private to their conversation: the assistant can't reach uploads from anyone else's chats, and other users can't reach yours.
 
-**Give it a link.** Ask the assistant to attach a file by URL — "attach https://example.com/logo.png as this post's cover" — and it proposes the download on a confirmation card showing the URL, the filename, and the record. Nothing is fetched until you click **Attach**; the assistant can't fetch anything on its own, which is what keeps a malicious link that slipped into your data from ever being followed unseen.
+**Give it a link.** Ask the assistant to attach a file by URL — "attach https://example.com/logo.png as this post's cover" — and it proposes the download on a confirmation card showing the URL, the filename, and the record. When the link points at an image the card previews it, so you are approving a picture you have seen rather than an address you had to read. Nothing is fetched until you click **Attach**; the assistant can't fetch anything on its own, which is what keeps a malicious link that slipped into your data from ever being followed unseen.
 
-The download itself is hardened: only public `https://` URLs are accepted (private and internal addresses are rejected, on every redirect too), the size is capped, and the file's content type is read from its bytes rather than trusted from the server. The undo is the same as for any attachment — detach it; the file stays in the Media Library.
+The download itself is hardened: only public `https://` URLs are accepted (private and internal addresses are rejected, on every redirect too), the file's content type is read from its bytes rather than trusted from the server, and anything over `config.intelligence.max_remote_file_size` (25 MB by default) is refused mid-download. The undo is the same as for any attachment — detach it; the file stays in the Media Library.
 
 ## Customize the assistant's instructions
 

--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -150,11 +150,21 @@ Ask it to **show** a file — "show me this post's cover", "what's on this produ
 
 You can also name the file instead of the record — "show me dummy-video.mp4", or just "show me the beach photo". The assistant searches for it across everything you're allowed to see and tells you which record each match belongs to, so you never have to know where a file lives before asking for it. Every file comes back with its blob id, which is what you reference when asking for a change.
 
-It can also attach and detach files on a record — "attach blob 42 to this post's cover", "take the cover off this post". Files are referenced by their blob id, so the assistant only ever links something already in your Media Library: it never uploads bytes and never fetches a file from a URL.
+It can also attach and detach files on a record — "attach blob 42 to this post's cover", "take the cover off this post". Files are referenced by their blob id, so the assistant links files already in your Media Library rather than uploading bytes itself.
 
 Attach and detach apply immediately rather than through the confirmation card that record writes use. Detaching only unlinks the file — the blob stays in the Media Library and the assistant can re-attach it with the same id. Purging a file is never something the assistant can do; deleting the file itself stays a manual action.
 
 Both respect your policies: file reports only count blobs attached to resources you are allowed to list, and attaching or detaching goes through the same `upload_<name>?` and `delete_<name>?` policy methods the Avo UI checks.
+
+### Getting new files in
+
+Two paths bring a file that isn't in your Media Library yet onto a record:
+
+**Upload it in the chat.** Drop a file into the composer and send it — the assistant sees the file and knows its blob id, so "attach the file I just sent to this post's cover" is a one-step ask. Files uploaded this way are private to their conversation: the assistant can't reach uploads from anyone else's chats, and other users can't reach yours.
+
+**Give it a link.** Ask the assistant to attach a file by URL — "attach https://example.com/logo.png as this post's cover" — and it proposes the download on a confirmation card showing the URL, the filename, and the record. Nothing is fetched until you click **Attach**; the assistant can't fetch anything on its own, which is what keeps a malicious link that slipped into your data from ever being followed unseen.
+
+The download itself is hardened: only public `https://` URLs are accepted (private and internal addresses are rejected, on every redirect too), the size is capped, and the file's content type is read from its bytes rather than trusted from the server. The undo is the same as for any attachment — detach it; the file stays in the Media Library.
 
 ## Customize the assistant's instructions
 

--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -158,13 +158,13 @@ The assistant reports on your Active Storage usage, so you can ask about files t
 
 Ask it to **show** a file — "show me this post's cover", "what's on this product?" — and the reply carries the file itself: images render inline, video and audio get a player, and anything else comes back as a link that opens in a new tab.
 
-You can also name the file instead of the record — "show me dummy-video.mp4", or just "show me the beach photo". The assistant searches for it across everything you're allowed to see and tells you which record each match belongs to, so you never have to know where a file lives before asking for it. Every file comes back with its blob id, which is what you reference when asking for a change.
+You can also name the file instead of the record — "show me dummy-video.mp4", or just "show me the beach photo". The assistant searches for it across everything you're allowed to see and tells you which record each match belongs to, so you never have to know where a file lives before asking for it. Files sitting in the Media Library attached to nothing are searched too, and come back marked as such. Every file comes back with its blob id, which is what you reference when asking for a change.
 
-It can also attach and detach files on a record — "attach blob 42 to this post's cover", "take the cover off this post". Files are referenced by their blob id, so the assistant links files already in your Media Library rather than uploading bytes itself.
+It can also attach and detach files on a record — "attach blob 42 to this post's cover", "take the cover off this post". Files are referenced by their blob id, so the assistant links files already in your Media Library rather than uploading bytes itself. A Media Library URL carries that id — `/avo/media-library/260/edit` is blob 260 — so "attach 260 to this post's cover" works straight off the link.
 
 Attach and detach apply immediately rather than through the confirmation card that record writes use. Detaching only unlinks the file — the blob stays in the Media Library and the assistant can re-attach it with the same id. Purging a file is never something the assistant can do; deleting the file itself stays a manual action.
 
-Both respect your policies: file reports only count blobs attached to resources you are allowed to list, and attaching or detaching goes through the same `upload_<name>?` and `delete_<name>?` policy methods the Avo UI checks.
+Both respect your policies: file reports only count blobs attached to resources you are allowed to list, and attaching or detaching goes through the same `upload_<name>?` and `delete_<name>?` policy methods the Avo UI checks. The file itself is judged by who owns it, not by what the Media Library shows: the library lists every blob, but a file already attached to a record you're not allowed to read can't be attached from the chat — otherwise anyone could lift another user's private upload onto a record of their own and read it there.
 
 ### Getting new files in
 


### PR DESCRIPTION
Documents the two new ways files reach a record's attachment through the chat, shipped in [avo-hq/workspace#133](https://github.com/avo-hq/workspace/pull/133) ([AVO-1623](https://linear.app/avohq/issue/AVO-1623)):

- **intelligence.md** — new *Getting new files in* subsection under *Files and attachments*: attaching a file uploaded through the composer (private to its conversation), and attach-by-URL behind a confirmation card, with the hardening summarized (https-only, private addresses rejected on every hop, size cap, byte-sniffed content type). Removes the now-outdated "never uploads bytes and never fetches a file from a URL" claim.
- **intelligence-agents-and-tools.md** — `active_storage_attachment` row updated (chat uploads + URL fetch) with a footnote: only `attach_from_url` goes through the confirmation card.

Follow-up commits, tracking the same work:

- The confirmation card **previews the file** when the URL points at an image — the gate exists so you see what you're approving, and an address isn't that.
- The download limits are now the app's, under one **`config.intelligence.remote_file`** namespace — `max_size` (25 MB default), `open_timeout`, `read_timeout`, `deadline`, `max_redirects` — set partially, merged over the defaults. Documented in *Configuration*; the ENV-fallback sentence there now says "the thinking options", since these have no environment variables.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security logic modified in this PR.
> 
> **Overview**
> Documents **chat uploads** and **attach-by-URL** for Intelligence file handling, replacing the old claim that the assistant never uploads or fetches files.
> 
> **intelligence.md** adds a *Getting new files in* section (composer uploads scoped to the conversation; URL attach behind a confirmation card with image preview) and documents download hardening plus **`config.intelligence.remote_file`** (`max_size`, timeouts, redirects). It also clarifies Media Library blob ids, orphan-file search, and attachment policy (files on records you can’t read can’t be re-attached from chat).
> 
> **intelligence-agents-and-tools.md** expands `active_storage_attachment` and footnotes that only **`attach_from_url`** waits for user confirmation.
> 
> **intelligence-what-you-can-ask.md** adds example prompts for chat uploads, Media Library ids, and URL attach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 756e66f6234f2bb88db5030246b5e9c0684ce287. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->