### PR TITLE
docs(intelligence): responding indicator, day dividers, full-page composer

### DIFF
--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -327,6 +327,8 @@ Clicking the window's own title bar minimizes it — the conversation stays in t
 
 To give a conversation the whole window, use **Open in full page** in the title bar. It's a normal link, so cmd-click opens it in a new tab. From that page, **Back to chat window** hands the conversation back to the floating bar and returns you to the page you opened it from. It only appears when there's somewhere to go back to — open a chat page directly, from a link or a bookmark, and there's no back control.
 
+The button is there before you've sent anything, too. On the new-chat view it points at the full-page composer instead, so you can start a long message with the whole window rather than the panel.
+
 A new conversation opens with a short greeting and a few suggested prompts. Clicking a suggestion types it into the composer and submits it — it takes exactly the same path as a typed message.
 
 :::info
@@ -374,6 +376,20 @@ The microphone only renders where the API exists, so Firefox users get a compose
 :::warning
 In Chrome and Edge, dictating means uploading admin-panel audio to Google. If that doesn't fit your compliance story, tell your admins to dictate in Safari — there's no gem setting that changes it, because the browser owns the audio path.
 :::
+
+## While the assistant is replying
+
+Your message lands on the transcript the moment you send it, with a **Thinking** indicator underneath — it's saved as part of the send, not by the background job, so it never blinks out for the second or two the queue takes. Starting a fresh conversation keeps the composer you typed into on screen until the conversation is ready, then trades one for the other, so there's no empty panel in between. A second **Enter** while that's happening doesn't start a second chat.
+
+The indicator is read from the conversation itself rather than from what your browser happened to witness. Reload mid-reply, or open the chat in full page while it's working, and the indicator is still there waiting on the same reply — the answer streams in wherever you're watching from when it lands. It clears when the assistant's reply arrives, when a card or a question hands the turn back to you, or when the run errors out.
+
+## When each message was sent
+
+A divider marks the start of every day in the transcript: **Today**, **Yesterday**, the weekday name for anything else inside the past week, then a date — `Jul 26`, and `Sep 24, 2025` once it isn't this year — each followed by the clock time of that day's first message.
+
+Day and month names come from your locale, and the **Today** and **Yesterday** words are locale keys (`avo.intelligence.messages.today` and `avo.intelligence.messages.yesterday`), so a translated admin panel gets translated dividers.
+
+Dividers are worked out when the page renders, not as each message arrives. Leave a conversation open across midnight and it picks up the new day's divider on the next full load.
 
 ## Copy a message
 


### PR DESCRIPTION
Documents the user-facing half of [avo-hq/workspace#129](https://github.com/avo-hq/workspace/pull/129) (AVO-1619), which landed yesterday and wasn't covered by the Intelligence docs that shipped alongside it (#604, #605).

Three additions to `docs/4.0/intelligence.md`:

**`## While the assistant is replying`** — the thinking indicator is now read from the conversation rather than from what the browser witnessed, so a reload or a maximize mid-reply keeps showing it. Also covers the message being persisted as part of the send (it no longer disappears while the job queues), the compose view staying up until a fresh conversation swaps in, and the double-Enter guard.

**`## When each message was sent`** — day dividers above each day's first message: Today / Yesterday / weekday / date, with the clock of that day's first message. Names the two new locale keys (`avo.intelligence.messages.today`, `avo.intelligence.messages.yesterday`) and notes that dividers are computed at render time.

**`## Open the chat`** — one paragraph: **Open in full page** is no longer hidden on the new-chat view; it points at the full-page composer.

Not documented, deliberately: workspace#128 (Conductor scripts, tree-scoped dummy databases) is dev tooling with no customer surface. `avo-hq/avo` had no commits yesterday.

`npx vitepress build docs` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHwfZfTnYSs4ccc9TWQ9XL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> **Docs-only** update to `docs/4.0/intelligence.md` for user-facing Intelligence behavior that shipped without documentation.
> 
> Under **Open the chat**, it now notes that **Open in full page** is available on the new-chat view and opens the full-page composer so long messages aren’t written in the panel.
> 
> New section **While the assistant is replying** covers the **Thinking** indicator persisted with the send (no gap while the job queues), keeping the compose view until a new conversation is ready, blocking double-**Enter**, and reading indicator state from the conversation so reload or full-page view mid-reply still shows it until the reply, a handoff card, or an error.
> 
> New section **When each message was sent** describes per-day transcript dividers (**Today** / **Yesterday** / weekday / date plus that day’s first message time), locale keys `avo.intelligence.messages.today` and `avo.intelligence.messages.yesterday`, and that dividers are computed at page render (not live across midnight until reload).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3b2361d30b174b07ee474f8d83056429352fdc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->