### PR TITLE
docs(4.0): upgrade with bin/rails avo:update, not bundle update avo

### DIFF
--- a/docs/4.0/index.md
+++ b/docs/4.0/index.md
@@ -98,7 +98,7 @@ Avo ships as a [gem](https://rubygems.org/gems/avo), so none of its internals li
 bin/rails avo:update
 ```
 
-That resolves every Avo gem you have — core plus any add-ons — and updates them together, conservatively, so a `belongs_to` picker from one gem never ends up a release behind the resource it lives on. `bundle update avo` moves core alone and quietly leaves the rest where they were.
+That resolves every Avo gem you have — core plus any add-ons — and updates them together, conservatively.
 
 ## Start here
 

--- a/docs/4.0/index.md
+++ b/docs/4.0/index.md
@@ -92,7 +92,13 @@ We lean into it. Point your agent at the [docs map](https://docs.avohq.io/4.0/do
 
 ## Seamless upgrades
 
-Avo ships as a [gem](https://rubygems.org/gems/avo), so none of its internals live in your app. Upgrading is `bundle update avo`: no file conflicts, no generated code drifting out of date.
+Avo ships as a [gem](https://rubygems.org/gems/avo), so none of its internals live in your app: no file conflicts, no generated code drifting out of date.
+
+```bash
+bin/rails avo:update
+```
+
+That resolves every Avo gem you have — core plus any add-ons — and updates them together, conservatively, so a `belongs_to` picker from one gem never ends up a release behind the resource it lives on. `bundle update avo` moves core alone and quietly leaves the rest where they were.
 
 ## Start here
 


### PR DESCRIPTION
Independent of the skills work — no dependency on avo-hq/docs.avohq.io#599, avo-hq/avo#4689, or anything else. Branched from `main`.

## The problem

`docs/4.0/index.md` tells people their upgrade is `bundle update avo`. That bumps **core only** and silently leaves every add-on gem where it was — `avo-kanban`, `avo-dashboards`, `avo-advanced_search`, and the rest.

The failure is invisible until something breaks across the seam: a picker from one gem a release behind the resource it renders in, with nothing reporting a version skew.

## The fix

```bash
bin/rails avo:update
```

That task resolves every Avo gem in the bundle and updates them together with `--conservative`, so unrelated dependencies stay put. It also handles the case where a plugin registers under a nickname rather than its gem name (`avo-rhino_field` registers as `:rhino`), which a hand-written `bundle update` list gets wrong.

## Why this is a fix, not a preference

**The Avo 3 → Avo 4 guide already says to run it** — `docs/4.0/avo-3-avo-4-upgrade.md:130`. The landing page was the odd one out, so this makes the docs internally consistent rather than introducing a new recommendation.

## Scope

Avo 4 only. `docs/2.0/` and `docs/3.0/` still say `bundle update avo` and are untouched — those are historical pages for versions with a different add-on story, and changing them is a separate decision.

This is the only remaining `bundle update avo` in `docs/4.0/`.

## Verification

```
npx vitepress build docs   # build complete
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)