### PR TITLE
docs(intelligence): document the conversation menu

### DIFF
--- a/docs/4.0/intelligence-agents-and-tools.md
+++ b/docs/4.0/intelligence-agents-and-tools.md
@@ -25,7 +25,7 @@ A second, much smaller agent does exactly one job: reading a conversation's mess
 It runs on three occasions:
 
 - automatically, after the first message of a new conversation
-- when you pick **Rename again with AI** from the chat page's menu
+- when you pick **Rename again with AI** from the ⋯ menu, in the chat bar or on a chat page
 - when you ask the assistant to rename the conversation without giving it a name
 
 ## The tools
@@ -71,7 +71,8 @@ After that, renaming is a chat feature like any other:
 
 - **"rename this conversation to 'Q3 invoices'"** — the assistant passes your exact wording to `rename_conversation` and the title applies immediately.
 - **"rename this conversation"** — with no name given, the assistant triggers the renamer agent instead of inventing a title itself. The regenerated title reflects where the conversation actually went, not just how it started.
-- **Rename again with AI** in the chat page's menu does the same regeneration without involving the assistant.
+- **Rename again with AI** does the same regeneration without involving the assistant. It sits in the ⋯ menu, both in the chat bar and on a full-page chat.
+- **Rename chat**, in the same menu, skips the model entirely: the title becomes editable in place and what you type is what it's called. See [The conversation menu](./intelligence.html#the-conversation-menu).
 
 Wherever the conversation's name is on screen, it updates live when a rename lands — the chat's tab in the floating bar, the breadcrumb on its full-page view, and the title, name field, and breadcrumb on its resource page.
 

--- a/docs/4.0/intelligence-what-you-can-ask.md
+++ b/docs/4.0/intelligence-what-you-can-ask.md
@@ -149,6 +149,8 @@ The files stay on the message, so you can keep asking about them later in the co
 
 New conversations title themselves after your first message. See [Renaming conversations](./intelligence-agents-and-tools.html#renaming-conversations).
 
+You don't have to ask, either. The ⋯ menu next to the title renames the conversation without the assistant — **Rename chat** to type the title yourself, **Rename again with AI** to have one generated — and the bar's menu adds **Copy as markdown**, which puts the conversation on your clipboard as plain text. See [The conversation menu](./intelligence.html#the-conversation-menu).
+
 ## What it won't do
 
 Knowing the edges saves a round trip:

--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -388,6 +388,19 @@ Chats are also real pages, at `/chats` under your Avo mount point (`/avo/chats` 
 
 The list is scoped to the signed-in user. It's not an admin view of everyone's conversations — for that, browse the `Avo::Intelligence::Chat` resource from the sidebar.
 
+## The conversation menu
+
+The ⋯ button next to a conversation's title opens its menu. It's in the chat window's title bar and on the full-page chat, and both carry the same two rename entries:
+
+- **Rename chat** makes the title editable in place — the panel's header in the bar, the last breadcrumb on a chat page. **Enter** commits and **Esc** cancels in both. Clicking away differs: in the bar it cancels the edit, on the chat page it commits it. An empty title is refused, so a conversation always keeps a name.
+- **Rename again with AI** hands the conversation back to the [renamer agent](./intelligence-agents-and-tools.html#renaming-conversations) for a fresh title, without going through the assistant. The title shimmers while the renamer runs, and the new name lands everywhere the old one showed.
+
+Renaming needs no policy of its own — owning the chat is the entire permission, and you only ever see your own.
+
+The bar's menu carries one more entry. **Copy as markdown** puts the whole conversation on your clipboard as plain markdown: the chat's title as a heading, then every turn labelled **User:** or **Assistant:**. Only what was actually said is copied — tool cards, confirmation cards, and debug rows stay behind, so what you paste into an issue or a PR is the conversation, not the machinery.
+
+The menu's other entries have their own sections: [deleting a chat](#who-can-delete-a-chat), and — for viewers whose policy allows it — [the debug toggle](#debug-levels).
+
 ## Write a message
 
 The composer is a rich text box, not a bare textarea. The usual markdown shortcuts work as you type — `**bold**`, `# heading`, `- list`, backticks for code — and formatting survives a paste. **Enter** sends the message, **Shift+Enter** starts a new line, and on an empty composer **Up** recalls your previously sent messages, shell-style. The assistant receives the message as markdown, structure intact.


### PR DESCRIPTION
Daily docs sweep over yesterday's changes in `avo-hq/avo` and `avo-hq/workspace`. Most of what shipped was already documented — this is the gap that was left.

## What was missing

The chat's ⋯ menu has three entries no page mentioned:

| Entry | Status before |
| ------------------------ | ----------------------------------------------------------------- |
| **Rename chat** | Undocumented — the manual, model-free rename was absent entirely |
| **Rename again with AI** | Documented, but placed only on "the chat page's menu" |
| **Copy as markdown** | Undocumented anywhere in the docs |

The "Renaming conversations" section listed three ways to rename, all of which go through a model — the one that doesn't wasn't among them.

Both rename entries also moved onto the full-page chat in avo-hq/workspace#135, which makes the two existing placement claims read as wrong rather than merely incomplete: **Rename again with AI** is in the bar's menu too, and always was.

## What this changes

- **`intelligence.md`** — new `## The conversation menu` section covering all three entries, with the behavior differences that actually bite (in the bar, clicking away cancels an inline rename; on a chat page it commits), what the markdown export leaves out, and pointers to the existing delete and debug sections for the rest of the menu.
- **`intelligence-agents-and-tools.md`** — adds **Rename chat** to the renaming list and corrects both placement claims.
- **`intelligence-what-you-can-ask.md`** — a line in "Manage the conversation" noting you can rename without asking, per the catalog rule from avo-hq/workspace#136.

Documentation only — no code, config, or frontmatter changes.

## Verification

`npx vitepress build docs` completes clean. All four added cross-links resolve to existing headings (`#renaming-conversations`, `#the-conversation-menu`, `#who-can-delete-a-chat`, `#debug-levels`).

Behavior was read from the shipped source rather than the commit messages: `chat_bar_controller.js` (`startRename`/`commitRename`/`cancelRename`/`copyMarkdown`), `chat_title_controller.js`, `chats/show.html.erb`, `avo/partials/_scripts.html.erb`, and `ChatsController#markdown`/`#update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApoPXZf5Mi1dqB4cWa6hmV

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApoPXZf5Mi1dqB4cWa6hmV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation updates with no runtime, config, or security impact.
> 
> **Overview**
> Documents the chat **⋯** menu so rename and export behavior matches what shipped in the UI.
> 
> **`intelligence.md`** adds **The conversation menu**: **Rename chat** (inline edit, bar vs full-page click-away behavior), **Rename again with AI**, and bar-only **Copy as markdown** (user/assistant text only), with links to delete and debug sections.
> 
> **`intelligence-agents-and-tools.md`** fixes **Rename again with AI** placement (bar and full-page chat, not only the chat page) and lists **Rename chat** as a non-model rename path.
> 
> **`intelligence-what-you-can-ask.md`** notes menu-based rename and **Copy as markdown** under **Manage the conversation**.
> 
> Documentation only — no application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 224c57c3b9b3be0cdce352708417b66fe103dce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->