### PR TITLE
docs(skills): keep skill names on one line in the catalog tables

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -122,3 +122,12 @@ pre code span.line:not(:last-child) {
   height: 100%;
   margin-top: 0 !important;
 }
+
+/* Skills catalog (4.0/agentic-engineering) — the first column is a bare skill
+   name, and a name broken across two lines stops the column being scannable,
+   which is the only reason it is a column. VitePress already gives .vp-doc
+   table `overflow-x: auto`, so a long name scrolls the table rather than
+   forcing the page sideways. */
+.skills-catalog .vp-doc td:first-child code {
+  white-space: nowrap;
+}

--- a/docs/4.0/agentic-engineering.md
+++ b/docs/4.0/agentic-engineering.md
@@ -1,4 +1,5 @@
 ---
+pageClass: skills-catalog
 prompt: Use this page (${link}) to set up my AI coding agent to work with Avo — add the LLM docs context, install the Avo skills loader, and connect the MCP server.
 ---
 


### PR DESCRIPTION
Follow-up to #599. Skill names in the catalog's first column could wrap mid-name at narrow widths, which stops the column being scannable — the only reason it is a column.

## How

```css
.skills-catalog .vp-doc td:first-child code {
  white-space: nowrap;
}
```

with `pageClass: skills-catalog` in the page's frontmatter.

**Scoped to the page rather than styled site-wide.** A global `td:first-child code` rule would also hit pages that put long method signatures in that position, and start scrolling their tables for no reason. `pageClass` wasn't used anywhere in the repo yet, so this introduces the pattern — it's the VitePress-native way to scope a rule to one page.

**No overflow risk.** VitePress already ships `.vp-doc table { display: block; overflow-x: auto }`, so a narrow viewport scrolls the table rather than pushing the page sideways. The longest name is `avo-branding-appearance` at 23 characters, so this should rarely trigger.

## Verification

Against the built output, not just the source:

- `class="Layout skills-catalog"` lands on the page wrapper, and `.vp-doc` is a descendant of it, so the selector actually bites
- `.skills-catalog .vp-doc td:first-child code{white-space:nowrap}` is in the built stylesheet
- all **39** first cells render as `<td><code>avo-…</code></td>`, matching the selector
- the page has only the five skill tables, so nothing else on it is affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)