### PR TITLE
docs(skills): align the catalog with what avo 4.1.3 actually ships

### DIFF
--- a/docs/4.0/actions-api.md
+++ b/docs/4.0/actions-api.md
@@ -518,7 +518,7 @@ end
 
 <Option name="`reload_records`" headingSize="3">
 
-Refreshes only the affected table rows or grid cards via Turbo Streams instead of reloading the whole page. Accepts an array of records or a single record, and defaults to the records the action is running on when called with no argument; `reload_record` is an alias.
+Refreshes only the affected table rows or grid cards via Turbo Streams instead of reloading the whole page. Accepts an array of records or a single record, and defaults to the records the action is running on when called with no argument (Avo 4.1.2 and later); `reload_record` is an alias.
 
 <div style="position: relative; padding-bottom: 56.25%; height: 0;"><iframe src="https://www.loom.com/embed/6b9ae6a3968c447f98ac4f9a161fe781?sid=17f08010-6a56-4e8c-8b80-692424327b55" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
 

--- a/docs/4.0/agentic-engineering.md
+++ b/docs/4.0/agentic-engineering.md
@@ -19,6 +19,8 @@ AI agents generate better code when they have up-to-date Avo documentation in th
 
 ## Skills
 
+<VersionReq version="4.1.1" />
+
 Skills are pre-built instruction sets that teach your agent how to perform specific Avo workflows. Instead of prompting from scratch each time, you install a skill and the agent follows a proven, repeatable process.
 
 The skills ship **inside the `avo` gem**, so they describe the version your app has locked rather than whatever version a globally-installed copy happened to be written for.
@@ -27,7 +29,7 @@ Install the loader that finds them with **`rails g avo:skills`**:
 
 <CustomCode content="rails g avo:skills" />
 
-That starts a short interactive installer. It explains each choice as you go and shows you exactly what it will do before writing anything. It:
+That starts a short interactive installer — one question per screen, all answered up front, with a summary of exactly what it will do before it writes anything (Avo 4.1.3 and later). It:
 
 - installs into this app, or into your home directory so one copy serves every Avo project
 - sets up any of `.agents/skills`, `.claude/skills`, and `.cursor/skills`
@@ -50,11 +52,12 @@ Update your Avo gems with `bin/rails avo:update` and the skills come with them. 
 | ------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `avo-resources`           | generate and configure resources — title, includes, sorting, pagination, cover/avatar, array (non-DB) resources |
 | `avo-fields`              | add and configure fields in `def fields` — pick the `as:` type, options, formatting, layout                     |
-| `avo-associations`        | wire `belongs_to` / `has_many` / `has_one` / HABTM fields, searchable pickers, polymorphism, STI                |
+| `avo-associations`        | wire `belongs_to` / `has_many` / `has_one` / HABTM fields, polymorphism, STI, nested create-in-form             |
 | `avo-actions`             | build actions that run Ruby on selected, single, or no records — bulk ops, forms, modals, responses             |
-| `avo-filters`             | filter and segment the index — basic filters, dynamic filters, and scopes                                       |
+| `avo-filters`             | basic filters on the index — dynamic filters and scopes ship as their own add-on skills                         |
 | `avo-index-views`         | control how the index renders — table styling, grid cards, map markers, view types                              |
-| `avo-menu-icons`          | auto-populate menu items with semantically appropriate Tabler icons                                             |
+| `avo-custom-fields`       | build a brand-new field type — generator plus its Edit/Show/Index view components                               |
+| `avo-menu-icons`          | pick semantically appropriate Tabler icons and set them on resources and dashboards                             |
 
 ### Config & ops
 
@@ -63,29 +66,26 @@ Update your Avo gems with `bin/rails avo:update` and the skills come with them. 
 | `avo-setup`               | install Avo, mount it, authenticate the private gem server, and set the license key            |
 | `avo-update`              | bump the Avo gems and apply every upgrade-guide step for the versions crossed, with a log      |
 | `avo-authentication`      | tell Avo who the current user is, gate access, and wire roles / profile / sign-out             |
-| `avo-authorization`       | restrict who sees and does what with Pundit policies — resources, actions, associations, files |
 | `avo-admin-config`        | global initializer knobs — app name, per-page, container width, density, home path             |
 | `avo-performance`         | caching and stale-row fixes to make the admin fast                                             |
 | `avo-testing`             | unblock the license check in the test suite and use Avo's test helpers                         |
+| `avo-multitenancy`        | scope the admin per tenant — route- or session-based, with an account switcher                 |
 
 ### Customization
 
 | Skill                     | What it covers                                                                                                           |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `avo-branding-appearance` | make the admin look like the product — logo, favicon, color scheme, palettes, CSS re-skin, icons                         |
-| `avo-navigation-search`   | menus, breadcrumbs, keyboard shortcuts, per-resource search, and the <kbd>Cmd</kbd> + <kbd>K</kbd> global search palette |
+| `avo-navigation-search`   | per-resource search, breadcrumbs, keyboard shortcuts, and the auto-generated sidebar                                     |
 | `avo-custom-ui`           | build custom pages, embedded panels, dynamic/nested forms, eject views, JS/Stimulus, Tailwind                            |
-| `avo-custom-fields`       | build a brand-new field type — generator plus its Edit/Show/Index view components                                        |
 | `avo-i18n`                | translate and localize the admin — labels, locale switching, RTL                                                         |
-| `avo-multitenancy`        | scope the admin per tenant — route- or session-based, with an account switcher                                           |
-| `avo-record-reordering`   | persistent up/down and drag-and-drop record ordering                                                                     |
-| `avo-custom-controls`     | take over the show/edit/index/row button bars — relabel, remove, add links/actions/dropdowns                             |
+| `avo-media-library`       | turn on the central asset browser and the picker inside rich-text editors                                                |
 | `avo-controllers`         | override per-resource CRUD controller hooks and safely extend Avo's `ApplicationController`                              |
 | `avo-engine-internals`    | engine plumbing for custom Ruby — `main_app`/`avo` helpers, `Avo::Current`, `ExecutionContext`, reserved names           |
 
 ### Add-ons
 
-Separately-licensed gems (paid add-on or Enterprise). `avo-media-library` is Community but off by default.
+Separately-licensed gems (paid add-on or Enterprise). These skills ship inside their own gem, not inside `avo`.
 
 | Skill                     | What it covers                                                                                     |
 | ------------------------- | -------------------------------------------------------------------------------------------------- |
@@ -96,12 +96,14 @@ Separately-licensed gems (paid add-on or Enterprise). `avo-media-library` is Com
 | `avo-kanban`              | DB-backed drag-and-drop boards across resources                                                    |
 | `avo-audit-logging`       | track who changed and viewed what — timeline, diffs, revert                                        |
 | `avo-collaboration`       | comments, reactions, and an automatic change-log on a record                                       |
-| `avo-media-library`       | central asset browser and a picker inside rich-text editors                                        |
+| `avo-authorization`       | restrict who sees and does what with Pundit policies — resources, actions, associations, files     |
 | `avo-http-resource`       | back a resource with an external HTTP API instead of Active Record                                 |
 | `avo-menu`                | build the sidebar with the menu editor DSL — sections, dividers, links, icons, per-user visibility |
 | `avo-scopes`              | one-click segment tabs above the index, with counts and a default view                             |
 | `avo-dynamic-filters`     | let end users build their own ad-hoc filters from a filters bar                                    |
 | `avo-advanced-search`     | the <kbd>Cmd</kbd> + <kbd>K</kbd> global search palette, and type-to-search association pickers    |
+| `avo-record-reordering`   | persistent up/down and drag-and-drop record ordering                                               |
+| `avo-custom-controls`     | take over the show/edit/index/row button bars — relabel, remove, add links/actions/dropdowns       |
 
 ### Cross-cutting
 


### PR DESCRIPTION
Daily docs sweep over yesterday's `avo-hq/avo` and `avo-hq/workspace` commits (2026-08-04). Two pages needed changes.

## `docs/4.0/agentic-engineering.md` — skills catalog

The catalog landed the same day as the gem-shipped skills themselves (#599), and it drifted from what `avo` 4.1.3 ships. Checked every row against `lib/avo/skills/index.md` and `lib/avo/skills/package-map.md` in avo, plus the `skills/` trees in the workspace gems — the tables now match exactly: 24 core skills, 15 package-owned.

**Skills in the wrong table.** Three skills were listed as if they came with core, when they ship inside their own paid gem — a reader with only `avo` installed would go looking for skills their app does not have:

| Skill | Was | Ships in |
| ----- | --- | -------- |
| `avo-authorization` | Config & ops | `avo-authorization` |
| `avo-record-reordering` | Customization | `avo-record_reordering` |
| `avo-custom-controls` | Customization | `avo-custom_controls` |
| `avo-media-library` | Add-ons | `avo` (Community, off by default) |

`avo-custom-fields` moved to Core and `avo-multitenancy` to Config & ops, matching the gem's own index.

**Rows that overstated what a core skill covers.** Each of these subjects is owned by a different skill, which is exactly what the core skill's own frontmatter says:

- `avo-associations` — dropped "searchable pickers" (that's `avo-advanced-search`)
- `avo-filters` — basic filters only; dynamic filters and scopes are their own add-on skills
- `avo-navigation-search` — dropped the menu DSL (`avo-menu`) and the <kbd>Cmd</kbd>+<kbd>K</kbd> palette (`avo-advanced-search`)

**Version markers.** Gem-shipped skills landed in 4.1.1 (`<VersionReq>`), and the screen-per-question installer the page describes landed in 4.1.3 — noted inline so a reader on 4.1.1/4.1.2 isn't looking for a panel they don't have.

## `docs/4.0/actions-api.md` — `reload_records`

The no-argument form is documented but was undated; it shipped in 4.1.2. Calling it with no argument on anything earlier raises `ArgumentError`, so the version is worth stating.

## Checked, no docs needed

- Media library attach modal widening — internal (`ModalComponent`'s `width` prop gained `:5xl`; the prop isn't part of the documented surface).
- Shift-select on index tables, create-modal tab alignment, `require_dependency` removal — bug fixes with no user-facing API change.
- avo-intelligence work (chats history in Avo's panel, chat window re-anchoring after a tab reorder, one-round-trip conversation swap) — UI fixes; the user-facing pieces from yesterday (send queue, action-field prefill) were already documented in #616/#617.
- `ws` changes (setup, `release --only`, skill staleness check) — workspace tooling, not customer-facing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1TzmLWXZBCnMAQUo2GU5M)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2def8c67ce6a75cf35036f606b4afe38cc134871. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->