### PR TITLE
Lexxy field docs (AVO-1236)

### DIFF
--- a/docs/4.0/fields/lexxy.md
+++ b/docs/4.0/fields/lexxy.md
@@ -65,6 +65,12 @@ end
 field :body, as: :lexxy
 ```
 
+## Media Library
+
+When the [Media Library](../media-library) is enabled, the editor's toolbar gets a button that opens the library in a modal. Picking an asset inserts it into the content — images as Action Text attachments, other files as links.
+
+The button is hidden when the field has attachments disabled (which is the default on plain `string`/`text` columns), since there is nothing to attach the blob to.
+
 ## Editor configuration
 
 Lexxy's element attributes (`markdown`, `rich-text`, `headings`, `permitted-attachment-types`, etc.) are documented in the [Lexxy docs](https://lexxy.dev/docs/) and can be configured globally through `Lexxy.configure` presets in your JavaScript, or per field through the field's `html` option.

--- a/docs/4.0/fields/lexxy.md
+++ b/docs/4.0/fields/lexxy.md
@@ -1,0 +1,70 @@
+---
+license: community
+description: "Renders the Lexxy rich text editor, Basecamp's modern Action Text editor built on Lexical."
+fieldTags: [rich text, attachments]
+---
+
+# Lexxy
+
+```ruby
+field :body, as: :lexxy
+```
+
+The `Lexxy` field renders [Lexxy](https://github.com/basecamp/lexxy), Basecamp's modern rich text editor for Action Text, built on Meta's Lexical framework. It produces clean HTML semantics, supports Markdown shortcuts, code syntax highlighting, and rich attachment previews.
+
+It supports [Action Text](https://guides.rubyonrails.org/action_text_overview.html) attributes and plain `string`/`text` columns storing HTML, with file attachments uploaded through [Active Storage](https://guides.rubyonrails.org/active_storage_overview.html) direct uploads.
+
+Lexxy field is hidden from the `Index` view.
+
+## Requirements
+
+- Rails >= 8.0.2 (required by the `lexxy` gem)
+
+:::info Add this field to the `Gemfile`
+```ruby
+# Gemfile
+gem "avo-lexxy_field"
+```
+:::
+
+:::warning Lexxy takes over Action Text
+The `lexxy` gem replaces Trix as the default `form.rich_text_area` editor across your whole app. If you only want Lexxy inside Avo, opt out in the host app:
+
+```ruby
+# config/application.rb (Rails 8.0/8.1)
+config.lexxy.override_action_text_defaults = false
+```
+:::
+
+## Options
+
+<!-- @include: ./../common/field_options/always_show.md-->
+
+<Option name="`attachments_disabled`">
+
+Disables file attachments (toolbar button, paste, and drag & drop).
+
+#### Default value
+
+`false` on Action Text attributes, `true` on plain columns.
+
+Lexxy uploads files through Active Storage direct uploads and relies on Action Text to attach the blobs to the record on save. On plain columns the uploads would remain orphaned blobs, so attachments are disabled there by default. Pass `attachments_disabled: false` to enable them anyway.
+</Option>
+
+## Action Text
+
+Lexxy is built for Action Text and works with it out of the box, including file attachments.
+
+```ruby
+class Post < ApplicationRecord
+  has_rich_text :body
+end
+```
+
+```ruby
+field :body, as: :lexxy
+```
+
+## Editor configuration
+
+Lexxy's element attributes (`markdown`, `rich-text`, `headings`, `permitted-attachment-types`, etc.) are documented in the [Lexxy docs](https://lexxy.dev/docs/) and can be configured globally through `Lexxy.configure` presets in your JavaScript, or per field through the field's `html` option.

--- a/docs/4.0/media-library.md
+++ b/docs/4.0/media-library.md
@@ -14,7 +14,7 @@ If you run an asset-intensive app, having one place to view and manage all those
 The Media Library has two goals in mind.
 
 1. Browse and manage all your assets
-2. Use it to inject assets in all three of Avo's rich text editors ([trix](./fields/trix), [rhino](./fields/rhino), and [markdown](./fields/markdown)).
+2. Use it to inject assets in Avo's rich text editors ([trix](./fields/trix), [rhino](./fields/rhino), [markdown](./fields/markdown), and [lexxy](./fields/lexxy)).
 
 :::warning
 The Media Library feature is still in alpha and future releases might contain breaking changes so keep an eye out for the upgrade guide.
@@ -91,6 +91,7 @@ The Media Library will seamlessly integrate with all the rich text editors.
 field :body, as: :trix
 field :body, as: :rhino
 field :body, as: :markdown
+field :body, as: :lexxy
 ```
 
 The editors will each have a button to open the Media Library modal.
@@ -104,4 +105,4 @@ The [`markdown`](./fields/markdown) field accepts a `media_library` option (defa
 field :body, as: :markdown, media_library: false
 ```
 
-This is a `markdown`-only option; the `trix` and `rhino` fields don't support per-field toggling.
+This is a `markdown`-only option; the `trix` and `rhino` fields don't support per-field toggling. The [`lexxy`](./fields/lexxy) field hides the button when its attachments are disabled (`attachments_disabled: true`).


### PR DESCRIPTION
Documents the new `lexxy` field and its Media Library integration.

- New page: `4.0/fields/lexxy.md` — requirements, installation, `always_show` / `attachments_disabled` options, Action Text notes, editor configuration.
- Media Library section on that page: the toolbar button opens the library in a modal; images come in as Action Text attachments, other files as links; the button is hidden when the field has attachments disabled.
- `4.0/media-library.md`: the picker now covers four editors, not three — `lexxy` added to the intro, the field list, and the per-field toggle note.

Ships alongside the media library support in [avo-lexxy_field](https://github.com/avo-hq/avo-lexxy_field).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or application code impact.
> 
> **Overview**
> Adds **Avo 4.0 documentation** for the **`lexxy`** rich text field (`avo-lexxy_field`), covering setup, Action Text vs plain columns, and how it behaves with attachments and the Media Library.
> 
> The new **`docs/4.0/fields/lexxy.md`** page documents `field :body, as: :lexxy`, Rails 8.0.2+ and gem install, the global Action Text override warning, **`attachments_disabled`** defaults (off on plain columns to avoid orphaned blobs), Action Text usage, Media Library toolbar behavior (images as attachments, other files as links; button hidden when attachments are disabled), and pointers to Lexxy’s own editor config.
> 
> **`docs/4.0/media-library.md`** is updated so Lexxy is listed alongside trix, rhino, and markdown in the intro, example field list, and the note on per-field Media Library toggles (Lexxy follows **`attachments_disabled`** rather than a dedicated `media_library` flag).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a946d2041466e4daf37d84099916e558eaa92689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->