### PR TITLE
docs(intelligence): document the ask-user card and its multi-select shape

### DIFF
--- a/docs/4.0/intelligence-agents-and-tools.md
+++ b/docs/4.0/intelligence-agents-and-tools.md
@@ -34,7 +34,7 @@ Tool names below are how calls appear in the Tool calls resource and in the chat
 
 | Tool                         | What it does                                                                                                        | Writes apply      |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `ask_user`                   | Asks you one clarifying question, optionally with clickable answer options, then ends the turn                       | —                 |
+| `ask_user`                   | Asks you one clarifying question — free-form, or with clickable options — then ends the turn                         | —                 |
 | `schema_inspector`           | Reports the database structure — scoped to the resources the signed-in user is allowed to see                        | read-only         |
 | `resource_inspector`         | Reads one resource's real columns, associations, and scopes; unlocks querying and writing that resource              | read-only         |
 | `active_record_query`        | Runs read-only, paginated, policy-scoped queries against a resource                                                  | read-only         |
@@ -50,6 +50,21 @@ Tool names below are how calls appear in the Tool calls resource and in the chat
 "After you confirm" means the tool call produces a card describing the pending change; your click applies it, not the model. "Immediately" is reserved for actions that are reversible (a detached file can be re-attached, a conversation can be renamed again) or additive (creating a record).
 
 ¹ Attaching and detaching existing blobs apply immediately; the `attach_from_url` operation is the exception — a server-side download always goes through a confirmation card showing the URL, and nothing is fetched until you click **Attach**. See [Getting new files in](./intelligence.html#getting-new-files-in).
+
+### The shapes an ask can take
+
+Every ask is one card, but the card takes a few shapes — the model chooses per question, through the arguments it passes:
+
+| Arguments                          | The card                                                                                   |
+| ---------------------------------- | ------------------------------------------------------------------------------------------ |
+| the question alone                 | A plain question; you answer in the composer                                                |
+| plus `options` (up to 10, short)   | Numbered options you can click — or reply with an option's number — beside a free-text box  |
+| plus `free_text: false`            | The options only, for questions whose answer set really is closed (yes/no, an enum's values) |
+| plus `multiple: true`              | Checkboxes and a text box, sent together as one comma-separated reply                       |
+
+Both flags only mean anything alongside `options`: a question with none is a free-form ask, and closing that off would leave nothing to answer with.
+
+Clicking an option posts the option's *text* through the same path a typed reply takes, so answering a card is an ordinary turn — one that can never confirm a pending write, even when the option reads "Yes". See [Answering the assistant's questions](./intelligence.html#answering-the-assistant-s-questions).
 
 ### Where tools get their context
 

--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -167,13 +167,27 @@ Every message you send starts a fresh turn against the provider, built from thre
 
 **Writing.** Updates and deletes show you a card describing the change and run only when you confirm it; the confirmation applies the change, not the model. Those two work one record at a time — ask for a bulk change and the assistant will say so and ask you to pick. Creates apply immediately, since there's nothing to preview for a record that doesn't exist yet, and creating is the one write it will repeat: "add 15 cities" creates fifteen without stopping between them. Every executed write is recorded in an audit log, and the assistant can undo one through the same confirmation card.
 
-**Confirming a card — click or type.** Every card that waits on you — an update, a delete, an undo, an action run, an attach-by-URL — settles the same two ways: click its button (**Confirm**, or **Run** on an action, **Attach** on a file), or just tell the assistant to go ahead in the composer — "do it", "go for it", "run it", "yes". A typed confirmation is *your* word, so it counts exactly as the click does and the card flips in place; the assistant still can't confirm on its own, and it can't talk its way past a Cancel. It only reads as a confirmation when that's all you say — "run it, but change the reason to budget cut" carries a fresh instruction, so the assistant re-proposes with your change instead of running the old card.
+**Confirming a card — click or type.** Every card that waits on you — an update, a delete, an undo, an action run, an attach-by-URL — settles the same two ways: click its button (**Confirm**, or **Run** on an action, **Attach** on a file), or just tell the assistant to go ahead in the composer — "do it", "go for it", "run it", "yes". A typed confirmation is *your* word, so it counts exactly as the click does and the card flips in place; the assistant still can't confirm on its own, and it can't talk its way past a Cancel. It only reads as a confirmation when that's all you say — "run it, but change the reason to budget cut" carries a fresh instruction, so the assistant re-proposes with your change instead of running the old card. An answer sent from a question card is never a confirmation either, however it reads — see [Answering the assistant's questions](#answering-the-assistant-s-questions).
 
 **Running your actions.** The assistant can also run the [actions](./actions.html) a resource registers, not just write columns — see [Your actions, from the chat](#your-actions-from-the-chat).
 
 **Authorization is enforced at the tool layer, on every call.** Each read and write goes through your Avo policies for the signed-in user who owns the chat — per-resource and per-field. Instructions are guidance for the model; your policies are what actually decides. A resource the user can't list is invisible to the assistant rather than refused, so it can't be used to probe for what exists.
 
 For the full reference — both agents, every tool and its gates, and how conversations get their names — see [Agents and tools](./intelligence-agents-and-tools.html).
+
+## Answering the assistant's questions
+
+When the assistant genuinely can't proceed — a required value you didn't mention, or which of three matching records you meant — it asks you, and the question arrives as a card rather than as a sentence buried in a reply. The card *is* the message: the turn ends there and waits on you. It asks one thing at a time, and it asks instead of guessing; it won't use a question to chase optional values you never brought up.
+
+**A plain question.** With no options to offer, the card is the question and nothing else. Answer it in the composer the way you'd answer anything else.
+
+**Question with options.** When the answer is one of a small known set — a status, a yes/no, the titles of the records it matched — the card lists them, numbered `1`, `2`, `3…`. Click one and it replies with that option's own text, so the conversation reads back as what you actually said ("Published"), not as an opaque "2". The numbers are there for typing: reply `2` in the composer and it lands on the second option.
+
+**The box beside them.** Options are usually a shortcut rather than the whole truth, so most cards keep a free-text box next to them — *Or answer in your own words…* — with its own **Send**. When the options really are the entire answer space, the assistant closes that box off and the buttons become the only way to answer.
+
+**Picking several at once.** Some questions take more than one answer — which fields to fill in, which of the matched records to include. Those render as checkboxes instead of buttons, with one **Send** under them and an *Add anything else…* box alongside. Everything goes back as a single reply: the labels you ticked, plus whatever you typed, separated by commas.
+
+Answering a question card is an ordinary turn, never a confirmation. An option can quite legitimately read "Yes", and clicking it answers the question it belongs to — it can't reach back and confirm an update or a delete waiting further up the conversation.
 
 ## Your actions, from the chat
 


### PR DESCRIPTION
Daily docs sweep over yesterday's changes in `avo-hq/avo` and `avo-hq/workspace`.

The one change that moved documented behavior is workspace [#153](https://github.com/avo-hq/workspace/pull/153) — *avo-intelligence: multi-select asks and a redesigned ask-user card (AVO-1547)*:

- `ask_user` gained `multiple: true` (checkboxes plus a shared free-text box, joined into one comma-separated reply) and `free_text: false` (options only, for a closed answer set).
- Clicking an option now posts the option's own text instead of a bare number; numbers stay as a visible, typeable index.
- Card answers are marked `ask_answer` so the typed-confirmation gate skips them — an option reading "Yes" answers its question and can no longer confirm a pending write sitting last in the transcript.

None of that surface was documented. The ask card only ever existed as one row in the tools table, so this adds the section it never had.

## Changes

**`docs/4.0/intelligence.md`**

- New `## Answering the assistant's questions` section: the plain ask, numbered clickable options (click or type the number), the free-text box beside them and when the assistant closes it off, multi-select checkboxes, and the rule that answering a card is an ordinary turn — never a confirmation.
- The **Confirming a card — click or type** paragraph links to it, since that gate is exactly what changed.

**`docs/4.0/intelligence-agents-and-tools.md`**

- New `### The shapes an ask can take`: a table mapping the arguments the model passes (`options`, `free_text: false`, `multiple: true`) to the card the user sees, plus the note that both flags only mean anything alongside `options`.
- The `ask_user` row now reads "free-form, or with clickable options".

## Not needing docs

| Change | Why |
| --- | --- |
| avo [#4595](https://github.com/avo-hq/avo/pull/4595) — grid view populates Actions on select | Bug fix; `grid-view.md` never claimed otherwise |
| workspace [#158](https://github.com/avo-hq/workspace/pull/158) — iOS chat fixes | Bug fixes to an already-documented surface |
| workspace [#152](https://github.com/avo-hq/workspace/pull/152) — chats history in Avo's panel | Cosmetic; "All chats" prose still accurate |
| workspace [#159](https://github.com/avo-hq/workspace/pull/159) — `ws provision` | Internal workspace CLI, not customer docs |
| workspace [#151](https://github.com/avo-hq/workspace/pull/151) — dummy db prefix cap | Test infrastructure |

## Verification

- Behavior verified against `gems/avo-intelligence/app/tools/ask_user_tool.rb`, the `_ask_user.html.erb` partial, `messages_controller.rb`, and `config/locales/en.yml` — not from the PR description.
- `npx vitepress build docs` passes; the cross-page anchor `#answering-the-assistant-s-questions` resolves in the built output.
- `yarn generate-llms-4` and `node scripts/generate-docs-map.js 4.0` re-run — no changes (no new pages).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJeVVqRfGiD6AgUJBo2mHm)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Documents the redesigned **`ask_user`** experience that shipped without user-facing docs: question cards, option layouts, and how answers interact with write confirmations.
> 
> **`intelligence.md`** adds **Answering the assistant's questions** — plain asks, numbered clickable options (click sends the option text; typing `1`/`2` still works), the optional free-text box vs **`free_text: false`** (options only), and **`multiple: true`** (checkboxes plus comma-separated reply). It states that replying from a question card is a normal turn and **never** counts as confirming a pending write (e.g. an option labeled "Yes"). The **Confirming a card** paragraph now points to that section.
> 
> **`intelligence-agents-and-tools.md`** expands the **`ask_user`** table row and adds **The shapes an ask can take** — an argument-to-UI table (`options`, `free_text: false`, `multiple: true`) and the same answer-vs-confirmation rule, with a cross-link to the main intelligence page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaa3a6e58f95c774a9376401d7dc9ca047ea5598. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->