### PR TITLE
docs(intelligence): the thinking knobs split, progress hints, and the worked trail

### DIFF
--- a/docs/4.0/intelligence-agents-and-tools.md
+++ b/docs/4.0/intelligence-agents-and-tools.md
@@ -37,7 +37,7 @@ Tool names below are how calls appear in the Tool calls resource and in the chat
 | `ask_user`                   | Asks you one clarifying question, optionally with clickable answer options, then ends the turn                       | —                 |
 | `schema_inspector`           | Reports the database structure — scoped to the resources the signed-in user is allowed to see                        | read-only         |
 | `resource_inspector`         | Reads one resource's real columns, associations, and scopes; unlocks querying and writing that resource              | read-only         |
-| `active_record_query`        | Runs read-only, paginated, policy-scoped queries against a resource                                                  | read-only         |
+| `active_record_query`        | Runs read-only, paginated, policy-scoped queries against a resource — filters, scopes, grouping, and free-text search through the resource's own [configured search](./search.html) | read-only         |
 | `active_storage_insights`    | Storage reports — totals, orphans, duplicates, growth, biggest files — and finding/showing files                     | read-only         |
 | `active_storage_attachment`  | Attaches or detaches a Media Library blob (or a chat upload) on a record's attachment; can also fetch a URL onto one | immediately¹      |
 | `create_record`              | Creates a record                                                                                                     | immediately       |

--- a/docs/4.0/intelligence-what-you-can-ask.md
+++ b/docs/4.0/intelligence-what-you-can-ask.md
@@ -17,6 +17,7 @@ For how a turn actually unfolds — inspect-first, confirmation cards, authoriza
 | Ask                                              | What you get                                                             |
 | ------------------------------------------------ | ------------------------------------------------------------------------ |
 | "Find the user with the email ada@example.com"   | The matching record, as a card with a link to open it                    |
+| "Find the user called John Deere"                | The record — found by search, even when the name lives across several columns |
 | "Show me the 5 most recent posts"                | A short list, sorted by the timestamp that matches what you asked about  |
 | "Which users signed up in the last 7 days?"      | A date-filtered list, resolved against the real current time             |
 | "List projects whose name contains 'orbit'"      | A partial-match list                                                     |
@@ -24,6 +25,8 @@ For how a turn actually unfolds — inspect-first, confirmation cards, authoriza
 | "Who signed up last?"                            | One record, rendered as a card                                           |
 
 Ranges, sets, and emptiness all work in the same sentence-shaped way: "orders over $500", "users older than 26", "posts with no author", "projects in draft or review".
+
+**Naming a record in words is enough.** "The user called John Deere", "the post about pricing", "find Acme" — the assistant looks the record up the way your admin does: a resource that [configures search](./search.html) gets that exact search, and one that doesn't is matched across every text column you're allowed to read. A multi-word name still finds the record when its words live in different columns, so a first and last name stored separately aren't a problem. And "no such record" is only ever reported after that search came back empty — never off a guessed column filter.
 
 **Your scopes are part of the vocabulary.** Domain words like "admins", "active", or "published" are usually named scopes on the model rather than columns, and the assistant prefers the scope over guessing at a filter — so "list the published posts" runs `Post.published`, whatever that scope actually does.
 

--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -43,7 +43,7 @@ bin/rails generate avo:intelligence install
 bin/rails db:migrate
 ```
 
-This creates the `avo_intelligence_*` tables and writes `config/initializers/ruby_llm.rb` (skipped if it already exists).
+This creates the `avo_intelligence_*` tables and writes `config/initializers/ruby_llm.rb` (skipped if it already exists). It also appends every intelligence setting — commented out, at its default — to the end of `config/initializers/avo.rb`, so the options are in the file waiting to be uncommented rather than in terminal output that scrolls away. If the file already configures `config.intelligence`, it's left untouched.
 
 :::warning Already installed an earlier alpha?
 The installer only ever writes the initial migration, so a schema created by an earlier version won't pick up columns added since. Two are current, both on `avo_intelligence_chats`: `attached_context` stores [the record the chat was started from](#the-record-you-start-from), and `responding_at` tracks [whether a chat is being answered right now](#while-the-assistant-is-replying). Add them by hand:

--- a/docs/4.0/intelligence.md
+++ b/docs/4.0/intelligence.md
@@ -106,8 +106,9 @@ Avo.configure do |config|
   # Only sent to models that support reasoning; ignored otherwise.
   config.intelligence.thinking_effort = "medium"
 
-  # Token budget for the model's thinking trace (positive integer).
+  # Token budget for the model's thinking trace (positive integer, min 1024).
   config.intelligence.thinking_budget = 2048
+  # Set both — see "Thinking" below. A model takes one knob or the other.
 
   # Clock format for chat timestamps: :auto (default), :h12, or :h24.
   config.intelligence.time_format = :h24
@@ -132,6 +133,49 @@ The two thinking options fall back to an environment variable when unset, so you
 | `thinking_budget` | `AVO_INTELLIGENCE_THINKING_BUDGET` | unset |
 
 When both are unset, no thinking parameters are sent to the provider.
+
+### Thinking
+
+Set **both** options. They are not alternatives, and they are not a fallback pair — they are two
+different knobs, and each model accepts exactly one of them. Its provider rejects the other
+outright.
+
+This is not an Anthropic quirk — the split runs across providers, and which knob a model takes is a
+property of the model, not of the company that made it:
+
+| Knob              | Models that take it                                           |
+| ----------------- | ------------------------------------------------------------- |
+| `thinking_budget` | `claude-haiku-4-5`, `claude-sonnet-4-6`, Gemini 2.5            |
+| `thinking_effort` | `claude-opus-5`, Gemini 3, OpenAI reasoning models (`gpt-5`, …) |
+
+Avo reads the answer from the model's own registry entry and sends only that knob, preferring the
+budget where a model takes both. So a picker offering Haiku and Opus needs both values set —
+configure only `thinking_effort` and every Haiku conversation quietly answers with no thinking at
+all, with nothing in the logs to say so.
+
+Both options reach every provider RubyLLM supports thinking for, which is most of them: Anthropic,
+OpenAI, Gemini, VertexAI, Bedrock, Azure, Mistral, Perplexity, OpenRouter, Ollama, and GPUStack. A
+few of those don't take direction — Mistral's Magistral models always think and ignore what you
+send, and local Ollama or GPUStack models get the values passed through untranslated. For the
+current per-provider picture, RubyLLM documents it at
+[rubyllm.com/thinking](https://rubyllm.com/thinking/).
+
+Effort is passed to the provider exactly as written, so the accepted strings are the provider's,
+not Avo's. `"low"`, `"medium"`, and `"high"` are understood everywhere effort applies; OpenAI also
+takes `"minimal"`, Gemini 3 takes only `"low"` and `"high"`, and `"none"` turns thinking off on
+Anthropic. A value the provider doesn't recognise fails on the first request, not at boot. Budgets
+are thinking tokens, minimum 1024 on Anthropic; zero or negative reads as unset.
+
+The same two knobs are how you size the reasoning readers see above a reply: a bigger budget or a
+higher effort buys a longer, deeper trace; a smaller one keeps it to a line or two. On budget
+models the trace is the model's own reasoning verbatim, so the budget bounds it directly. On
+effort models what renders is the provider's summary of the reasoning — its length loosely follows
+the effort, and its wording isn't steerable from your side.
+
+:::info
+Thinking only reaches models that declare reasoning support. Sending it to a plain chat model like
+`gpt-4o-mini` would have the provider reject the whole request, so Avo doesn't.
+:::
 
 ### Timestamps
 
@@ -444,6 +488,10 @@ In Chrome and Edge, dictating means uploading admin-panel audio to Google. If th
 
 Your message lands on the transcript the moment you send it, with a **Thinking** indicator underneath — it's saved as part of the send, not by the background job, so it never blinks out for the second or two the queue takes. Starting a fresh conversation keeps the composer you typed into on screen until the conversation is ready, then trades one for the other, so there's no empty panel in between. A second **Enter** while that's happening doesn't start a second chat.
 
+When answering takes real work — a lookup, an inspection, a write — the assistant leaves short progress hints while it works: *Inspecting the schema*, *Checking today's signups*. They render small and muted, alongside the reasoning trace, so they read as status rather than replies — and they name the goal in your terms, never the tool it reaches for. It's what you read while the work happens instead of watching an empty panel.
+
+When the answer lands, the worked trail folds up: everything between your question and the reply — the reasoning, the hints — collapses into a single **Worked for 12 seconds** row above the answer, so a settled conversation reads question, one quiet row, answer. Open the row to see how the assistant got there; viewers with the [`:tools` debug level](#debug-levels) find the tool calls in there too.
+
 You can keep typing while it works. A message sent before the current answer lands doesn't interrupt it — it waits in a short list above the composer, in the order you sent it, and goes out on its own the moment the assistant finishes. One turn at a time, so two replies never race each other in the same conversation.
 
 While a message waits you can move it to the front of the line or drop it, which is the point of showing you the wait rather than hiding it. The list belongs to the page you typed on: reloading clears it, the same way it clears anything else you'd typed but not sent.
@@ -571,8 +619,12 @@ How much of the assistant's internal work a viewer may see is an authorization d
 
 There are two levels:
 
-- `:off` — the conversation only: replies, record cards, confirmation buttons, the assistant's questions, and the "Thinking…" indicator. The default.
-- `:tools` — everything above plus the system prompt, the raw thinking trace, the tool calls, and the raw tool output.
+- `:off` — the conversation: replies, record cards, confirmation buttons, the assistant's questions, the "Thinking…" indicator, and the collapsed trail with its reasoning trace and progress hints. The default.
+- `:tools` — everything above plus the system prompt, the tool calls, and the raw tool output.
+
+The reasoning trace deliberately sits on the `:off` side of the line: it narrates the answer the
+viewer is already allowed to read, not the machinery. The system prompt and the raw tool traffic
+stay gated because they are the defenses.
 
 The level is decided by your app's policy for `Avo::Intelligence::Chat`. It's never stored and never switchable from the chat UI:
 
@@ -586,4 +638,4 @@ end
 
 No policy, no `#debug_level` method, an unrecognized value, or any error inside the policy all fail closed to `:off`.
 
-Viewers who get `:tools` also get a **bug** button — in the panel's title bar, and in the chat page's ⋯ menu — that hides those rows without leaving the conversation. It's a display preference, remembered per device and shared by both places. Nobody on `:off` sees the button, because none of those rows reach their browser to begin with.
+Viewers who get `:tools` also get a **bug** button — in the panel's title bar, and beside the ⋯ menu on the chat page — that hides those rows without leaving the conversation. It's a display preference, remembered per device and shared by both places. Nobody on `:off` sees the button, because none of those rows reach their browser to begin with.


### PR DESCRIPTION
Documents the behavior shipping in avo-hq/workspace#160.

- **Thinking**: set **both** knobs — each model takes exactly one (`thinking_budget` vs `thinking_effort`, a per-model split that runs across providers), and Avo sends only the knob the model declares. The same knobs are the size dial for the visible reasoning: effort models render the provider's summary, budget models the reasoning verbatim (floor 1024).
- **While the assistant is replying**: the one first-person heads-up sentence is now terse muted progress hints (*Inspecting the schema*), and a settled turn folds its worked rounds into a collapsed **Worked for N seconds** row — prompt / trail / response.
- **Debug levels**: the reasoning trace moves to the `:off` side of the line (it narrates the answer, not the machinery); the system prompt and raw tool traffic stay gated. The bug toggle now sits beside the ⋯ menu on the chat page.
- **Free-text record lookup**: the query tool grew a `search` parameter — naming a record in words ("the user called John Deere") runs the resource's own configured Avo search, falling back to a match across readable text columns, so names split over several columns are found. Covered on the what-you-can-ask page and in the tool table.
- **Installer**: the generator now appends every intelligence setting, commented out at its default, to `config/initializers/avo.rb` — noted in the install step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Updates **Avo Intelligence** docs to match behavior shipping in the product (workspace#160).
> 
> **Thinking configuration** adds a dedicated section: admins must set **both** `thinking_effort` and `thinking_budget` because each model accepts only one knob (per-model split across providers). Avo sends the knob from the model registry; the doc lists which models use which knob, provider quirks, min budget (1024), and how those settings size the visible reasoning (verbatim vs provider summary).
> 
> **While the assistant is replying** now documents muted progress hints (*Inspecting the schema*) and a collapsed **Worked for N seconds** row that folds reasoning and hints after the answer lands.
> 
> **Debug levels** are reframed so the reasoning trace and progress hints stay visible at `:off`; `:tools` adds system prompt and raw tool I/O. The debug **bug** toggle placement is described as beside the ⋯ menu on the chat page.
> 
> Smaller doc additions: the **installer** appends commented intelligence defaults to `config/initializers/avo.rb`; **`active_record_query`** and **What you can ask** explain free-text / configured search for finding records by name across columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39e03a9a7f67cafddae12984fbe3c57099a50b65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->