### PR TITLE
Document dynamic filters localization (AVO-1465)

### DIFF
--- a/docs/4.0/dynamic-filters-api.md
+++ b/docs/4.0/dynamic-filters-api.md
@@ -486,7 +486,7 @@ With the default key, a filtered URL looks like `/avo/resources/users?filters[fi
 
 Each filter type ships a set of conditions the user picks from. The tables below list each condition's key (used in URL params and as a reference for the [`conditions`](#conditions) option), its English label, and the i18n key that label resolves from.
 
-i18n keys are relative to `avo.dynamic_filters.conditions`, and resolve per filter type before falling back to `defaults` — so `number.is` overrides `defaults.is` for number filters only. See [Localization](./dynamic-filters.html#localization) for the full tree and the matching `pill_conditions` phrases.
+i18n keys are relative to `avo.dynamic_filters.conditions` — `defaults.is_null` in the tables below is `avo.dynamic_filters.conditions.defaults.is_null` in a locale file. They resolve per filter type before falling back to `defaults`, so `number.is` overrides `defaults.is` for number filters only. See [Localization](./dynamic-filters.html#localization) for the full tree and the matching `pill_conditions` phrases.
 
 :::info Null conditions appear only on nullable columns
 The `Is null` / `Is not null` conditions (and `Is present` / `Is blank` on text filters) are offered only when the underlying database column is nullable — on columns with a `NOT NULL` constraint they're omitted, since they could never match anything.
@@ -494,7 +494,7 @@ The `Is null` / `Is not null` conditions (and `Is present` / `Is blank` on text 
 
 ### Boolean
 
-| Key | Label | i18n key |
+| Key | Label | i18n key, under `avo.dynamic_filters.conditions` |
 | --- | --- | --- |
 | `is_true` | Is true | `defaults.is_true` |
 | `is_false` | Is false | `defaults.is_false` |
@@ -509,7 +509,7 @@ Test it on [avodemo](https://main.avodemo.com/avo/resources/users?filters[is_adm
 
 Covers the `:date`, `:date_time`, and `:time` types — same conditions, different picker: `:date_time` adds time selection to the calendar and `:time` shows a time-only picker (no calendar).
 
-| Key | Label | i18n key |
+| Key | Label | i18n key, under `avo.dynamic_filters.conditions` |
 | --- | --- | --- |
 | `is` | Is | `defaults.is` |
 | `is_not` | Is not | `defaults.is_not` |
@@ -525,7 +525,7 @@ Test it on [avodemo](https://main.avodemo.com/avo/resources/teams?filters[create
 
 ### Number
 
-| Key | Label | i18n key |
+| Key | Label | i18n key, under `avo.dynamic_filters.conditions` |
 | --- | --- | --- |
 | `is` | `=` (equals) | `number.is` |
 | `is_not` | `!=` (is different) | `number.is_not` |
@@ -543,7 +543,7 @@ Test it on [avodemo](https://main.avodemo.com/avo/resources/teams?filters[id][gt
 
 ### Select
 
-| Key | Label | i18n key |
+| Key | Label | i18n key, under `avo.dynamic_filters.conditions` |
 | --- | --- | --- |
 | `is` | Is | `defaults.is` |
 | `is_not` | Is not | `defaults.is_not` |
@@ -556,7 +556,7 @@ Test it on [avodemo](https://main.avodemo.com/avo/resources/courses?filters[coun
 
 ### Text
 
-| Key | Label | i18n key |
+| Key | Label | i18n key, under `avo.dynamic_filters.conditions` |
 | --- | --- | --- |
 | `contains` | Contains | `defaults.contains` |
 | `does_not_contain` | Does not contain | `defaults.does_not_contain` |
@@ -575,7 +575,7 @@ Test it on [avodemo](https://main.avodemo.com/avo/resources/users?filters[first_
 
 ### Tags
 
-| Key | Label | i18n key |
+| Key | Label | i18n key, under `avo.dynamic_filters.conditions` |
 | --- | --- | --- |
 | `array_is` | Are | `defaults.array_is` |
 | `array_contains` | Contain | `defaults.array_contains` |

--- a/docs/4.0/dynamic-filters-api.md
+++ b/docs/4.0/dynamic-filters-api.md
@@ -435,14 +435,20 @@ Set these through `Avo::DynamicFilters.configure` in `config/initializers/avo.rb
 The label on the button that expands the filters bar.
 
 ```ruby
-config.button_label = "Advanced filters"
+config.button_label = -> { I18n.t("my.filters") }
 ```
 
-- **Type:** String or Proc
-- **Default:** the translated default
+- **Type:** Proc or String
+- **Default:** `-> { I18n.t("avo.filters") }`
 - **i18n key:** `avo.filters` ("Filters")
 
 The button only renders when [`always_expanded`](#always_expanded) is `false`.
+
+:::warning A plain string is fixed for the life of the process
+The initializer runs once at boot and the configuration object lives for the whole process, so a string is pinned for every request afterwards. `config.button_label = I18n.t("my.filters")` has the same problem — it looks translated, but it is evaluated at boot like any other expression.
+
+Pass a proc and it is re-evaluated on every render, so it follows the request locale. Left unset, the default is already a proc, so a localized app usually needs nothing here.
+:::
 
 </Option>
 
@@ -478,7 +484,9 @@ With the default key, a filtered URL looks like `/avo/resources/users?filters[fi
 
 ## Filter types and their conditions
 
-Each filter type ships a set of conditions the user picks from. The tables below list each condition's key (used in URL params and as a reference for the [`conditions`](#conditions) option) and its label.
+Each filter type ships a set of conditions the user picks from. The tables below list each condition's key (used in URL params and as a reference for the [`conditions`](#conditions) option), its English label, and the i18n key that label resolves from.
+
+i18n keys are relative to `avo.dynamic_filters.conditions`, and resolve per filter type before falling back to `defaults` — so `number.is` overrides `defaults.is` for number filters only. See [Localization](./dynamic-filters.html#localization) for the full tree and the matching `pill_conditions` phrases.
 
 :::info Null conditions appear only on nullable columns
 The `Is null` / `Is not null` conditions (and `Is present` / `Is blank` on text filters) are offered only when the underlying database column is nullable — on columns with a `NOT NULL` constraint they're omitted, since they could never match anything.
@@ -486,12 +494,12 @@ The `Is null` / `Is not null` conditions (and `Is present` / `Is blank` on text 
 
 ### Boolean
 
-| Key | Label |
-| --- | --- |
-| `is_true` | Is true |
-| `is_false` | Is false |
-| `is_null` | Is null |
-| `is_not_null` | Is not null |
+| Key | Label | i18n key |
+| --- | --- | --- |
+| `is_true` | Is true | `defaults.is_true` |
+| `is_false` | Is false | `defaults.is_false` |
+| `is_null` | Is null | `defaults.is_null` |
+| `is_not_null` | Is not null | `defaults.is_not_null` |
 
 <Image src="/assets/img/4_0/dynamic-filters/boolean.webp" dark-src="/assets/img/4_0/dynamic-filters/boolean-dark.webp" width="3268" height="1082" alt="Avo Users index: the Is active dynamic filter pill and open card showing the Is true condition and Apply button, zoomed in over a short three-row table with pagination." />
 
@@ -501,15 +509,15 @@ Test it on [avodemo](https://main.avodemo.com/avo/resources/users?filters[is_adm
 
 Covers the `:date`, `:date_time`, and `:time` types — same conditions, different picker: `:date_time` adds time selection to the calendar and `:time` shows a time-only picker (no calendar).
 
-| Key | Label |
-| --- | --- |
-| `is` | Is |
-| `is_not` | Is not |
-| `lte` | Is on or before |
-| `gte` | Is on or after |
-| `is_within` | Is within |
-| `is_null` | Is null |
-| `is_not_null` | Is not null |
+| Key | Label | i18n key |
+| --- | --- | --- |
+| `is` | Is | `defaults.is` |
+| `is_not` | Is not | `defaults.is_not` |
+| `lte` | Is on or before | `date.lte` |
+| `gte` | Is on or after | `date.gte` |
+| `is_within` | Is within | `defaults.is_within` |
+| `is_null` | Is null | `defaults.is_null` |
+| `is_not_null` | Is not null | `defaults.is_not_null` |
 
 <Image src="/assets/img/4_0/dynamic-filters/date3.webp" dark-src="/assets/img/4_0/dynamic-filters/date3-dark.webp" width="3268" height="2032" alt="Avo Teams index with a short three-row table: the Created at dynamic filter with flatpickr calendar and time picker open over the table." />
 
@@ -517,17 +525,17 @@ Test it on [avodemo](https://main.avodemo.com/avo/resources/teams?filters[create
 
 ### Number
 
-| Key | Label |
-| --- | --- |
-| `is` | `=` (equals) |
-| `is_not` | `!=` (is different) |
-| `gt` | `>` (greater than) |
-| `gte` | `>=` (greater than or equal to) |
-| `lt` | `<` (lower than) |
-| `lte` | `<=` (lower than or equal to) |
-| `is_within` | Is within |
-| `is_null` | Is null |
-| `is_not_null` | Is not null |
+| Key | Label | i18n key |
+| --- | --- | --- |
+| `is` | `=` (equals) | `number.is` |
+| `is_not` | `!=` (is different) | `number.is_not` |
+| `gt` | `>` (greater than) | `number.gt` |
+| `gte` | `>=` (greater than or equal to) | `number.gte` |
+| `lt` | `<` (lower than) | `number.lt` |
+| `lte` | `<=` (lower than or equal to) | `number.lte` |
+| `is_within` | Is within | `defaults.is_within` |
+| `is_null` | Is null | `defaults.is_null` |
+| `is_not_null` | Is not null | `defaults.is_not_null` |
 
 <Image src="/assets/img/4_0/dynamic-filters/number.webp" dark-src="/assets/img/4_0/dynamic-filters/number-dark.webp" width="3268" height="1082" alt="Avo Teams index with a short three-row table: the ID dynamic filter pill and open card over the table." />
 
@@ -535,12 +543,12 @@ Test it on [avodemo](https://main.avodemo.com/avo/resources/teams?filters[id][gt
 
 ### Select
 
-| Key | Label |
-| --- | --- |
-| `is` | Is |
-| `is_not` | Is not |
-| `is_null` | Is null |
-| `is_not_null` | Is not null |
+| Key | Label | i18n key |
+| --- | --- | --- |
+| `is` | Is | `defaults.is` |
+| `is_not` | Is not | `defaults.is_not` |
+| `is_null` | Is null | `defaults.is_null` |
+| `is_not_null` | Is not null | `defaults.is_not_null` |
 
 <Image src="/assets/img/4_0/dynamic-filters/select.webp" dark-src="/assets/img/4_0/dynamic-filters/select-dark.webp" width="3268" height="1082" alt="Avo Courses index with a short three-row table: the Country dynamic filter pill and open card over the table." />
 
@@ -548,18 +556,18 @@ Test it on [avodemo](https://main.avodemo.com/avo/resources/courses?filters[coun
 
 ### Text
 
-| Key | Label |
-| --- | --- |
-| `contains` | Contains |
-| `does_not_contain` | Does not contain |
-| `is` | Is |
-| `is_not` | Is not |
-| `starts_with` | Starts with |
-| `ends_with` | Ends with |
-| `is_null` | Is null |
-| `is_not_null` | Is not null |
-| `is_present` | Is present |
-| `is_blank` | Is blank |
+| Key | Label | i18n key |
+| --- | --- | --- |
+| `contains` | Contains | `defaults.contains` |
+| `does_not_contain` | Does not contain | `defaults.does_not_contain` |
+| `is` | Is | `defaults.is` |
+| `is_not` | Is not | `defaults.is_not` |
+| `starts_with` | Starts with | `defaults.starts_with` |
+| `ends_with` | Ends with | `defaults.ends_with` |
+| `is_null` | Is null | `defaults.is_null` |
+| `is_not_null` | Is not null | `defaults.is_not_null` |
+| `is_present` | Is present | `defaults.is_present` |
+| `is_blank` | Is blank | `defaults.is_blank` |
 
 <Image src="/assets/img/4_0/dynamic-filters/text.webp" dark-src="/assets/img/4_0/dynamic-filters/text-dark.webp" width="3268" height="1082" alt="Avo Users index with a short three-row table: the First name dynamic filter pill and open card over the table." />
 
@@ -567,12 +575,12 @@ Test it on [avodemo](https://main.avodemo.com/avo/resources/users?filters[first_
 
 ### Tags
 
-| Key | Label |
-| --- | --- |
-| `array_is` | Are |
-| `array_contains` | Contain |
-| `array_overlap` | Overlap |
-| `array_contained_in` | Contained in |
+| Key | Label | i18n key |
+| --- | --- | --- |
+| `array_is` | Are | `defaults.array_is` |
+| `array_contains` | Contain | `defaults.array_contains` |
+| `array_overlap` | Overlap | `defaults.array_overlap` |
+| `array_contained_in` | Contained in | `defaults.array_contained_in` |
 
 :::warning
 `array_contained_in` requires the [`active_record_extended`](https://github.com/GeorgeKaraszi/ActiveRecordExtended) gem and is not offered on fields using the `acts-as-taggable-on` gem.

--- a/docs/4.0/dynamic-filters-api.md
+++ b/docs/4.0/dynamic-filters-api.md
@@ -529,10 +529,10 @@ Test it on [avodemo](https://main.avodemo.com/avo/resources/teams?filters[create
 | --- | --- | --- |
 | `is` | `=` (equals) | `number.is` |
 | `is_not` | `!=` (is different) | `number.is_not` |
-| `gt` | `>` (greater than) | `number.gt` |
-| `gte` | `>=` (greater than or equal to) | `number.gte` |
-| `lt` | `<` (lower than) | `number.lt` |
-| `lte` | `<=` (lower than or equal to) | `number.lte` |
+| `gt` | `>` (greater than) | `defaults.gt` |
+| `gte` | `>=` (greater than or equal to) | `defaults.gte` |
+| `lt` | `<` (lower than) | `defaults.lt` |
+| `lte` | `<=` (lower than or equal to) | `defaults.lte` |
 | `is_within` | Is within | `defaults.is_within` |
 | `is_null` | Is null | `defaults.is_null` |
 | `is_not_null` | Is not null | `defaults.is_not_null` |

--- a/docs/4.0/dynamic-filters.md
+++ b/docs/4.0/dynamic-filters.md
@@ -237,6 +237,8 @@ sv:
           contains: Contains
           does_not_contain: Does not contain
           ends_with: Ends with
+          gt: ">"
+          gte: ">="
           is: Is
           is_blank: Is blank
           is_false: Is false
@@ -246,17 +248,15 @@ sv:
           is_present: Is present
           is_true: Is true
           is_within: Is within
+          lt: "<"
+          lte: "<="
           starts_with: Starts with
         date:
           gte: Is on or after
           lte: Is on or before
         number:
-          gt: ">"
-          gte: ">="
           is: "="
           is_not: "!="
-          lt: "<"
-          lte: "<="
       pill_conditions:
         defaults:
           array_contained_in: contained in

--- a/docs/4.0/dynamic-filters.md
+++ b/docs/4.0/dynamic-filters.md
@@ -205,13 +205,110 @@ end
 
 if defined?(Avo::DynamicFilters)
   Avo::DynamicFilters.configure do |config|
-    config.button_label = "Advanced filters"
+    config.button_label = -> { I18n.t("my.filters") } # [!code focus]
     config.always_expanded = false
   end
 end
 ```
 
-See [`button_label`](./dynamic-filters-api#button_label), [`always_expanded`](./dynamic-filters-api#always_expanded), and [`param_key`](./dynamic-filters-api#param_key) in the API reference.
+Pass `button_label` a proc rather than a string. The initializer runs once at boot, so a string is pinned for every request afterwards — see [`button_label`](./dynamic-filters-api#button_label). Also [`always_expanded`](./dynamic-filters-api#always_expanded) and [`param_key`](./dynamic-filters-api#param_key) in the API reference.
+
+## Localization
+
+Every built-in string in the filters bar resolves through `I18n` on each request, under the `avo.dynamic_filters.*` namespace. The gem ships English only — add a file per locale in your app, the same way you do for Avo's own `avo.*` keys.
+
+Copy this tree, rename the root key to your locale, and translate the values:
+
+```yaml
+# config/locales/avo.dynamic_filters.sv.yml
+sv:
+  avo:
+    dynamic_filters:
+      apply: Apply
+      remove_filter: Remove filter
+      remove_tag: Remove tag
+      save_scope: Save scope
+      conditions:
+        defaults:
+          array_contained_in: Contained in
+          array_contains: Contain
+          array_is: Are
+          array_overlap: Overlap
+          contains: Contains
+          does_not_contain: Does not contain
+          ends_with: Ends with
+          is: Is
+          is_blank: Is blank
+          is_false: Is false
+          is_not: Is not
+          is_not_null: Is not null
+          is_null: Is null
+          is_present: Is present
+          is_true: Is true
+          is_within: Is within
+          starts_with: Starts with
+        date:
+          gte: Is on or after
+          lte: Is on or before
+        number:
+          gt: ">"
+          gte: ">="
+          is: "="
+          is_not: "!="
+          lt: "<"
+          lte: "<="
+      pill_conditions:
+        defaults:
+          array_contained_in: contained in
+          array_contains: contain
+          array_is: are
+          array_overlap: overlap
+          contains: contains
+          does_not_contain: does not contain
+          ends_with: ends with
+          gt: ">"
+          gte: ">="
+          is: is
+          is_blank: blank
+          is_empty: empty
+          is_false: "false"
+          is_not: is not
+          is_not_empty: not empty
+          is_not_null: not null
+          is_null: "null"
+          is_present: present
+          is_true: "true"
+          is_within: is within
+          lt: "<"
+          lte: "<="
+          starts_with: starts with
+```
+
+### How the keys resolve
+
+**Condition labels** — the entries in the condition dropdown — resolve per filter type first, then fall back to `defaults`. That is why a number filter shows `=` where a text filter shows `Is`, without you having to repeat every shared label under all six types. Override a type only where it differs.
+
+**Pill conditions** are the inline phrase inside a filter pill: the `is` in `Name is "Oradea"`. They resolve `pill_conditions.<type>` → `pill_conditions.defaults` → the dropdown label, so translating only `conditions` still gets you a localized pill — you just get the dropdown's capitalization inside the sentence. A menu item and a mid-sentence fragment often inflect differently, which is why the two are separate.
+
+:::warning Condition labels must be unique within a filter type
+The condition dropdown is built from a `label => condition_key` hash, so two conditions that translate to the same string would collapse into one and quietly disappear from the dropdown. Avo raises `Avo::DynamicFilters::DuplicateConditionLabelError` instead, naming the filter type and the duplicated label.
+
+Watch for this on nullable text fields, which offer `Is null`, `Is not null`, `Is present` and `Is blank` together — four database distinctions that are easy to collapse into two phrases.
+:::
+
+A `conditions:` hash you pass yourself is used exactly as written and never translated — you own those strings. Call `I18n.t` directly: `filters` runs on every request, so the lookups follow the request locale with no lambda needed.
+
+```ruby
+def filters
+  dynamic_filter :first_name,
+    conditions: {
+      case_sensitive: I18n.t("my.filters.case_sensitive"),
+      not_case_sensitive: I18n.t("my.filters.not_case_sensitive")
+    }.invert
+end
+```
+
+The pill for a custom condition is lowercased from your label, so write the label the way you want it to read in the dropdown.
 
 ## Caveats
 

--- a/docs/4.0/i18n.md
+++ b/docs/4.0/i18n.md
@@ -262,6 +262,16 @@ These provide a guide for you for when you want to add more languages.
 
 If you do translate Avo in a new language please consider contributing it to the [main repo](https://github.com/avo-hq/avo). Thank you
 
+## Add-on gems
+
+The locale generator covers Avo core. Add-on gems keep their own strings under their own namespace inside `avo.*`, and they ship **English only** — you supply the other locales in your app, the same way you would for any other key.
+
+| Gem | Namespace | Reference |
+| --- | --- | --- |
+| Dynamic Filters | `avo.dynamic_filters.*` | [Localization](./dynamic-filters.html#localization) |
+
+The keys deep-merge into the same `avo` tree as core's, so one `sv.yml` per gem — or a single file carrying both — works fine.
+
 ## FAQ
 
 If you try to localize your resources and fields and it doesn't seem to work, please be aware of the following.


### PR DESCRIPTION
Docs half of AVO-1465. Pairs with avo-hq/workspace#168, which makes the dynamic filters bar resolve its built-in strings through `avo.dynamic_filters.*` on every request.

Without this, the capability ships undiscoverable.

## Changes

**`4.0/i18n.md` — an add-on gems section.** This is the page someone localizing an Avo admin actually starts from, and it described only core's bundled locale files. A reader who upgraded and re-read it would still conclude the filters bar could not be localized. It now says add-on gems keep their own namespace inside `avo.*` and ship English only, with a table pointing at each gem's reference.

**`4.0/dynamic-filters.md` — a Localization section.** Carries the complete key tree as one copy-paste block. A translator transcribing ~50 keys out of table rows will mistype one, and a mistyped key falls back silently rather than raising — so the block is the thing people should actually use. Also documents how the two tiers resolve, the uniqueness rule that now raises, and that a `conditions:` hash you pass yourself is never translated.

**`4.0/dynamic-filters-api.md` — i18n keys in the condition tables.** Each of the six "Key | Label" tables gains the key its label resolves from, so the published list stays the canonical map. The `button_label` block now leads with the proc form and warns that a plain string is pinned for the life of the process — including the near-miss `config.button_label = I18n.t("...")`, which looks translated but is evaluated at boot just the same.

## Verified

The copyable YAML tree is checked key-for-key and value-for-value against the gem's shipped `config/locales/en.yml` — 52 keys, no drift. `npx vitepress build docs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
