### PR TITLE
Document the sidebar icon color option (resources + menu editor)

### DIFF
--- a/docs/4.0/menu-editor-api.md
+++ b/docs/4.0/menu-editor-api.md
@@ -87,7 +87,7 @@ link_to "Google", path: "https://google.com", target: :_blank
 | `method` | Non-GET HTTP method, submitted through Turbo. Honored in the profile and header menus. |
 | `params` | Extra query parameters appended to the path. Honored in the profile and header menus. |
 
-Also accepts the shared [`icon`](#icon), [`hotkey`](#hotkey), [`data`](#data), and [`visible`](#visible) options.
+Also accepts the shared [`icon`](#icon), [`color`](#color), [`hotkey`](#hotkey), [`data`](#data), and [`visible`](#visible) options.
 
 `active` controls when the link is highlighted as active:
 
@@ -118,7 +118,7 @@ resource :posts, params: { status: "published" }
 | `label` | Overrides the resource's navigation label. |
 | `params` | Hash of query params appended to the link, or a Proc returning one (evaluated with access to `resource`). |
 
-Also accepts the shared [`icon`](#icon), [`hotkey`](#hotkey), [`data`](#data), and [`visible`](#visible) options. When no `hotkey` is given, the resource class's own `self.hotkey` is used as a fallback. When no `icon` is given, the resource class's `self.icon` is used.
+Also accepts the shared [`icon`](#icon), [`color`](#color), [`hotkey`](#hotkey), [`data`](#data), and [`visible`](#visible) options. When no `hotkey` is given, the resource class's own `self.hotkey` is used as a fallback. When no `icon` is given, the resource class's `self.icon` is used, and when no `color` is given, the resource class's `self.color` is used.
 
 Passing a block nests sub-items under the resource — see the [sub-items guide](./menu-editor.html#sub-items). Any item type can be nested; nested items don't render icons, and a nested `action` inherits the enclosing resource.
 
@@ -144,7 +144,7 @@ dashboard :dashy
 dashboard "Sales", label: "Sales dashboard"
 ```
 
-- **Options:** `label` (overrides the dashboard's navigation label), plus the shared [`icon`](#icon), [`hotkey`](#hotkey), [`data`](#data), and [`visible`](#visible) options
+- **Options:** `label` (overrides the dashboard's navigation label), plus the shared [`icon`](#icon), [`color`](#color), [`hotkey`](#hotkey), [`data`](#data), and [`visible`](#visible) options
 - **Validation:** raises `Failed to find "..." dashboard used in the menu.` at render time when no dashboard matches the given `id` or `name`
 
 </Option>
@@ -189,7 +189,7 @@ Generates a link to one of your [kanban boards](./kanban-boards.html). Pass the 
 board 1
 ```
 
-- **Options:** the shared [`icon`](#icon), [`hotkey`](#hotkey), [`data`](#data), and [`visible`](#visible) options; the label is the board's name
+- **Options:** the shared [`icon`](#icon), [`color`](#color), [`hotkey`](#hotkey), [`data`](#data), and [`visible`](#visible) options; the label is the board's name
 - **Availability:** provided by the [`avo-kanban`](./kanban-boards.html) add-on
 
 </Option>
@@ -351,6 +351,22 @@ resource :reviews, icon: "heroicons/outline/star"
 - **Not supported on:** `group` and sub-items nested inside a `resource` block
 
 Icons come from [Tabler Icons](https://tabler.io/icons) (preferred in Avo 4) or [Heroicons](https://heroicons.com/) (`outline` and `solid` variants).
+
+</Option>
+
+<Option name="`color`" headingSize="3">
+
+Tints the item's icon with a color from Avo's palette. Only the icon stroke is colored — the label and the hover and active backgrounds stay neutral. Give related items the same color to visually group them.
+
+```ruby
+resource :reviews, icon: "heroicons/outline/star", color: :amber
+```
+
+- **Type:** Symbol or String — one of `red`, `orange`, `amber`, `yellow`, `lime`, `green`, `emerald`, `teal`, `cyan`, `sky`, `blue`, `indigo`, `violet`, `purple`, `fuchsia`, `pink`, `rose`
+- **Default:** `nil`; for `resource` items, falls back to the resource class's [`self.color`](./resources-api.html#self.color) — a menu-entry `color:` always wins over it
+- **Supported on:** `resource`, `link_to`, `dashboard`, and `board` items
+
+Colors adapt automatically to the light and dark themes. An unknown color name renders the default neutral icon.
 
 </Option>
 

--- a/docs/4.0/menu-editor.md
+++ b/docs/4.0/menu-editor.md
@@ -215,6 +215,34 @@ section "Resources", icon: "tabler/outline/building-store" do
 end
 ```
 
+## Icon colors
+
+The [`color`](./menu-editor-api.html#color) option tints an item's icon with a color from Avo's palette — only the icon stroke is colored; the label and the hover and active backgrounds stay neutral. It's supported on `resource`, `link_to`, `dashboard`, and `board` items. Give related items the same color to visually group them into "namespaces".
+
+```ruby
+# config/initializers/avo.rb
+Avo.configure do |config|
+  config.main_menu = -> {
+    section "Content", icon: "tabler/outline/files" do
+      resource :posts, color: :teal
+      resource :categories, color: :teal
+      link_to "Analytics", path: "/avo/analytics", color: :sky
+    end
+  }
+end
+```
+
+Pick from `red`, `orange`, `amber`, `yellow`, `lime`, `green`, `emerald`, `teal`, `cyan`, `sky`, `blue`, `indigo`, `violet`, `purple`, `fuchsia`, `pink`, and `rose` — as Symbols or Strings. Colors adapt automatically to the light and dark themes, and an unknown name renders the default neutral icon.
+
+For `resource` items you can also set the color on the resource class itself with [`self.color`](./resources-api.html#self.color), which acts as a fallback when no `color:` is passed to the menu item — a menu-entry `color:` always overrides it:
+
+```ruby
+# app/avo/resources/post.rb
+class Avo::Resources::Post < Avo::BaseResource
+  self.color = :teal
+end
+```
+
 ## Keyboard shortcuts on menu items
 
 Any menu item accepts a [`hotkey:`](./menu-editor-api.html#hotkey) option. When set, Avo renders a `<kbd>` badge next to the label and registers the key binding so users can jump straight to that item from anywhere in the admin panel.

--- a/docs/4.0/resources-api.md
+++ b/docs/4.0/resources-api.md
@@ -164,6 +164,8 @@ end
 
 Tints the resource's sidebar icon with a color from Avo's palette. Only the icon stroke is colored — the label and the hover and active backgrounds stay neutral. Use it to make a resource recognizable at a glance, or give related resources the same color to visually group them.
 
+The color follows the resource beyond the sidebar: the initials chip in the breadcrumbs is tinted too, and with [Advanced Search](./search.html) installed, so are the resource group headers in global search results (which also show the resource's `self.icon`).
+
 ```ruby
 class Avo::Resources::User < Avo::BaseResource
   self.icon = "tabler/outline/user"

--- a/docs/4.0/resources-api.md
+++ b/docs/4.0/resources-api.md
@@ -160,6 +160,24 @@ end
 
 </Option>
 
+<Option name="`self.color`" headingSize="3">
+
+Tints the resource's sidebar icon with a color from Avo's palette. Only the icon stroke is colored — the label and the hover and active backgrounds stay neutral. Use it to make a resource recognizable at a glance, or give related resources the same color to visually group them.
+
+```ruby
+class Avo::Resources::User < Avo::BaseResource
+  self.icon = "tabler/outline/user"
+  self.color = :purple
+end
+```
+
+- **Type:** Symbol or String — one of `red`, `orange`, `amber`, `yellow`, `lime`, `green`, `emerald`, `teal`, `cyan`, `sky`, `blue`, `indigo`, `violet`, `purple`, `fuchsia`, `pink`, `rose`
+- **Default:** `nil` — the neutral icon color
+
+Colors adapt automatically to the light and dark themes. An unknown color name renders the default neutral icon. A [`color:`](./menu-editor-api.html#color) set on the menu entry overrides this value.
+
+</Option>
+
 <Option name="`self.model_class`" headingSize="3">
 
 The model this resource references. Set it when the model is namespaced, when the class can't be inferred from the resource name, or when the resource is a [secondary resource for a model](./resources.html#use-multiple-resources-for-the-same-model).

--- a/docs/4.0/resources.md
+++ b/docs/4.0/resources.md
@@ -259,13 +259,14 @@ class Avo::Resources::User < Avo::BaseResource
 end
 ```
 
-You can also set the record's avatar with [`self.avatar`](./resources-api.html#self.avatar) and the sidebar icon with [`self.icon`](./resources-api.html#self.icon):
+You can also set the record's avatar with [`self.avatar`](./resources-api.html#self.avatar) and the sidebar icon with [`self.icon`](./resources-api.html#self.icon). To make the resource easier to spot — or to visually group related resources — tint the sidebar icon with [`self.color`](./resources-api.html#self.color):
 
 ```ruby
 # app/avo/resources/user.rb
 class Avo::Resources::User < Avo::BaseResource
   self.avatar = :avatar
   self.icon = "tabler/outline/user"
+  self.color = :purple
 end
 ```
 


### PR DESCRIPTION
Documents the new sidebar icon color option: `self.color` on resources (resources.md + resources-api.md) and `color:` on menu entries (menu-editor.md + menu-editor-api.md), including the 17-name palette, menu-wins precedence, resource-class fallback, and the neutral fallback for unknown names.

Ships with avo-hq/avo#4702 and the avo-menu change (workspace#170); hold merging until those release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Adds Avo 4.0 documentation for **sidebar icon tinting** via `self.color` on resources and `color:` on menu entries, aligned with the upcoming core/menu feature.
> 
> The **menu editor** guide and API now describe the shared `color` option on `resource`, `link_to`, `dashboard`, and `board` items, with a dedicated API section covering the 17-name palette, light/dark behavior, and neutral fallback for unknown names. **`resource` menu items** document that `color:` overrides the resource class and that `self.color` is used when the menu omits `color`.
> 
> The **resources** guide and API add **`self.color`**, including effects beyond the sidebar (breadcrumb initials chip and Advanced Search group headers) and the rule that menu-level `color:` wins over the class default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2261d021de7a2096e3a4d1c120ce0b9c9524652f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->