### PR TITLE
use_browser_timezone defaults to true

### DIFF
--- a/docs/4.0/customization-api.md
+++ b/docs/4.0/customization-api.md
@@ -57,6 +57,21 @@ config.timezone = "UTC"
 
 </Option>
 
+<Option name="`use_browser_timezone`" headingSize="3">
+
+Render server-side dates and times in each visitor's own time zone instead of the app's `Time.zone`. **On by default** — set it to `false` to render everyone in the app's configured zone.
+
+Avo detects the browser's IANA time zone with JavaScript, stores it in the `avo.browser_timezone` cookie, and wraps every Avo request in `Time.use_zone` with it. The very first page a browser ever loads still renders in the app zone — no HTTP header carries the time zone — so Avo soft-reloads that one page through Turbo and shows an alert telling the user times are now displayed in their zone. Browsers with cookies disabled keep the app zone and never reload.
+
+```ruby
+config.use_browser_timezone = false
+```
+
+- **Type:** Boolean
+- **Default:** `true`
+
+</Option>
+
 <Option name="`currency`" headingSize="3">
 
 The global currency used when displaying `currency` fields that don't set their own.

--- a/docs/4.0/customization.md
+++ b/docs/4.0/customization.md
@@ -54,6 +54,15 @@ Avo.configure do |config|
 end
 ```
 
+By default Avo follows each visitor's own time zone via [`use_browser_timezone`](./customization-api.html#use_browser_timezone): it detects the browser's time zone, stores it in a cookie, and renders all server-side dates and times in it — announcing the switch with an alert the first time. Set it to `false` to render everyone in the configured zone above.
+
+```ruby
+# config/initializers/avo.rb
+Avo.configure do |config|
+  config.use_browser_timezone = false
+end
+```
+
 ## Resource Index view
 
 There are a few customization options to change how resources are displayed in the **Index** view.

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -6,6 +6,29 @@ If you're looking for the Avo 3 to Avo 4 upgrade guide, please visit [the dedica
 
 Migrating to TailwindCSS 4? See the [TailwindCSS 4 Migration Guide](./tailwind-4-migration).
 
+## Unreleased — browser time zone on by default
+
+<Option name="`use_browser_timezone` now defaults to `true`">
+
+### Breaking Change
+
+Server-side dates and times now render in [each visitor's own time zone](./customization.html#time-and-currency) by default instead of the app's `Time.zone`. Avo detects the browser's zone via a cookie; the first page a browser loads soft-reloads once through Turbo and shows a one-time alert that times are now displayed in the visitor's zone.
+
+**Action required:** None if per-visitor times are what you want — most apps do. Displayed values only change for users whose browser zone differs from the app zone; nothing about stored data changes.
+
+### Maintaining Previous Behavior
+
+Pin every visitor to the app's configured zone:
+
+```ruby
+# config/initializers/avo.rb
+Avo.configure do |config|
+  config.use_browser_timezone = false # [!code ++]
+end
+```
+
+</Option>
+
 ## Unreleased — resizable sidebar
 
 <Option name="Sidebar labels truncate instead of wrapping">


### PR DESCRIPTION
Companion to avo-hq/avo#4703, which flips the default: Avo now renders server-side dates and times in each visitor's own time zone out of the box. Updates the customization guide and API reference to document the new default and show the opt-out (`config.use_browser_timezone = false`) instead of the opt-in.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown documentation only; no runtime or config changes in this repo.
> 
> **Overview**
> Documentation-only follow-up for the framework change that makes **`use_browser_timezone` default to `true`**. The Avo 4 docs now describe per-visitor server-side date/time rendering as the default and show **`config.use_browser_timezone = false`** as the way to keep everyone on the app zone.
> 
> The **Customization API** adds a full `use_browser_timezone` option (default `true`, cookie + `Time.use_zone`, first-visit Turbo soft-reload and alert, cookies-disabled behavior). The **Customization guide** adds a short “Timezone and currency” note with the same opt-out snippet. The **Upgrade guide** gets a new unreleased breaking-change entry explaining the display-only impact and how to restore the old behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 385f94ef0c5d92e5ffabec126b92ec4cdb8ad332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->