### PR TITLE
Document scope, card and dashboard localization (AVO-1444)

### DIFF
--- a/docs/4.0/cards-api.md
+++ b/docs/4.0/cards-api.md
@@ -53,6 +53,14 @@ self.label = "Users count"
 - **Type:** String or Proc
 - **Default:** `nil`
 
+A Proc is resolved on every render in the requesting user's locale, which is how you localize the title:
+
+```ruby
+self.label = -> { I18n.t("avo.cards.users_metric.label", default: "Users count") }
+```
+
+The String `default:` matters — without one, a locale you have not translated renders `Translation missing: …` as the title. See [Localization](./cards.html#localization).
+
 </Option>
 
 <Option name="`self.description`" headingSize="3">
@@ -66,6 +74,8 @@ self.description = "Across all teams and workspaces"
 - **Type:** String or Proc
 - **Default:** `nil`
 
+Like `self.label`, a Proc is resolved per request, so `-> { I18n.t("avo.cards.users_metric.description", default: "Across all teams and workspaces") }` follows the user's locale. See [Localization](./cards.html#localization).
+
 </Option>
 
 <Option name="`self.discreet_description`" headingSize="3">
@@ -78,6 +88,8 @@ self.discreet_description = "Counts only active, non-deleted users."
 
 - **Type:** String or Proc
 - **Default:** `nil`
+
+Like `self.label`, a Proc is resolved per request, so `-> { I18n.t("avo.cards.users_metric.discreet_description", default: "Counts only active, non-deleted users.") }` follows the user's locale. See [Localization](./cards.html#localization).
 
 </Option>
 
@@ -191,13 +203,14 @@ class Avo::Cards::UsersCount < Avo::Cards::MetricCard
 end
 ```
 
-Avo caches through `Avo.configuration.cache_store`. The key is scoped to the current user and tenant, so a card querying `current_user` never serves one user's data to another. In full, it covers:
+Avo caches through `Avo.configuration.cache_store`. The key is scoped to the current user, tenant and locale, so a card querying `current_user` never serves one user's data to another, and a card whose result depends on the language never serves one locale's text to another. In full, it covers:
 
 | Part | Why |
 | --- | --- |
 | Card class, parent, and position | Separates cards, and two registrations of the same class |
 | [`range`](#self.ranges) and the dashboard's global range | Each range is its own result |
 | Current user and tenant | Keeps per-user and per-tenant queries apart |
+| Current locale | A [localized](./cards.html#localization) card, or a `query` returning translated content, caches per language |
 | The resource's view and record | A [resource card](./cards.html) caches per record and per view |
 
 - **Type:** `ActiveSupport::Duration` (or seconds as an Integer), or a Proc returning one

--- a/docs/4.0/cards.md
+++ b/docs/4.0/cards.md
@@ -154,13 +154,86 @@ class Avo::Cards::UsersMetric < Avo::Cards::MetricCard
 end
 ```
 
-Entries are scoped to the current user and tenant, so a card querying `current_user` is safe to cache. Each [range](#ranges) is cached separately too, and on a resource card each record gets its own entry. If your `query` varies on something else, override `cache_key` as shown in the [reference](./cards-api.html#self.cache_for).
+Entries are scoped to the current user, tenant and **locale**, so a card querying `current_user` — or returning translated content — is safe to cache. Each [range](#ranges) is cached separately too, and on a resource card each record gets its own entry. If your `query` varies on something else, override `cache_key` as shown in the [reference](./cards-api.html#self.cache_for).
 
 Someone clicking the card's [refresh control](#refresh-a-card-on-demand) is asking for current data, so that click re-runs the `query` and rewrites the entry — but only their own, since the key is per user. Automatic `refresh_every` polling still respects `cache_for`, which is what makes the two worth pairing: poll often, query rarely.
 
 :::warning
 Partial and HTML cards build their content at render time instead of running a `query`, so `cache_for` does nothing for them. Wrap the markup in Rails' own `cache` block instead.
 :::
+
+## Localization
+
+A card's `label`, `description` and `discreet_description` all accept a callable, and it is resolved on **every render** in the requesting user's locale. That is all it takes to translate a card's chrome: assign a lambda that calls `I18n.t`.
+
+```ruby{3-5}
+# app/avo/cards/users_metric.rb
+class Avo::Cards::UsersMetric < Avo::Cards::MetricCard
+  self.id = "users_metric"
+  self.label = -> { I18n.t("avo.cards.users_metric.label", default: "Users count") }
+  self.description = -> { I18n.t("avo.cards.users_metric.description", default: "Across all teams") }
+  self.discreet_description = -> { I18n.t("avo.cards.users_metric.discreet_description", default: "Active users only") }
+
+  def query
+    result User.where(active: true).count
+  end
+end
+```
+
+```yaml
+# config/locales/avo.cards.sv.yml
+sv:
+  avo:
+    cards:
+      users_metric:
+        label: Antal användare
+        description: Över alla team
+        discreet_description: Endast aktiva användare
+```
+
+The key paths are spelled in full above on purpose: the lookups are `avo.cards.users_metric.label`, `avo.cards.users_metric.description` and `avo.cards.users_metric.discreet_description`.
+
+A [dashboard's](./dashboards.html#localization) `name` and `description` work the same way.
+
+:::info The namespace is yours
+Pick a key namespace your app owns. `avo.cards.*` reads well beside Avo's own keys, though note the Dashboards gem ships its own chrome strings under `avo.cards.*` too — see the table in [Localization](./i18n.html#add-on-gems). Keys nested under your card's id, as above, cannot collide with them.
+:::
+
+:::warning Always pass a String `default:`
+Under a locale your app has not translated, a lookup with no `default:` renders `Translation missing: …` as the card title, and Avo does not fall back to English for you unless you have configured `config.i18n.fallbacks`.
+:::
+
+A Symbol is **not** resolved as an i18n key. `self.label = :users_count` sets the literal label `:users_count` — use a callable.
+
+### It holds on the refresh path too
+
+A card reloading through its own Turbo frame — whether from the [refresh control](#refresh-a-card-on-demand) or `refresh_every` polling — goes through Avo's normal controller stack, which wraps every request in the reader's locale. So a refreshed card comes back translated, not in the server's default language.
+
+### The cost of a callable
+
+Because it re-resolves per request — which is exactly what makes it follow the locale — anything expensive inside `label` runs on every render. An `I18n.t` lookup is cheap. A query is not: that is what `query` is for.
+
+### Translating the gem's own chrome
+
+Separately from your card titles, the Dashboards gem renders a few strings of its own — the refresh controls, the empty state, the editor links. Those resolve under `avo.cards.*`, and the gem ships **English only**. Copy this tree, rename the root key to your locale, and translate the values:
+
+```yaml
+# config/locales/avo.cards.sv.yml
+sv:
+  avo:
+    cards:
+      open_in_editor: Open card in your editor
+      refresh: Refresh card
+      refresh_labeled: Refresh %{label}
+      dashboard:
+        learn_more: Learn more
+        open_in_editor: Open dashboard in your editor
+        refresh: Refresh all cards
+```
+
+`refresh_labeled` names the card being refreshed and is used when the card has a label; `refresh` is the fallback for a card without one. **Keep the `%{label}` placeholder** — a translation that drops it renders the sentence without the card name rather than raising.
+
+Two more strings the gem renders come from core's namespace, not its own, so they are already translated in every locale Avo ships: `avo.no_cards_present` and `avo.no_item_found` (a table or list card's empty state, overridable per card with `self.empty_message`).
 
 ## Hide the header
 

--- a/docs/4.0/cards.md
+++ b/docs/4.0/cards.md
@@ -222,12 +222,10 @@ Separately from your card titles, the Dashboards gem renders a few strings of it
 sv:
   avo:
     cards:
-      open_in_editor: Open card in your editor
       refresh: Refresh card
       refresh_labeled: Refresh %{label}
       dashboard:
         learn_more: Learn more
-        open_in_editor: Open dashboard in your editor
         refresh: Refresh all cards
 ```
 
@@ -239,7 +237,15 @@ sv:
 The dashboard refresh control reads `avo.cards.dashboard.refresh` and falls back to `avo.refresh_dashboard` before the shipped English. That older key was never defined by Avo, so an app that wanted a translated dashboard refresh button had to define it itself — those translations keep working, and there is no rush to move them.
 :::
 
-Two more strings the gem renders come from core's namespace, not its own, so they are already translated in every locale Avo ships: `avo.no_cards_present` and `avo.no_item_found` (a table or list card's empty state, overridable per card with `self.empty_message`).
+Three more strings the gem renders come from core's namespace, not its own, so they are already translated in every locale Avo ships — override them there rather than under `avo.cards`:
+
+| Key | Where it appears |
+| --- | --- |
+| `avo.open_in_your_editor` | the development-only editor link on a card and on a dashboard |
+| `avo.no_cards_present` | a dashboard with no visible cards |
+| `avo.no_item_found` | a table or list card's empty state, overridable per card with `self.empty_message` |
+
+`avo.open_in_your_editor` is deliberately entity-free — it does not name the card or dashboard it opens. That is not an oversight to work around by interpolating the noun: the tooltip is attached to the thing it opens, and a noun interpolated into a sentence goes wrong in inflected languages, as Avo's own `%{item}` keys show (Polish fixes the adjective to one gender; German has to invert the sentence).
 
 ## Hide the header
 

--- a/docs/4.0/cards.md
+++ b/docs/4.0/cards.md
@@ -231,7 +231,13 @@ sv:
         refresh: Refresh all cards
 ```
 
-`refresh_labeled` names the card being refreshed and is used when the card has a label; `refresh` is the fallback for a card without one. **Keep the `%{label}` placeholder** — a translation that drops it renders the sentence without the card name rather than raising.
+`refresh_labeled` names the card being refreshed and is used when the card has a label; `refresh` is the fallback for a card without one.
+
+**Keep the `%{label}` placeholder.** Dropping it is harmless — the sentence just renders without the card name. *Renaming* it (to `%{card}`, say) is what I18n treats as an error, and Avo catches that and falls back to `refresh` plus the label rather than letting one translation break the dashboard header.
+
+:::info Already translated `avo.refresh_dashboard`?
+The dashboard refresh control reads `avo.cards.dashboard.refresh` and falls back to `avo.refresh_dashboard` before the shipped English. That older key was never defined by Avo, so an app that wanted a translated dashboard refresh button had to define it itself — those translations keep working, and there is no rush to move them.
+:::
 
 Two more strings the gem renders come from core's namespace, not its own, so they are already translated in every locale Avo ships: `avo.no_cards_present` and `avo.no_item_found` (a table or list card's empty state, overridable per card with `self.empty_message`).
 

--- a/docs/4.0/dashboards-api.md
+++ b/docs/4.0/dashboards-api.md
@@ -51,11 +51,13 @@ The title shown to the user at the top of the dashboard.
 ```ruby
 self.name = "Dashy"
 # or
-self.name = -> { I18n.t("avo.dashboards.dashy.name") }
+self.name = -> { I18n.t("avo.dashboard_titles.dashy.name", default: "Dashy") }
 ```
 
 - **Type:** String or Proc
 - **Default:** `nil`
+
+A Proc is resolved on every render in the requesting user's locale — see [Localization](./dashboards.html#localization). Note the namespace: core defines `avo.dashboards` as a *string* (the sidebar heading), so nesting keys under it replaces that string with a Hash and breaks the heading. Use `avo.dashboard_titles.*` or any other namespace.
 
 </Option>
 
@@ -69,6 +71,8 @@ self.description = "Key metrics at a glance"
 
 - **Type:** String or Proc
 - **Default:** `nil`
+
+Like `self.name`, a Proc is resolved per request, so `-> { I18n.t("avo.dashboard_titles.dashy.description", default: "Key metrics at a glance") }` follows the user's locale. See [Localization](./dashboards.html#localization).
 
 </Option>
 

--- a/docs/4.0/dashboards.md
+++ b/docs/4.0/dashboards.md
@@ -55,10 +55,10 @@ Each dashboard is a file. It holds information about itself like the `id`, `name
 
 The [`id`](dashboards-api#self.id) field has to be unique. The [`name`](dashboards-api#self.name) is what the user sees in big letters on top of the page, and the [`description`](dashboards-api#self.description) is some text you pass to give the user more details regarding the dashboard.
 
-Both `name` and `description` accept a Proc, evaluated through [`Avo::ExecutionContext`](execution-context) with access to all its attributes plus the `dashboard` — handy for i18n:
+Both `name` and `description` accept a Proc, evaluated through [`Avo::ExecutionContext`](execution-context) with access to all its attributes plus the `dashboard` — which is how you [localize them](#localization):
 
 ```ruby
-self.name = -> { I18n.t("avo.dashboards.dashy.name") }
+self.name = -> { I18n.t("avo.dashboard_titles.dashy", default: "Dashy") }
 ```
 
 Use the [`grid_cols`](dashboards-api#self.grid_cols) parameter to organize the cards in a grid of `3`, `4`, `5`, or `6` columns. The default is `3`.
@@ -79,7 +79,55 @@ class Avo::Dashboards::Dashy < Avo::Dashboards::BaseDashboard
 end
 ```
 
-Each entry is a number of days; its button label comes from the `avo.<days>` translation key. The default is an empty array (no global range bar).
+Each entry's button label resolves the `avo.<value>` translation key, falling back to the humanized value — so `"three_days"` reads "Three days" with no translation at all. Avo ships no key for any value, so add your own under `avo.<value>` when the humanized form isn't what you want. The default is an empty array (no global range bar).
+
+## Localization
+
+A dashboard's `name` and `description` accept a callable, resolved on **every render** in the requesting user's locale. Assign a lambda that calls `I18n.t`:
+
+```ruby{4-5}
+# app/avo/dashboards/dashy.rb
+class Avo::Dashboards::Dashy < Avo::Dashboards::BaseDashboard
+  self.id = "dashy"
+  self.name = -> { I18n.t("avo.dashboard_titles.dashy.name", default: "Dashy") }
+  self.description = -> { I18n.t("avo.dashboard_titles.dashy.description", default: "Key metrics") }
+end
+```
+
+```yaml
+# config/locales/avo.dashboards.sv.yml
+sv:
+  avo:
+    dashboard_titles:
+      dashy:
+        name: Instrumentpanel
+        description: Nyckeltal
+```
+
+The key paths are spelled in full above on purpose: the lookups are `avo.dashboard_titles.dashy.name` and `avo.dashboard_titles.dashy.description`.
+
+Your dashboard's [cards](./cards.html#localization) are localized the same way.
+
+:::danger Do not nest keys under `avo.dashboards`
+Avo core defines **`avo.dashboards` as a single string** — it is the "Dashboards" heading above the dashboard list in the sidebar. Adding `avo.dashboards.dashy.name` to your locale file replaces that string with a Hash, and the sidebar heading breaks:
+
+```ruby
+I18n.t("avo.dashboards")
+# => "Dashboards"
+
+# after your locale file adds avo.dashboards.dashy.name:
+I18n.t("avo.dashboards")
+# => {dashy: {name: "Dashy"}}   ← the sidebar heading now renders a Hash
+```
+
+Use any other namespace — `avo.dashboard_titles.*` above, or one of your own outside `avo` entirely. Earlier versions of this page suggested `avo.dashboards.dashy.name`; if you followed it, move those keys.
+:::
+
+:::warning Always pass a String `default:`
+Under a locale your app has not translated, a lookup with no `default:` renders `Translation missing: …` as the dashboard title, and Avo does not fall back to English for you unless you have configured `config.i18n.fallbacks`.
+:::
+
+Because the callable re-resolves per request — which is what makes it follow the locale — keep it cheap. An `I18n.t` lookup is fine; a query is not.
 
 ## Refresh every card at once
 

--- a/docs/4.0/i18n.md
+++ b/docs/4.0/i18n.md
@@ -268,9 +268,15 @@ The locale generator covers Avo core. Add-on gems keep their own strings under t
 
 | Gem | Namespace | Reference |
 | --- | --- | --- |
+| Dashboards & Cards | `avo.cards.*` | [Cards](./cards.html#localization) · [Dashboards](./dashboards.html#localization) |
 | Dynamic Filters | `avo.dynamic_filters.*` | [Localization](./dynamic-filters.html#localization) |
+| Scopes | `avo.scopes.*` | [Localization](./scopes.html#localization) |
 
 The keys deep-merge into the same `avo` tree as core's, so one `sv.yml` per gem — or a single file carrying both — works fine.
+
+:::danger Deep-merging can overwrite a core key
+Because the merge is into core's own `avo` tree, nesting keys under a path where core already holds a **string** replaces that string with a Hash. The live example is `avo.dashboards`, which core uses for the sidebar's "Dashboards" heading — so `avo.dashboards.my_dashboard.name` breaks that heading. Add keys under a path core does not already use, and if you are naming your own keys inside `avo.*`, check the [generated locale file](#customize-the-locale) first.
+:::
 
 ## FAQ
 

--- a/docs/4.0/scopes-api.md
+++ b/docs/4.0/scopes-api.md
@@ -64,8 +64,19 @@ end
 - **Type:** String or Proc
 - **Default:** `nil`
 
+A Proc is resolved on every render in the requesting user's locale, which is how you localize the label:
+
+```ruby
+# app/avo/scopes/admins.rb
+class Avo::Scopes::Admins < Avo::Scopes::BaseScope
+  self.name = -> { I18n.t("avo.scopes.admins.name", default: "Admins") }
+end
+```
+
+The String `default:` matters — without one, a locale you have not translated renders `Translation missing: …` as the label. See [Localization](./scopes.html#localization). Translating `name` cannot change the scope's URL slug, which is derived from the scope's class path by `self.param`, not from `name`.
+
 :::tip Record counts
-To show a record count next to the scope, use the built-in [`counter`](#counter) option instead of computing it inside `name`. It supports lazy loading so it won't slow down the page.
+To show a record count next to the scope, use the built-in [`counter`](#counter) option instead of computing it inside `name`. It supports lazy loading so it won't slow down the page. A Proc here runs on every render, so keep it cheap.
 :::
 
 </Option>
@@ -83,6 +94,8 @@ end
 
 - **Type:** String or Proc
 - **Default:** `nil`
+
+Like `name`, a Proc is resolved per request, so `self.description = -> { I18n.t("avo.scopes.even_id.description", default: "Only records that have an even ID.") }` follows the user's locale. See [Localization](./scopes.html#localization).
 
 </Option>
 

--- a/docs/4.0/scopes.md
+++ b/docs/4.0/scopes.md
@@ -134,6 +134,65 @@ end
 
 See the [execution context reference](./scopes-api.html#execution-context) for what each option's proc has access to.
 
+## Localization
+
+A scope's `name` and `description` accept a callable, and it is resolved on **every render** in the requesting user's locale. That is all it takes to translate a tab bar: assign a lambda that calls `I18n.t`.
+
+```ruby{3-4}
+# app/avo/scopes/admins.rb
+class Avo::Scopes::Admins < Avo::Scopes::BaseScope
+  self.name = -> { I18n.t("avo.scopes.admins.name", default: "Admins") }
+  self.description = -> { I18n.t("avo.scopes.admins.description", default: "Admins only") }
+  self.scope = :admins
+end
+```
+
+```yaml
+# config/locales/avo.scopes.sv.yml
+sv:
+  avo:
+    scopes:
+      admins:
+        name: Administratörer
+        description: Endast administratörer
+```
+
+The key path is spelled in full above on purpose: the lookups are `avo.scopes.admins.name` and `avo.scopes.admins.description`.
+
+:::info The namespace is yours
+Pick a key namespace your app owns. `avo.scopes.*` reads well beside Avo's own keys and is safe — the Scopes gem itself only ships `avo.scopes.record_count` — but nothing requires it. Any namespace works.
+:::
+
+:::warning Always pass a String `default:`
+Under a locale your app has not translated, a lookup with no `default:` renders `Translation missing: …` as the tab label, and Avo does not fall back to English for you unless you have configured `config.i18n.fallbacks`.
+:::
+
+A Symbol is **not** resolved as an i18n key. `self.name = :admins` sets the literal label `:admins` — use a callable.
+
+### Translating a label cannot break scope selection
+
+A scope's URL slug comes from its class path through `self.param`, never from `name`. So `?scope=admins` is identical in every locale, and a bookmark made in one language keeps working in another. You can translate `name` freely.
+
+### The cost of a callable
+
+Because it re-resolves per request — which is exactly what makes it follow the locale — anything expensive inside `name` runs on every page load. An `I18n.t` lookup is cheap. A query is not: to show a record count, use the [`counter`](./scopes-api.html#counter) option rather than computing it in `name`.
+
+### Translating the gem's own chrome
+
+Separately from your tab labels, the Scopes gem renders one string of its own — the accessible name on a [count pill](#show-record-counts) — and it ships **English only**:
+
+```yaml
+# config/locales/avo.scopes.sv.yml
+sv:
+  avo:
+    scopes:
+      record_count:
+        one: "%{count} record"
+        other: "%{count} records"
+```
+
+**Keep the `%{count}` placeholder.** The `All` tab's label is core's `avo.default_scope`, which is already translated in every locale Avo ships — override it there, not under `avo.scopes`.
+
 ## Limit index columns per scope
 
 A scope normally changes which **records** appear on the index. It can also change which **columns** appear while it's active — only on the <Index /> view; the show, new, and edit views keep the resource's normal fields.


### PR DESCRIPTION
Documents that scope, card and dashboard display strings accept a callable resolved per request, and fixes a namespace bug these pages have been recommending. Linear: **AVO-1444**.

Code PR (separate repo): avo-hq/workspace#178 — the gem changes these pages describe.

## Why

A customer reported that scope and card display strings cannot follow the request locale, and built their own resolver to work around it. The mechanism already existed — `name`, `label`, `description` and `discreet_description` all resolve a callable through `Avo::ExecutionContext` on every read path — but nothing documented it, so there was no way to find out.

## What's new

`## Localization` sections on **Scopes**, **Cards** and **Dashboards**, each showing the `I18n.t` form with key paths spelled out in full. The API references now say so on each option instead of only listing "String or Proc".

Each section carries the three things that are easy to get wrong:

- the key namespace belongs to the app, and each gem's reserved leaves are listed
- a Symbol is not resolved as an i18n key
- a lookup needs a String `default:`, or an untranslated locale renders `Translation missing: …` as the title

Also documented: translating a scope's `name` cannot change its URL slug (that comes from the class path via `self.param`, so bookmarks survive), and a card localized this way stays localized across a Turbo refresh.

## Fixes a namespace bug these pages were recommending

Both dashboard pages suggested:

```ruby
self.name = -> { I18n.t("avo.dashboards.dashy.name") }
```

But core defines **`avo.dashboards` as a string** — the sidebar's "Dashboards" heading. An app following that advice deep-merges a Hash over it and the heading breaks:

```ruby
I18n.t("avo.dashboards")   # => "Dashboards"
# after the app adds avo.dashboards.dashy.name:
I18n.t("avo.dashboards")   # => {dashy: {name: "Dashy"}}
```

Verified against the dummy app. Examples now use `avo.dashboard_titles.*`, with a `:::danger` callout telling anyone who followed the old advice to move their keys, and `i18n.md` warns about the general deep-merge case.

## Three corrections to shipped-behaviour statements

- The add-on gem table gains **Scopes** and **Dashboards & Cards** rows, and each gem's own chrome tree is now published so apps can translate it.
- `global_ranges` button labels no longer require a translation per value — they fall back to the humanized value. Both pages said translations were mandatory.
- The card cache key now includes the locale.

Plus, from review of the code PR: the dashboard refresh control keeps `avo.refresh_dashboard` in its fallback chain, so apps that defined that key themselves keep their translation — worth stating rather than leaving readers to guess. And the `%{label}` guidance now distinguishes dropping the placeholder (harmless) from renaming it (raises, and is rescued).

## Verification

`npx vitepress build docs` succeeds. Every anchor added here was checked against the target page's headings; the one dead link found (`scopes-api.html#param`, an option that does not exist) was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
