### PR TITLE
Update back to top docs for the new visibility behavior

### DIFF
--- a/docs/4.0/customization-api.md
+++ b/docs/4.0/customization-api.md
@@ -396,18 +396,18 @@ config.hide_layout_when_printing = true
 
 <Option name="`back_to_top`" headingSize="3">
 
-A floating "Back to top" pill that appears centered below the navbar. It stays hidden within `threshold` pixels of the top of the page, reveals when you scroll back up, and hides again when you scroll down. Clicking it smooth-scrolls to the top.
+A floating "Back to top" pill that appears centered below the navbar. It shows once the page is scrolled `threshold` pixels down and hides again near the top of the page — the scroll direction doesn't matter. Clicking it smooth-scrolls to the top.
 
-It's off by default — opt in from your initializer:
+It's on by default. Turn it off or move the threshold from your initializer:
 
 ```ruby
 config.back_to_top = {
-  enabled: true, # show the "Back to top" pill
-  threshold: 64  # pixels scrolled down before an upward scroll reveals it
+  enabled: true,  # render the "Back to top" pill
+  threshold: 400  # pixels scrolled down before it shows up
 }
 ```
 
-Raise `threshold` if you'd rather the pill only show up further down long pages.
+Raise `threshold` if you'd rather the pill only show up further down long pages. Any key you leave out keeps its default.
 
 The button's label is translated — override it like any other Avo string:
 
@@ -419,7 +419,7 @@ en:
 ```
 
 - **Type:** Hash, merged over the defaults
-- **Default:** `{ enabled: false, threshold: 64 }`
+- **Default:** `{ enabled: true, threshold: 400 }`
 - **i18n key:** `avo.back_to_top` ("Back to top")
 
 </Option>

--- a/docs/4.0/customization.md
+++ b/docs/4.0/customization.md
@@ -299,6 +299,30 @@ Avo.configure do |config|
 end
 ```
 
+## Send the user back to the top
+
+Long index tables and record pages leave the user far from the navbar. Avo renders a "Back to top" pill centered under the navbar that scrolls the page back up when clicked.
+
+The pill shows up once the page is scrolled 400 pixels down and hides again near the top — the direction the user scrolls in doesn't change that. If you'd rather it appeared later, or not at all, configure [`back_to_top`](./customization-api.html#back_to_top).
+
+```ruby
+# config/initializers/avo.rb
+Avo.configure do |config|
+  config.back_to_top = {threshold: 1000}
+end
+```
+
+To remove it, disable it. Any key you leave out of the hash keeps its default, so this is all you need:
+
+```ruby
+# config/initializers/avo.rb
+Avo.configure do |config|
+  config.back_to_top = {enabled: false}
+end
+```
+
+The label comes from the `avo.back_to_top` translation key, so you can rename it from your locale files. Read more on the [localization page](./i18n.html).
+
 ## Home path
 
 When a user clicks your logo inside Avo or goes to the `/avo` URL, they will be redirected to one of your resources. Point them somewhere else — a dashboard, for example — with [`home_path`](./customization-api.html#home_path).

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -30,6 +30,31 @@ Hosts with an accessibility conformance obligation can disable the drag handle w
 
 </Option>
 
+## Upgrade to 4.1.4
+
+<Option name="The back to top pill is enabled by default">
+
+### Breaking Change
+
+The ["Back to top" pill](./customization.html#send-the-user-back-to-the-top) used to be off by default and only revealed itself when the user scrolled back up. It's now **on by default** and its visibility depends only on how far down the page is scrolled, not on the scroll direction. The [`threshold`](./customization-api.html#back_to_top) default moved from `64` to `400` pixels so the pill stays out of the way on short scrolls.
+
+**Action required:** None, unless you don't want the pill in your app. Every app that doesn't configure `back_to_top` gets it after this upgrade ([#4705](https://github.com/avo-hq/avo/pull/4705)).
+
+### Maintaining Previous Behavior
+
+Turn it off from the initializer. Keys you leave out fall back to the defaults, so `enabled` is enough:
+
+```ruby
+# config/initializers/avo.rb
+Avo.configure do |config|
+  config.back_to_top = {enabled: false} # [!code ++]
+end
+```
+
+The direction-aware reveal is gone for good — `threshold` is now the only thing that decides when the pill shows up.
+
+</Option>
+
 ## Upgrade to `avo-dashboards` `4.0.9`
 
 <Option name="The per-card refresh control is opt-in">


### PR DESCRIPTION
Documents [avo-hq/avo#4705](https://github.com/avo-hq/avo/pull/4705), which shipped in **avo 4.1.4** (the version bump commit sits directly on top of the merge).

## What changed in the gem

Verified against the gem source, not just the PR description:

- The pill's visibility no longer depends on scroll direction — it shows whenever `scrollTop >= threshold` and hides below it.
- `enabled` flipped from `false` to `true`.
- `threshold` moved from `64` to `400`.

## Docs changes

- **`docs/4.0/customization-api.md`** — the `back_to_top` `<Option>` still described the direction-aware reveal and `{ enabled: false, threshold: 64 }`. Rewrote the description and the `**Default:**` bullet.
- **`docs/4.0/customization.md`** — added a `## Send the user back to the top` guide section. The feature had no guide entry at all, only the API one; this covers moving the threshold, turning the pill off, and the `avo.back_to_top` i18n key, and links to the API anchor.
- **`docs/4.0/upgrade.md`** — added `## Upgrade to 4.1.4` with an `<Option>` for the flipped `enabled` default. Every app that doesn't configure `back_to_top` gets the pill after upgrading, which is exactly the "a default flips" case from `AGENTS.md`. Put here rather than in `avo-3-avo-4-upgrade.md`, which is reserved for the one-time 3 → 4 migration.

## Verification

- `vitepress build` passes.
- The rendered output carries the `#send-the-user-back-to-the-top` and `#back_to_top` anchors that the new cross-links point at.
- Skipped `yarn generate-llms-4` / `generate-docs-map.js` — their outputs aren't committed (only the `<!-- @content -->` shell is) and no pages were added or renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMd8KRRryWeEQJ82gnZ8TL

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMd8KRRryWeEQJ82gnZ8TL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or application code impact.
> 
> **Overview**
> Documentation for **avo 4.1.4** (`back_to_top` from [#4705](https://github.com/avo-hq/avo/pull/4705)): the pill is on by default, visibility follows scroll depth only (not scroll direction), and defaults are `{ enabled: true, threshold: 400 }`.
> 
> **`customization-api.md`** — The `back_to_top` option text no longer describes the old direction-aware reveal or `{ enabled: false, threshold: 64 }`; it matches the new behavior and defaults.
> 
> **`customization.md`** — New **Send the user back to the top** section with threshold tuning, disabling the pill, and the `avo.back_to_top` i18n key, linked from the API anchor.
> 
> **`upgrade.md`** — New **Upgrade to 4.1.4** entry flagging the flipped default and how to opt out with `config.back_to_top = { enabled: false }`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6606672a16a7ab82b4d97bf1b2bd114f6859fa6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->