### PR TITLE
Document `data` attributes on menu sections and groups (AVO-1681)

### DIFF
--- a/docs/4.0/menu-editor-api.md
+++ b/docs/4.0/menu-editor-api.md
@@ -45,7 +45,7 @@ section "Resources", icon: "heroicons/outline/academic-cap" do
 end
 ```
 
-- **Options:** [`icon`](#icon), [`collapsable`](#collapsable), [`collapsed`](#collapsed), [`visible`](#visible)
+- **Options:** [`icon`](#icon), [`collapsable`](#collapsable), [`collapsed`](#collapsed), [`visible`](#visible), [`data`](#data)
 - **Default `name`:** `nil` — the name may be omitted for an unlabeled section
 
 </Option>
@@ -61,7 +61,7 @@ group "Blog", collapsable: true, collapsed: true do
 end
 ```
 
-- **Options:** [`collapsable`](#collapsable), [`collapsed`](#collapsed), [`visible`](#visible)
+- **Options:** [`collapsable`](#collapsable), [`collapsed`](#collapsed), [`visible`](#visible), [`data`](#data)
 - **Not supported:** `icon`
 
 A group automatically hides itself when every item inside it is invisible (for example, when all of them fail their `visible` checks).
@@ -387,12 +387,23 @@ resource :post, hotkey: "g p"
 
 Arbitrary `data` attributes added to the item's HTML element — for example `data: { turbo: false }` to make a link perform a regular request, or `data: { turbo_method: :delete }` to send a non-GET request.
 
+On a `section` or a `group` the attributes land on the container's root element, so they're available to a Stimulus controller that needs to reach the whole branch rather than a single link.
+
 ```ruby
 resource :users, data: { turbo: false }
+
+section "Content", data: { controller: "analytics", analytics_area_value: "content" } do
+  resource :posts
+end
 ```
 
 - **Type:** Hash
 - **Default:** `{}`
+- **Supported on:** every item type, plus `section` and `group`
+
+:::warning
+On a [`collapsable`](#collapsable) `section` or `group`, Avo sets its own `controller`, `menu_target`, `menu_key_param`, and `menu_default_collapsed_state` attributes on that same root element, and your `data` hash is merged on top of them. Reusing one of those keys overwrites Avo's value and breaks collapsing — namespace your own keys, or attach the controller to a non-collapsible container.
+:::
 
 </Option>
 

--- a/docs/4.0/menu-editor.md
+++ b/docs/4.0/menu-editor.md
@@ -199,6 +199,24 @@ Avo.configure do |config|
 end
 ```
 
+`section` and `group` take the same option, and their attributes land on the container's root element. That's the hook to reach for when a [Stimulus controller](./javascript.html) needs the whole branch — every item inside it — rather than one link.
+
+```ruby{4}
+# config/initializers/avo.rb
+Avo.configure do |config|
+  config.main_menu = -> {
+    section "Content", icon: "tabler/outline/files", data: { controller: "analytics", analytics_area_value: "content" } do
+      resource :posts
+      resource :comments
+    end
+  }
+end
+```
+
+:::warning
+A [collapsable](./menu-editor-api.html#collapsable) section or group already carries Avo's own `controller`, `menu_target`, `menu_key_param`, and `menu_default_collapsed_state` attributes on that element, and yours are merged over them. Reusing one of those keys breaks collapsing, so keep your own keys namespaced.
+:::
+
 ## Icons
 
 The [`icon`](./menu-editor-api.html#icon) option is supported on `section` and on individual menu items (`link_to`, `resource`, `dashboard`, `page`, `form`, `board`, `action`). It is not supported on `group` or on sub-items nested inside a `resource` block.


### PR DESCRIPTION
Daily docs sweep over yesterday's (2026-08-10) changes in `avo-hq/avo` and `avo-hq/workspace`. Almost everything that shipped was already documented — this is the one gap I found.

## The gap

[avo-hq/avo#4701](https://github.com/avo-hq/avo/pull/4701) changed `Avo::Sidebar::BaseItemComponent#data` to merge the item's own hash into the attributes it renders:

```ruby
result.merge(item.data || {})
```

`Avo::Menu::Section` and `Avo::Menu::Group` both inherit `prop :data` from `Avo::Menu::BaseItem`, and both templates render `data: data` on their root element (`.sidebar-section` / `.sidebar-group`). So `section` and `group` now carry `data:` the way individual items always have — shipped in avo v4.1.6, undocumented.

On the API page `data` sat under **Shared options** with no note of where the attributes land, and neither container's own option list mentioned it.

## Changes

**`menu-editor-api.md`**
- `data` added to the `section` and `group` option lists.
- The `data` block says the attributes land on the container's root element, gains a `section` example, and a **Supported on** line.
- A `:::warning` for the collision this creates: a `collapsable` section or group already renders Avo's `controller`, `menu_target`, `menu_key_param`, and `menu_default_collapsed_state` on that same element, and the item's hash is merged *over* them — so reusing one of those keys silently breaks collapsing.

**`menu-editor.md`**
- The "Add `data` attributes to items" section gets the container case, framed as the hook for a Stimulus controller that needs the whole branch, with the same warning.

`npx vitepress build docs` passes.

## Checked and already covered — no change needed

| Change | Where it's documented |
| --- | --- |
| `config.use_browser_timezone` ([#4703](https://github.com/avo-hq/avo/pull/4703)) | `customization.md`, `customization-api.md`, `upgrade.md` |
| Back-to-top on by default, threshold 400 ([#4705](https://github.com/avo-hq/avo/pull/4705)) | `customization-api.md`, `upgrade.md` |
| Resource / menu-entry icon color ([#4702](https://github.com/avo-hq/avo/pull/4702), workspace#170) | #625 — `resources-api.md`, `menu-editor*.md` |
| Advanced search group headers get the resource icon + color (workspace#170) | #625 |
| Intelligence thinking knobs, progress hints, worked trail, free-text record search (workspace#160) | #623 |
| `run_action` prefill wording (workspace#179) | `intelligence.md`, `intelligence-what-you-can-ask.md` already describe the behavior |
| Dynamic filters localization (workspace#168) | #624 |

Purely cosmetic and internal work needs no docs: dimmed disabled selects ([#4704](https://github.com/avo-hq/avo/pull/4704)), refresh-icon spin direction ([#4706](https://github.com/avo-hq/avo/pull/4706)), back-to-top transition ([#4707](https://github.com/avo-hq/avo/pull/4707)), and the workspace release-notes/`ws test-ratio` tooling.

## One thing I did not act on

The attachment-scoping security fix (`GHSA-49qj-7hqj-6whp`) shipped in **avo v4.1.5** — it landed between the 4.1.4 and 4.1.5 bumps. It's a real privilege-escalation fix worth telling users to upgrade for, but this site has no security-advisory page or precedent for one, and inventing that structure is an editorial call rather than routine maintenance. Flagging it for a human to decide: a note in `upgrade.md`, or leave it to the GitHub advisory.

The fix also slightly narrows documented behavior — `delete_{FIELD_ID}?` is now only consulted when the name is a real attachment association on that record — but `authorization.md` doesn't claim otherwise, so it reads correctly as-is.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WpU5erCx2KT498r9QwnRGR)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> **Documents the `data` option on `section` and `group`**, matching behavior shipped when container `data` hashes are merged onto sidebar root elements (v4.1.6).
> 
> Updates **`menu-editor-api.md`**: lists `data` under `section` and `group` options; expands the shared **`data`** block with container-root placement, a Stimulus-style `section` example, and **Supported on** every item type plus `section`/`group`; adds a **warning** that on **collapsable** containers, custom `data` keys can overwrite Avo's `controller`, `menu_target`, `menu_key_param`, and `menu_default_collapsed_state` and break collapsing.
> 
> Updates **`menu-editor.md`**: extends **Add `data` attributes to items** with the same container use case and warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84d85435419f6043c9f527dfe55076eaad6665c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->