### PR TITLE
Document the scope, card and dashboard translation key conventions

### DIFF
--- a/docs/4.0/cards-api.md
+++ b/docs/4.0/cards-api.md
@@ -53,7 +53,7 @@ self.label = "Users count"
 - **Type:** String or Proc
 - **Default:** `nil`
 
-A Proc is resolved on every render in the requesting user's locale, which is how you localize the title:
+To localize this, prefer the `avo.card_translations.<class_path>.label` key — see [Localization](./cards.html#localization). A Proc remains the fallback and is resolved on every render in the requesting user's locale:
 
 ```ruby
 self.label = -> { I18n.t("avo.cards.users_metric.label", default: "Users count") }

--- a/docs/4.0/cards.md
+++ b/docs/4.0/cards.md
@@ -164,6 +164,40 @@ Partial and HTML cards build their content at render time instead of running a `
 
 ## Localization
 
+The shortest path is a locale key. Avo resolves `avo.card_translations.<class_path>.{label,description,discreet_description}` before falling back to the class attribute, the same way it does for [resources and actions](./i18n.html#localizing-scopes-cards-and-dashboards):
+
+```yaml
+# config/locales/avo.sv.yml
+sv:
+  avo:
+    card_translations:
+      users_metric:
+        label: Antal användare
+        description: Över alla team
+```
+
+```ruby
+# app/avo/cards/users_metric.rb
+class Avo::Cards::UsersMetric < Avo::Cards::MetricCard
+  self.id = "users_metric"
+  self.label = "Users count"    # the fallback when no translation is present
+  # Optional. Defaults to avo.card_translations.users_metric
+  # self.translation_key = "avo.card_translations.users_metric"
+end
+```
+
+The key is derived from the **class path**, not from `self.id` — two registrations of one card class share an id, and a card placed on a resource has no dashboard to scope an id against. A namespaced card uses the slash-joined path: `Avo::Cards::Sales::Monthly` resolves to `avo.card_translations.sales/monthly`.
+
+:::warning A label set at registration wins over the key
+`card Avo::Cards::UsersMetric, label: "Active users"` is more specific than a per-class translation, so it wins — otherwise a dashboard registering the same card twice would collapse both to one string. Pass a lambda if that override also needs translating.
+:::
+
+A [dashboard's](./dashboards.html#localization) own `name` and `description` work the same way, under `avo.dashboard_translations.*`.
+
+### Or assign a callable
+
+The class attribute stays available and still resolves per request, which is what you want when the title depends on something the locale file cannot know:
+
 A card's `label`, `description` and `discreet_description` all accept a callable, and it is resolved on **every render** in the requesting user's locale. That is all it takes to translate a card's chrome: assign a lambda that calls `I18n.t`.
 
 ```ruby{3-5}

--- a/docs/4.0/dashboards-api.md
+++ b/docs/4.0/dashboards-api.md
@@ -57,7 +57,7 @@ self.name = -> { I18n.t("avo.dashboard_titles.dashy.name", default: "Dashy") }
 - **Type:** String or Proc
 - **Default:** `nil`
 
-A Proc is resolved on every render in the requesting user's locale — see [Localization](./dashboards.html#localization). Note the namespace: core defines `avo.dashboards` as a *string* (the sidebar heading), so nesting keys under it replaces that string with a Hash and breaks the heading. Use `avo.dashboard_titles.*` or any other namespace.
+To localize this, prefer the `avo.dashboard_translations.<class_path>.name` key — see [Localization](./dashboards.html#localization). A Proc remains the fallback and is resolved on every render in the requesting user's locale. Note the namespace: core defines `avo.dashboards` as a *string* (the sidebar heading), so nesting keys under it replaces that string with a Hash and breaks the heading. Use `avo.dashboard_titles.*` or any other namespace.
 
 </Option>
 

--- a/docs/4.0/dashboards.md
+++ b/docs/4.0/dashboards.md
@@ -83,6 +83,34 @@ Each entry's button label resolves the `avo.<value>` translation key, falling ba
 
 ## Localization
 
+The shortest path is a locale key. Avo resolves `avo.dashboard_translations.<class_path>.{name,description}` before falling back to the class attribute, the same way it does for [resources and actions](./i18n.html#localizing-scopes-cards-and-dashboards):
+
+```yaml
+# config/locales/avo.sv.yml
+sv:
+  avo:
+    dashboard_translations:
+      dashy:
+        name: Instrumentpanel
+        description: Nyckeltal
+```
+
+```ruby
+# app/avo/dashboards/dashy.rb
+class Avo::Dashboards::Dashy < Avo::Dashboards::BaseDashboard
+  self.id = "dashy"
+  self.name = "Dashy"           # the fallback when no translation is present
+  # Optional. Defaults to avo.dashboard_translations.dashy
+  # self.translation_key = "avo.dashboard_translations.dashy"
+end
+```
+
+Note the namespace: `avo.dashboard_translations`, **not** a subtree under `avo.dashboards` — see the warning below for why that distinction matters.
+
+### Or assign a callable
+
+The class attribute stays available and still resolves per request:
+
 A dashboard's `name` and `description` accept a callable, resolved on **every render** in the requesting user's locale. Assign a lambda that calls `I18n.t`:
 
 ```ruby{4-5}

--- a/docs/4.0/i18n.md
+++ b/docs/4.0/i18n.md
@@ -77,6 +77,51 @@ Namespaced actions use the same underscored, slash-joined path as resources — 
 
 You can still set `self.name`, `self.message`, and the button labels as strings or lambdas. Those remain the fallback when no translation key is present, which is useful for dynamic labels that depend on `arguments` or `record`.
 
+## Localizing scopes, cards, and dashboards
+
+Scopes, dashboard cards, and dashboards follow the same convention, from the add-on gems that provide them.
+
+| Entity | Key | Attributes |
+| --- | --- | --- |
+| Scope | `avo.scope_translations.<class_path>` | `name`, `description` |
+| Card | `avo.card_translations.<class_path>` | `label`, `description`, `discreet_description` |
+| Dashboard | `avo.dashboard_translations.<class_path>` | `name`, `description` |
+
+```yaml
+# avo.sv.yml
+sv:
+  avo:
+    scope_translations:
+      admins:
+        name: "Administratörer"
+        description: "Endast administratörer"
+    card_translations:
+      users_metric:
+        label: "Antal användare"
+        description: "Över alla team"
+      sales/monthly:
+        label: "Månadsförsäljning"
+    dashboard_translations:
+      dashy:
+        name: "Instrumentpanel"
+```
+
+Each accepts `self.translation_key` to override the derived path, and each falls back to the class attribute — which may still be a String or a lambda — when no translation is present. Namespaced classes use the same slash-joined path as resources and actions.
+
+:::warning A card's per-registration label wins over its key
+Unlike actions, a card can be given a label where it is registered:
+
+```ruby
+card Avo::Cards::UsersMetric, label: "Active users"
+```
+
+That override is more specific than a per-class translation key, so it wins — otherwise a dashboard registering the same card class twice would collapse both to one string. Pass a lambda if such an override also needs translating.
+:::
+
+:::info Not to be confused with the gems' own chrome
+`avo.scope_translations.*` and `avo.card_translations.*` are for **your** scopes and cards. The strings the gems render themselves — the refresh controls, the count pill — live under `avo.scopes.*` and `avo.cards.*`, documented at [Scopes](./scopes.html#localization) and [Cards](./cards.html#localization). The namespaces are deliberately separate so a card named `refresh` cannot overwrite the gem's own refresh label.
+:::
+
 ## Localizing fields
 
 Similarly, you can even localize fields. When you don't set an explicit `translation_key:` option on the field declaration, Avo resolves the field label through a cascade, using the first key that has a translation:

--- a/docs/4.0/scopes-api.md
+++ b/docs/4.0/scopes-api.md
@@ -64,7 +64,7 @@ end
 - **Type:** String or Proc
 - **Default:** `nil`
 
-A Proc is resolved on every render in the requesting user's locale, which is how you localize the label:
+To localize this, prefer the `avo.scope_translations.<class_path>.name` key — see [Localization](./scopes.html#localization). A Proc remains the fallback and is resolved on every render in the requesting user's locale:
 
 ```ruby
 # app/avo/scopes/admins.rb

--- a/docs/4.0/scopes.md
+++ b/docs/4.0/scopes.md
@@ -136,6 +136,34 @@ See the [execution context reference](./scopes-api.html#execution-context) for w
 
 ## Localization
 
+The shortest path is a locale key. Avo resolves `avo.scope_translations.<class_path>.{name,description}` before falling back to the class attribute, the same way it does for [resources and actions](./i18n.html#localizing-scopes-cards-and-dashboards):
+
+```yaml
+# config/locales/avo.sv.yml
+sv:
+  avo:
+    scope_translations:
+      admins:
+        name: Administratörer
+        description: Endast administratörer
+```
+
+```ruby
+# app/avo/scopes/admins.rb
+class Avo::Scopes::Admins < Avo::Scopes::BaseScope
+  self.name = "Admins"          # the fallback when no translation is present
+  self.scope = :admins
+  # Optional. Defaults to avo.scope_translations.admins
+  # self.translation_key = "avo.scope_translations.admins"
+end
+```
+
+A namespaced scope uses the slash-joined path — `Avo::Scopes::Admin::Archived` resolves to `avo.scope_translations.admin/archived`.
+
+### Or assign a callable
+
+The class attribute stays available and still resolves per request, which is what you want when the label depends on something the locale file cannot know:
+
 A scope's `name` and `description` accept a callable, and it is resolved on **every render** in the requesting user's locale. That is all it takes to translate a tab bar: assign a lambda that calls `I18n.t`.
 
 ```ruby{3-4}


### PR DESCRIPTION
Documents the `translation_key` conventions for scopes, cards and dashboards. Linear: **AVO-1444**.

Code PR: avo-hq/workspace#182 — the gem changes these pages describe.
Follows: docs#628 (merged).

## Why

#628 documented localizing scopes and cards by assigning a callable, because that was the only mechanism at the time. workspace#182 adds the locale-key convention the ticket originally asked for — the same one resources, fields and actions already use — so the guidance now leads with the key and keeps the callable as the escape hatch.

| Entity | Key | Attributes |
| --- | --- | --- |
| Scope | `avo.scope_translations.<class_path>` | `name`, `description` |
| Card | `avo.card_translations.<class_path>` | `label`, `description`, `discreet_description` |
| Dashboard | `avo.dashboard_translations.<class_path>` | `name`, `description` |

## What changed

- **i18n.md** gains a section beside the resource and action ones, so all six entities read the same way in one place.
- **scopes.md / cards.md / dashboards.md** lead their Localization sections with the key; the callable stays, reframed as what to use when the label depends on something a locale file cannot know.
- **The three API references** point at the key first on `name` / `label` / `description`.

Two easy-to-get-wrong points are called out explicitly: a card's key comes from its **class path, not `self.id`** (two registrations of one class share an id), and a **label set at registration wins over the key**, because otherwise a dashboard registering the same card twice would collapse both to one string.

Also distinguished, since the names are close: `avo.card_translations.*` is for **your** cards, while `avo.cards.*` is the gem's own chrome (refresh controls, empty state). Separate namespaces on purpose, so a card named `refresh` cannot overwrite a gem string.

`npx vitepress build docs` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
