### PR TITLE
Document the avo.* i18n namespace shape contract (AVO-1464)

### DIFF
--- a/docs/4.0/i18n.md
+++ b/docs/4.0/i18n.md
@@ -320,7 +320,9 @@ Avo keeps eight namespaces of its own as well — `avo.appearance`, `avo.checkbo
 
 ### Pluralization hashes accept extra keys
 
-Four of the hashes Avo ships under `avo.` are pluralization hashes rather than namespaces: `avo.file`, `avo.record`, `avo.number_of_items` and `avo.x_items_more`. Adding a sibling next to `one:` and `other:` there is safe — pluralization reads only the plural keys (`zero`, `one`, `two`, `few`, `many`, `other`) and ignores everything else.
+Some of the hashes Avo ships are pluralization hashes rather than namespaces. Four sit directly under `avo.` — `avo.file`, `avo.record`, `avo.number_of_items` and `avo.x_items_more` — and others are nested, like `avo.checkbox_list.hidden_selections`. Adding a sibling next to `one:` and `other:` in any of them is safe — pluralization reads only the plural keys (`zero`, `one`, `two`, `few`, `many`, `other`) and ignores everything else.
+
+You can tell one apart by its keys, not its depth: a hash whose keys are plural categories is a pluralization hash wherever it appears.
 
 That's why `avo.resource_translations.user` carries `one:`/`other:` **and** `fields:`, `tabs:`, `panels:` and `save:` at the same time. It is a plural leaf and a subtree root at once, by design.
 

--- a/docs/4.0/i18n.md
+++ b/docs/4.0/i18n.md
@@ -119,7 +119,7 @@ That override is more specific than a per-class translation key, so it wins — 
 :::
 
 :::info Not to be confused with the gems' own chrome
-`avo.scope_translations.*` and `avo.card_translations.*` are for **your** scopes and cards. The strings the gems render themselves — the refresh controls, the count pill — live under `avo.scopes.*` and `avo.cards.*`, documented at [Scopes](./scopes.html#localization) and [Cards](./cards.html#localization). The namespaces are deliberately separate so a card named `refresh` cannot overwrite the gem's own refresh label.
+`avo.scope_translations.*` and `avo.card_translations.*` are for **your** scopes and cards. The strings the gems render themselves — the refresh controls, the count pill — live under `avo.scopes.*` and `avo.cards.*`, documented at [Scopes](./scopes.html#localization) and [Cards](./cards.html#localization). The namespaces are deliberately separate so a card named `refresh` cannot overwrite the gem's own refresh label. [What you can safely put under `avo.`](#safe-keys) covers which paths are yours to fill and which are already taken.
 :::
 
 ## Localizing fields
@@ -307,20 +307,112 @@ These provide a guide for you for when you want to add more languages.
 
 If you do translate Avo in a new language please consider contributing it to the [main repo](https://github.com/avo-hq/avo). Thank you
 
+## What you can safely put under `avo.` {#safe-keys}
+
+Avo's locale files, every add-on gem's, and your own all deep-merge into a single `avo` tree per locale — and your `config/locales` loads last. Overriding one of Avo's strings is supported; it's most of what this page is about. What silently breaks an app is changing a key's **shape**.
+
+- **Replace a string with a string.** Set `avo.save` to whatever you like and every save button follows.
+- **Never nest a key beneath a path Avo holds as a string.** A String and a Hash can't merge, so the file that loads last replaces the other one outright. There's no error and no warning — the label simply stops rendering.
+
+Plenty of Avo's strings read like namespaces. `avo.actions`, `avo.resources`, `avo.dashboards`, `avo.dashboard`, `avo.filters`, `avo.pages` and `avo.tools` are all labels Avo renders, and so are one-word keys like `avo.new`, `avo.edit`, `avo.delete`, `avo.copy`, `avo.confirm`, `avo.reset`, `avo.run`, `avo.view`, `avo.save` and `avo.close`. Treat every one of them as taken.
+
+Avo keeps eight namespaces of its own as well — `avo.appearance`, `avo.checkbox_list`, `avo.global_search`, `avo.key_value_field`, `avo.media_library`, `avo.nested`, `avo.order` and `avo.search`. They nest a level or two deeper, and the rule holds at every level: override a string, never nest beneath one.
+
+### Pluralization hashes accept extra keys
+
+Four of the hashes Avo ships under `avo.` are pluralization hashes rather than namespaces: `avo.file`, `avo.record`, `avo.number_of_items` and `avo.x_items_more`. Adding a sibling next to `one:` and `other:` there is safe — pluralization reads only the plural keys (`zero`, `one`, `two`, `few`, `many`, `other`) and ignores everything else.
+
+That's why `avo.resource_translations.user` carries `one:`/`other:` **and** `fields:`, `tabs:`, `panels:` and `save:` at the same time. It is a plural leaf and a subtree root at once, by design.
+
+The reverse needs a little care. Avo resolves resource and field names with `I18n.t(key, count: 1, default: ...)`, and a subtree holding no plural key at all raises `I18n::InvalidPluralizationData` — passing a `default:` doesn't prevent it. Avo rescues that and falls back to the humanized name, so a resource key holding only `save:` works fine (see [Localizing buttons label](#localizing-buttons-label)); you just don't get a translated resource name out of it. Keep `one:`/`other:` next to the nested keys when you want both. If your own code reads one of these keys with a `count:`, add the plural keys or rescue the exception.
+
+### Where your own keys go
+
+Six roots exist for keys you write. Avo derives these paths itself and ships nothing under them:
+
+| Root | Fills in | Comes from |
+| --- | --- | --- |
+| `avo.resource_translations.<class_path>` | [Resource](#localizing-resources) names, plus scoped `fields`, `tabs`, `panels` and `save` | Avo |
+| `avo.action_translations.<class_path>` | [Action](#localizing-actions) names, messages and button labels | Avo |
+| `avo.field_translations.<field_id>` | [Field](#localizing-fields) labels, help, placeholder and blank option | Avo |
+| `avo.scope_translations.<class_path>` | [Scope](#localizing-scopes-cards-and-dashboards) names and descriptions | `avo-scopes` |
+| `avo.card_translations.<class_path>` | [Card](#localizing-scopes-cards-and-dashboards) labels and descriptions | `avo-dashboards` |
+| `avo.dashboard_translations.<class_path>` | [Dashboard](#localizing-scopes-cards-and-dashboards) names and descriptions | `avo-dashboards` |
+
+`avo.resource_translations.<resource>` nests one level further — `.fields.<field_id>`, `.tabs.<slug>`, `.panels.<slug>` and `.save` — and it's the one place Avo expects a subtree of your own.
+
+Filters have no derived root today. Localize a filter by calling `I18n.t` from its `self.name` block with a key you choose; a namespace of your own keeps it clear of everything above.
+
+```ruby
+# app/avo/filters/name.rb
+class Avo::Filters::Name < Avo::Filters::TextFilter
+  self.name = -> { I18n.t("my_app.filters.name") }
+  self.button_label = -> { I18n.t("my_app.filters.name_button") }
+
+  def apply(request, query, value)
+    query.where("LOWER(name) LIKE ?", "%#{value}%")
+  end
+end
+```
+
+### See which keys are taken
+
+`I18n.t("avo")` returns the merged tree — Avo's keys, every gem's, and your own overrides. List the ones that are strings and you have the set you must not nest under:
+
+```bash
+bin/rails runner 'puts I18n.t("avo").select { |_, v| v.is_a?(String) }.keys.sort'
+```
+
+The [locale generator](#customize-the-locale) shows you the same thing, but it isn't the tool for a look: it copies Avo's locale files into `config/locales`, where they load last and pin today's wording into your app, so later changes to Avo's own strings never reach you. Run it when you actually want editable copies.
+
+Avo's pagination strings live in `locales/pagy/` and load through Pagy's own loader, so they sit outside the `avo.*` tree and none of this applies to them.
+
+### What a collision looks like
+
+`avo.dashboards` is the sidebar's "Dashboards" heading — a string. Nesting a dashboard's name under it takes the heading away:
+
+```yaml
+# config/locales/avo.en.yml
+en:
+  avo:
+    dashboards: # Avo holds this as a string
+      sales:
+        name: "Sales"
+```
+
+Your file loads after Avo's, `avo.dashboards` becomes a Hash, and the heading is gone — with nothing in the logs to say so. Use the derived root instead:
+
+```yaml
+# config/locales/avo.en.yml
+en:
+  avo:
+    dashboard_translations:
+      sales:
+        name: "Sales"
+```
+
+That's exactly why `avo-dashboards` derives `avo.dashboard_translations.*` rather than reusing `avo.dashboards`.
+
 ## Add-on gems
 
 The locale generator covers Avo core. Add-on gems keep their own strings under their own namespace inside `avo.*`, and they ship **English only** — you supply the other locales in your app, the same way you would for any other key.
 
 | Gem | Namespace | Reference |
 | --- | --- | --- |
+| Advanced Search | `avo.global_search.*` | |
+| Collaboration | `avo.collaboration.*` | |
 | Dashboards & Cards | `avo.cards.*` | [Cards](./cards.html#localization) · [Dashboards](./dashboards.html#localization) |
 | Dynamic Filters | `avo.dynamic_filters.*` | [Localization](./dynamic-filters.html#localization) |
+| Forms & Pages | `avo.forms.*` | |
+| Intelligence | `avo.intelligence.*` | |
 | Scopes | `avo.scopes.*` | [Localization](./scopes.html#localization) |
 
-The keys deep-merge into the same `avo` tree as core's, so one `sv.yml` per gem — or a single file carrying both — works fine.
+The keys deep-merge into the same `avo` tree as core's, so one `sv.yml` per gem — or a single file carrying all of them — works fine.
+
+Advanced Search is the one gem that ships no locale file at all. It renders under `avo.global_search.*`, which Avo core translates, plus a few keys of its own (`avo.global_search.direct_match`, `avo.global_search.search_results`, `avo.global_search.searching_on` and `avo.all`) that fall back to English until you define them in your locale file.
 
 :::danger Deep-merging can overwrite a core key
-Because the merge is into core's own `avo` tree, nesting keys under a path where core already holds a **string** replaces that string with a Hash. The live example is `avo.dashboards`, which core uses for the sidebar's "Dashboards" heading — so `avo.dashboards.my_dashboard.name` breaks that heading. Add keys under a path core does not already use, and if you are naming your own keys inside `avo.*`, check the [generated locale file](#customize-the-locale) first.
+Because the merge is into core's own `avo` tree, nesting keys under a path where core already holds a **string** replaces that string with a Hash. The live example is `avo.dashboards`, which core uses for the sidebar's "Dashboards" heading — so `avo.dashboards.my_dashboard.name` breaks that heading. Add keys under a path core does not already use — see [What you can safely put under `avo.`](#safe-keys) for the rule and the roots reserved for your own keys.
 :::
 
 ## FAQ


### PR DESCRIPTION
## Why

Avo's locale files, every add-on gem's, and the app's own all deep-merge into a single `avo` tree per locale — and the app's `config/locales` loads last. A String and a Hash cannot merge at one path, so whichever loads last replaces the other **silently**: no error, no warning, the label just stops rendering.

Nothing told an app developer which of core's 125 top-level strings are already taken, and several of them read exactly like namespace roots (`avo.actions`, `avo.dashboards`, `avo.filters`, `avo.tools`).

## The framing that matters

The contract is about **shape, not ownership**. Overriding Avo's own strings is supported and is most of what this page already teaches — an earlier draft of this change said "everything under `avo.` is Avo's", which would have told readers to stop doing the thing the page exists for.

What breaks an app is changing a key's *shape*: replace a string with a string, never nest beneath one.

## What's here

A new `## What you can safely put under `avo.`` section covering:

- the shape rule, and the strings that read like namespaces and are therefore the live hazard
- **the pluralization exception in both directions** — a sibling key beside `one:`/`other:` is safe, which is why `avo.resource_translations.<r>` is legitimately both a plural leaf and a subtree root; and a subtree with *no* plural key raises `I18n::InvalidPluralizationData` even with a `default:` (Avo rescues it into the humanized name)
- the six code-derived `*_translations` roots
- a **read-only** recipe for listing taken keys, instead of pointing at `bin/rails generate avo:locales` — that generator copies all 19 locale files into `config/locales`, pinning today's wording into the app so later core changes never arrive
- the `avo.dashboards` worked failure

Filters are recorded as having **no derived root today** rather than documenting `avo.filter_translations`, which no code derives — a previous attempt at this issue published it as a first-class root.

The `## Add-on gems` table is extended in place to every gem namespace, and the two existing callouts now point at the new section instead of restating its reasoning.

## Merge order

**This PR should merge and deploy before [avo-hq/avo](https://github.com/avo-hq/avo) PR for the same branch.** That one adds a link to the `#safe-keys` anchor created here, and avo core releases to rubygems independently — a core release ahead of this merge would ship every upgrading app a skill pointing at an anchor that doesn't resolve.

## Verification

`yarn build` — clean, no dead links. Run via the repo's own script rather than a bare `vitepress build`, so `generate-llms-txt` regenerates the `4.0/i18n.md` artifact that gem skills fetch.

Linear: [AVO-1464](https://linear.app/avo-hq/issue/AVO-1464/document-reserved-i18n-namespaces-and-avoid-leafsubtree-collisions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)