### PR TITLE
Document the `color` option on `add_breadcrumb`

### DIFF
--- a/docs/4.0/breadcrumbs.md
+++ b/docs/4.0/breadcrumbs.md
@@ -128,6 +128,22 @@ add_breadcrumb title: @resource.record_title, avatar: @resource.avatar
 
 </Option>
 
+<Option name="`color`" headingSize="3">
+
+Tints the crumb's initials chip with a color from Avo's palette. Only the chip is colored — the title, the icon, and an image `avatar` are unaffected — so it's the breadcrumb counterpart of the color you give a resource's sidebar icon.
+
+```ruby
+add_breadcrumb title: "John Doe", initials: "JD", color: :purple, path: avo.resources_user_path(@user)
+```
+
+- **Type:** Symbol or String — one of `red`, `orange`, `amber`, `yellow`, `lime`, `green`, `emerald`, `teal`, `cyan`, `sky`, `blue`, `indigo`, `violet`, `purple`, `fuchsia`, `pink`, `rose`
+- **Default:** `nil` — the neutral chip color
+- **Note:** an unknown color name renders the neutral chip, as if no color was given
+
+Colors adapt automatically to the light and dark themes. Avo passes this by hand only on custom crumbs — resource crumbs are tinted for you from the resource's [`self.color`](./resources-api.html#self.color).
+
+</Option>
+
 ## Breadcrumbs for custom pages
 
 Add breadcrumbs to a [custom page](./custom-tools.html) from its controller action:

--- a/docs/4.0/resources-api.md
+++ b/docs/4.0/resources-api.md
@@ -164,7 +164,7 @@ end
 
 Tints the resource's sidebar icon with a color from Avo's palette. Only the icon stroke is colored — the label and the hover and active backgrounds stay neutral. Use it to make a resource recognizable at a glance, or give related resources the same color to visually group them.
 
-The color follows the resource beyond the sidebar: the initials chip in the breadcrumbs is tinted too, and with [Advanced Search](./search.html) installed, so are the resource group headers in global search results (which also show the resource's `self.icon`).
+The color follows the resource beyond the sidebar: the [initials chip in the breadcrumbs](./breadcrumbs.html#color) is tinted too, and with [Advanced Search](./search.html) installed, so are the resource group headers in global search results (which also show the resource's `self.icon`).
 
 ```ruby
 class Avo::Resources::User < Avo::BaseResource


### PR DESCRIPTION
Daily docs sweep over yesterday's (2026-08-11) commits in `avo-hq/avo` and `avo-hq/workspace`. Almost everything that shipped was already covered — this is the one gap.

## What changed upstream

[avo-hq/avo#4702](https://github.com/avo-hq/avo/pull/4702) added `self.color` on resources, and along with it a `color:` keyword on the `add_breadcrumb` helper (`Avo::Concerns::Breadcrumbs::Crumb` gained a `:color` member). `Avo::BreadcrumbElementComponent` normalizes the value against `Avo::Sidebar::LinkComponent::PALETTE_COLORS` and emits `.breadcrumb-element--color-<name>`, which tints `.cado-avatar--initials` only — the title, the icon, and an image `avatar` stay untouched. An unknown or blank name normalizes to `nil` and renders no modifier at all.

`self.color` was already documented in `resources-api.md` (including the sentence that the breadcrumb chip follows the resource color), but `breadcrumbs.md` lists the `add_breadcrumb` options one by one and had no `color` entry — so the hand-passed path on custom pages was undocumented.

## Changes

- `docs/4.0/breadcrumbs.md` — new `color` `<Option>` after `avatar`: what it tints, the 17 palette names, the `nil` default, unknown-name behavior, and a note that resource crumbs get it automatically from `self.color`.
- `docs/4.0/resources-api.md` — the existing "initials chip in the breadcrumbs" mention now links to that option.

## Verified

- `npx vitepress build docs` — build complete, no errors.
- Palette list checked against `Avo::UI::BadgeComponent::VALID_COLORS - %i[neutral success info warning danger]`; the tinted-chip-only and unknown-name-is-neutral claims against `spec/components/avo/breadcrumb_element_component_spec.rb` and `css/components/breadcrumbs.css`.

## Also reviewed, no docs needed

| Change | Why |
| --- | --- |
| avo#4706 refresh icon spin direction, avo#4707 back-to-top transition | Visual polish, no documented behavior |
| workspace#170 menu `color:` + search group header tint | Already covered by #625 |
| workspace#160 intelligence visible thinking + free-text record search | Already covered by #623; the `search` argument is in the tool table and the "what you can ask" page |
| workspace#179 `run_action_tool` input handling | Prompt-only tweak; the docs already say the card is "prefilled with any values you named" |
| workspace#178/#182 scope and dashboard translation keys | Already covered by #628 and #632 |
| workspace#180 color lookup guard, dummy app fixes | Internal |

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kao1uftoRp17RhULVV55EL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, API, or security impact.
> 
> **Overview**
> Documents the previously missing **`color`** option on `add_breadcrumb`, covering palette values, defaults, and that only the initials chip is tinted.
> 
> Also links the existing `self.color` note in `resources-api.md` to that new option so resource and custom-crumb coloring stay cross-referenced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81dd29c9d3d0c76b1d9e7ffab101fb36e16a30af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->