### PR TITLE
The advanced search keys are core's now, and avo.all is taken

### DIFF
--- a/docs/4.0/i18n.md
+++ b/docs/4.0/i18n.md
@@ -314,7 +314,7 @@ Avo's locale files, every add-on gem's, and your own all deep-merge into a singl
 - **Replace a string with a string.** Set `avo.save` to whatever you like and every save button follows.
 - **Never nest a key beneath a path Avo holds as a string.** A String and a Hash can't merge, so the file that loads last replaces the other one outright. There's no error and no warning — the label simply stops rendering.
 
-Plenty of Avo's strings read like namespaces. `avo.actions`, `avo.resources`, `avo.dashboards`, `avo.dashboard`, `avo.filters`, `avo.pages` and `avo.tools` are all labels Avo renders, and so are one-word keys like `avo.new`, `avo.edit`, `avo.delete`, `avo.copy`, `avo.confirm`, `avo.reset`, `avo.run`, `avo.view`, `avo.save` and `avo.close`. Treat every one of them as taken.
+Plenty of Avo's strings read like namespaces. `avo.actions`, `avo.resources`, `avo.dashboards`, `avo.dashboard`, `avo.filters`, `avo.pages` and `avo.tools` are all labels Avo renders, and so are one-word keys like `avo.all`, `avo.new`, `avo.edit`, `avo.delete`, `avo.copy`, `avo.confirm`, `avo.reset`, `avo.run`, `avo.view`, `avo.save` and `avo.close`. Treat every one of them as taken.
 
 Avo keeps eight namespaces of its own as well — `avo.appearance`, `avo.checkbox_list`, `avo.global_search`, `avo.key_value_field`, `avo.media_library`, `avo.nested`, `avo.order` and `avo.search`. They nest a level or two deeper, and the rule holds at every level: override a string, never nest beneath one.
 
@@ -411,7 +411,9 @@ The locale generator covers Avo core. Add-on gems keep their own strings under t
 
 The keys deep-merge into the same `avo` tree as core's, so one `sv.yml` per gem — or a single file carrying all of them — works fine.
 
-Advanced Search is the one gem that ships no locale file at all. It renders under `avo.global_search.*`, which Avo core translates, plus a few keys of its own (`avo.global_search.direct_match`, `avo.global_search.search_results`, `avo.global_search.searching_on` and `avo.all`) that fall back to English until you define them in your locale file.
+Advanced Search is the one gem that ships no locale file at all, and it doesn't need one: every key it renders lives under `avo.global_search.*` or is `avo.all`, and Avo core translates all of them in each of its bundled locales.
+
+Four of those keys — `avo.global_search.direct_match`, `avo.global_search.search_results`, `avo.global_search.searching_on` and `avo.all` — reached core's locale files only after `4.1.6`. On `4.1.6` and earlier they fall back to English, so define them in your own locale file until you're on a newer Avo.
 
 :::danger Deep-merging can overwrite a core key
 Because the merge is into core's own `avo` tree, nesting keys under a path where core already holds a **string** replaces that string with a Hash. The live example is `avo.dashboards`, which core uses for the sidebar's "Dashboards" heading — so `avo.dashboards.my_dashboard.name` breaks that heading. Add keys under a path core does not already use — see [What you can safely put under `avo.`](#safe-keys) for the rule and the roots reserved for your own keys.


### PR DESCRIPTION
Yesterday's daily docs sweep over `avo-hq/avo` and `avo-hq/workspace`. One page drifted, in a way only visible by reading the two repos side by side.

## What changed upstream

[avo#4715](https://github.com/avo-hq/avo/pull/4715) defined `avo.global_search.direct_match`, `avo.global_search.search_results`, `avo.global_search.searching_on` and `avo.all` in **all 19** of core's locale files. `avo-advanced_search` renders those four with `I18n.t(..., default:)` and ships no locale file of its own, so until that PR they were correct English and untranslatable everywhere else.

It merged at **15:59:03**. #634 — which published the sentence saying those keys "fall back to English until you define them in your locale file" — merged at **15:58:41**, twenty-two seconds earlier. The sentence was true when it was written and false by the time it deployed.

## What this PR does

Both edits are in `docs/4.0/i18n.md`.

**The Add-on gems section** no longer tells readers to define those four keys themselves. Advanced Search now needs no locale file at all — every key it renders is one core translates. The version caveat is what survives: on `4.1.6` and earlier the fallback is still English, and core's next release is the first to carry them. (`4.1.6` is the latest tag; the keys are unreleased as of this PR, so no version number is asserted for the release that ships them.)

**The safe-keys list** gains `avo.all`. Core holds it as a string directly under `avo.`, alongside `avo.new`, `avo.save` and the rest, so nesting beneath it destroys the string exactly the way `avo.dashboards` does — the collision that whole section exists to prevent. A list of taken keys is only as good as its newest entry.

## Verification

- Every key confirmed present in all 19 locale files at `avo@4dbae8a` (`de` → `Direkter Treffer`, `fr` → `Tout`, `ja` → `検索結果`).
- `avo.all` confirmed as a string directly under `avo.` via `YAML.load_file(...)["en"]["avo"].select { |_, v| v.is_a?(String) }`.
- The four render sites confirmed in `gems/avo-advanced_search`, all still passing `default:`; the gem ships no locale file.
- `yarn generate-llms-4` and `node scripts/generate-docs-map.js 4.0` re-run — output unchanged, since neither page titles nor the sidebar moved.

No upgrade note: this is a pure addition upstream, and nothing an app already does stops working.

## Also reviewed, no docs change needed

- **[avo#4711](https://github.com/avo-hq/avo/pull/4711)** — teaches the shipped `avo-i18n` skill the namespace shape contract and adds `spec/lib/avo/locales_shape_spec.rb`. The skill's three new links to `i18n.md#safe-keys` all resolve against the current page.
- **[workspace#184](https://github.com/avo-hq/workspace/pull/184)** — internal conventions and a plan doc, no customer-facing surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBMe1sv5uf3nvSpgWPs1mQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to i18n guidance; no application code or locale files change.
> 
> **Overview**
> Updates **`docs/4.0/i18n.md`** so localization guidance matches Avo core after those Advanced Search strings moved into core’s bundled locales.
> 
> In **What you can safely put under `avo.`**, **`avo.all`** is added to the list of reserved one-word string keys (alongside `avo.new`, `avo.save`, etc.) so readers don’t nest custom keys under it and break merging.
> 
> In **Add-on gems**, the Advanced Search paragraph no longer tells apps to define `avo.global_search.direct_match`, `avo.global_search.search_results`, `avo.global_search.searching_on`, and **`avo.all`** themselves when using current core. It now states that the gem needs no locale file because core translates those keys in all bundled languages. A **version note** remains: on **4.1.6 and earlier**, those four keys still fall back to English until you override them locally or upgrade past that release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b222e7aa447b1a8284e24e97af6ae87c97fe3a88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->