### PR TITLE
docs: `visible` controls Media Library access (GHSA-cff8-4h3c-9r4q)

### DIFF
--- a/docs/3.0/media-library.md
+++ b/docs/3.0/media-library.md
@@ -41,9 +41,11 @@ end
 This is the killswitch of the whole feature.
 When disabled, the Media Library will not be available to anyone. It will hide the menu item, block the all the routes, and hide media the library icons from the editors.
 
-## Hide menu item
+## Control who can use it
 
-You can hide the menu item from the sidebar by setting the `visible` option to `false`.
+`visible` decides who may use the Media Library. It gates the sidebar item, the Media Library button in the rich text editors, and the Media Library routes themselves — a user it returns `false` for gets a 404 on every one of them.
+
+Turn it off for everyone with a Boolean:
 
 ```ruby
 # config/initializers/avo.rb
@@ -54,7 +56,7 @@ if defined?(Avo::MediaLibrary)
 end
 ```
 
-You may also use a [block](./execution-context) to conditionally show the menu item. You'll have access to the `Avo::Current` object and you can use it to show the menu item based on the current user.
+Or restrict it per user with a [block](./execution-context), which has access to the `Avo::Current` object:
 
 ```ruby
 # config/initializers/avo.rb
@@ -65,7 +67,13 @@ if defined?(Avo::MediaLibrary)
 end
 ```
 
-This will hide the menu item from the sidebar if the current user is not a developer.
+Anyone who isn't a developer then has no Media Library at all — no menu item, no button in the editors, and a 404 on every Media Library URL.
+
+`visible` defaults to `true`, so an enabled Media Library is available to everyone who can sign in to Avo. Leave it there only if every Avo user may browse, rename and delete every uploaded asset.
+
+:::warning
+Before Avo 3.32.4, `visible` hid the menu item but left the routes reachable by URL, so any authenticated Avo user could browse, rename and delete every asset. See [GHSA-cff8-4h3c-9r4q](https://github.com/avo-hq/avo/security/advisories/GHSA-cff8-4h3c-9r4q).
+:::
 
 ## Add it to the menu editor
 
@@ -94,3 +102,5 @@ field :body, as: :markdown
 
 The editors will each have a button to open the Media Library modal.
 Once open, after the user selects the asset, it will be injected into the editor.
+
+The button follows `visible` too, so a user the Media Library is not visible to won't see it.

--- a/docs/3.0/upgrade.md
+++ b/docs/3.0/upgrade.md
@@ -4,6 +4,34 @@ We'll update this page when we release new Avo 3 versions.
 
 If you're looking for the Avo 2 to Avo 3 upgrade guide, please visit [the dedicated page](./avo-2-avo-3-upgrade).
 
+## Upgrade to 3.32.4
+
+<Option name="`config.visible` now controls Media Library access, not just the menu item">
+
+### Breaking Change
+
+`Avo::MediaLibrary.configuration.visible` used to hide the sidebar item and the rich text editor button while leaving every Media Library route reachable by URL. It is now enforced on the routes as well: a user the block returns `false` for gets a 404 from `/media-library` and `/attach-media`.
+
+This closes [GHSA-cff8-4h3c-9r4q](https://github.com/avo-hq/avo/security/advisories/GHSA-cff8-4h3c-9r4q), where any authenticated Avo user could browse, rename and permanently delete every Active Storage blob in the application.
+
+### Action Required
+
+**If you set `config.visible`**, check that it returns `true` for everyone who is meant to use the Media Library, including through the rich text editors. Anyone it rejects now loses access entirely rather than only losing the menu item.
+
+**If you don't set it**, nothing changes on upgrade — `visible` defaults to `true`. That also means the Media Library stays available to every user who can sign in to Avo, so set it if that isn't what you want:
+
+```ruby
+# config/initializers/avo.rb
+if defined?(Avo::MediaLibrary)
+  Avo::MediaLibrary.configure do |config|
+    config.visible = -> { Avo::Current.user.is_developer? }
+  end
+end
+```
+
+</Option>
+
+
 ## Upgrade to 3.22.0
 
 <Option name="External image field options now apply to all views">

--- a/docs/4.0/media-library.md
+++ b/docs/4.0/media-library.md
@@ -42,9 +42,11 @@ end
 This is the killswitch of the whole feature.
 When disabled, the Media Library will not be available to anyone. It will hide the menu item, block all the routes, and hide the Media Library icons from the editors.
 
-## Hide menu item
+## Control who can use it
 
-You can hide the menu item from the sidebar by setting the `visible` option to `false`.
+`visible` decides who may use the Media Library. It gates the sidebar item, the Media Library button in the rich text editors, and the Media Library routes themselves — a user it returns `false` for gets a 404 on every one of them.
+
+Turn it off for everyone with a Boolean:
 
 ```ruby
 # config/initializers/avo.rb
@@ -55,7 +57,7 @@ if defined?(Avo::MediaLibrary)
 end
 ```
 
-You may also use a [block](./execution-context) to conditionally show the menu item. You'll have access to the `Avo::Current` object and you can use it to show the menu item based on the current user.
+Or restrict it per user with a [block](./execution-context), which has access to the `Avo::Current` object:
 
 ```ruby
 # config/initializers/avo.rb
@@ -66,7 +68,13 @@ if defined?(Avo::MediaLibrary)
 end
 ```
 
-This will hide the menu item from the sidebar if the current user is not a developer.
+Anyone who isn't a developer then has no Media Library at all — no menu item, no button in the editors, and a 404 on every Media Library URL.
+
+`visible` defaults to `true`, so an enabled Media Library is available to everyone who can sign in to Avo. Leave it there only if every Avo user may browse, rename and delete every uploaded asset.
+
+:::warning
+Before Avo 4.1.7, `visible` hid the menu item but left the routes reachable by URL, so any authenticated Avo user could browse, rename and delete every asset. See [GHSA-cff8-4h3c-9r4q](https://github.com/avo-hq/avo/security/advisories/GHSA-cff8-4h3c-9r4q).
+:::
 
 ## Add it to the menu editor
 
@@ -96,6 +104,8 @@ field :body, as: :lexxy
 
 The editors will each have a button to open the Media Library modal.
 Once open, after the user selects the asset, it will be injected into the editor.
+
+The button follows `visible` too, so a user the Media Library is not visible to won't see it.
 
 ### Disable it on a single markdown field
 

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -4,6 +4,34 @@ We'll update this page when we release new Avo 4 versions.
 
 If you're looking for the Avo 3 to Avo 4 upgrade guide, please visit [the dedicated page](./avo-3-avo-4-upgrade).
 
+## Upgrade to 4.1.7
+
+<Option name="`config.visible` now controls Media Library access, not just the menu item">
+
+### Breaking Change
+
+`Avo::MediaLibrary.configuration.visible` used to hide the sidebar item and the rich text editor button while leaving every Media Library route reachable by URL. It is now enforced on the routes as well: a user the block returns `false` for gets a 404 from `/media-library` and `/attach-media`.
+
+This closes [GHSA-cff8-4h3c-9r4q](https://github.com/avo-hq/avo/security/advisories/GHSA-cff8-4h3c-9r4q), where any authenticated Avo user could browse, rename and permanently delete every Active Storage blob in the application.
+
+### Action Required
+
+**If you set `config.visible`**, check that it returns `true` for everyone who is meant to use the Media Library, including through the rich text editors. Anyone it rejects now loses access entirely rather than only losing the menu item.
+
+**If you don't set it**, nothing changes on upgrade — `visible` defaults to `true`. That also means the Media Library stays available to every user who can sign in to Avo, so set it if that isn't what you want:
+
+```ruby
+# config/initializers/avo.rb
+if defined?(Avo::MediaLibrary)
+  Avo::MediaLibrary.configure do |config|
+    config.visible = -> { Avo::Current.user.is_developer? }
+  end
+end
+```
+
+</Option>
+
+
 Migrating to TailwindCSS 4? See the [TailwindCSS 4 Migration Guide](./tailwind-4-migration).
 
 ## Unreleased — browser time zone on by default


### PR DESCRIPTION
Documents the Media Library access-control change that shipped in **avo 4.1.7** and **3.32.4** for [GHSA-cff8-4h3c-9r4q](https://github.com/avo-hq/avo/security/advisories/GHSA-cff8-4h3c-9r4q).

## What changed in the gem

`Avo::MediaLibrary.configuration.visible` hid the sidebar item and the rich text editor button, but the Media Library routes stayed reachable by URL. Any authenticated Avo user could browse, rename and permanently delete every Active Storage blob in the application. `visible` is now enforced in `authorize_access!`, so it gates the routes too.

## What changed here

**`docs/4.0/media-library.md` and `docs/3.0/media-library.md`** — the `## Hide menu item` section becomes `## Control who can use it`. The old heading and its prose described `visible` as a menu toggle, which is exactly the misreading that led six researchers to report this: the option reads like access control, and for the routes it was not. The section now states that `visible` gates the sidebar item, the editor button, and the routes, notes that it defaults to `true` (so an enabled Media Library is open to every Avo user unless you say otherwise), and carries a `:::warning` pointing at the advisory for the pre-fix behaviour.

The rich-text-editors section gains one line noting the button follows `visible` as well.

**`docs/4.0/upgrade.md` and `docs/3.0/upgrade.md`** — an entry per line, in the existing `<Option>` format, split into Breaking Change / Action Required. The action required differs depending on whether the reader sets `visible` at all:

- sets it → check the block returns `true` for everyone meant to use the Media Library, including via the editors, since a rejection is now total rather than cosmetic
- doesn't set it → nothing changes on upgrade, but the Media Library is open to every Avo user, so set it if that isn't intended

The 4.0 upgrade guide had no version entries yet; this is its first.

## Conventions

Followed `AGENTS.md`: guide-only (two simple options, so no `-api.md`), task-phrased heading rather than a machinery-phrased one, plain English with conditional imperatives, `# config/initializers/avo.rb` on every snippet that maps to a real file, and `:::warning` for the sharp edge. Upgrade entries match the existing `## Upgrade to X` + `<Option>` shape and are placed newest-first.

`npx vitepress build docs` passes.
