### PR TITLE
Document use_browser_timezone defaulting off in the test environment

### DIFF
--- a/docs/4.0/customization-api.md
+++ b/docs/4.0/customization-api.md
@@ -67,8 +67,12 @@ Avo detects the browser's IANA time zone with JavaScript, stores it in the `avo.
 config.use_browser_timezone = false
 ```
 
+:::info Off in the test environment
+The option defaults to `false` when `Rails.env.test?`, because the first-load soft reload races browser tests — assertions run against a page that is about to be replaced. Enable it explicitly in a test if you are testing the time zone behavior itself.
+:::
+
 - **Type:** Boolean
-- **Default:** `true`
+- **Default:** `true` (`false` in the test environment)
 
 </Option>
 

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -44,6 +44,8 @@ Server-side dates and times now render in [each visitor's own time zone](./custo
 
 **Action required:** None if per-visitor times are what you want — most apps do. Displayed values only change for users whose browser zone differs from the app zone; nothing about stored data changes.
 
+The option defaults to `false` in the test environment, so browser/system tests are unaffected — the first-load soft reload would otherwise race them.
+
 ### Maintaining Previous Behavior
 
 Pin every visitor to the app's configured zone:


### PR DESCRIPTION
Companion to avo-hq/avo's change making `config.use_browser_timezone` default to `false` under `Rails.env.test?` — the first-load cookie handshake soft-reloads the page through Turbo, which races browser/system specs.

- `customization-api.md`: info callout on the test-env default, default annotated as `true` (`false` in the test environment)
- `upgrade.md`: note in the "browser time zone on by default" entry that test suites are unaffected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration behavior in this repo.
> 
> **Overview**
> Documents that **`config.use_browser_timezone`** defaults to **`false` when `Rails.env.test?`**, matching the framework change that avoids the first-load Turbo soft reload racing browser/system specs.
> 
> **`customization-api.md`** adds an info callout explaining the test default and why (soft reload vs assertions), and updates the documented default to **`true` (`false` in the test environment)`**.
> 
> **`upgrade.md`** adds a sentence under the unreleased “browser time zone on by default” entry clarifying that test suites stay on the app zone without extra configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8358ffd86e8c004204592ce3f0fb80c43cb5e9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->