### PR TITLE
Narrow the config namespace collision rule to Avo's own options

### DIFF
--- a/docs/4.0/plugins.md
+++ b/docs/4.0/plugins.md
@@ -238,7 +238,9 @@ Avo.configuration.feed_view.items_per_page # => 50
 Register the configuration from an engine initializer ordered `before: :load_config_initializers` (or at require time) — **not** from the `avo_boot` hook. The app's `config/initializers/avo.rb` reads the accessor while initializers run, which is before Avo boots, so registering any later blows up in the app's own initializer.
 :::
 
-Namespaces are exclusive. `register_configuration` raises an `ArgumentError` if the name collides with a method `Avo::Configuration` already defines, or with a namespace another plugin took first. Re-registering the same name with the same class is fine, so a boot that happens more than once is harmless.
+Namespaces are exclusive. `register_configuration` raises an `ArgumentError` if the name collides with a method `Avo::Configuration` defines itself, or with a namespace another plugin took first. Re-registering the same name with the same class is fine, so a boot that happens more than once is harmless.
+
+Only Avo's own options count as collisions. Gems that mix helpers into every object don't reserve a namespace: `amazing_print` defines `Kernel#ai`, so `Avo::Configuration` responds to `ai` in any app that bundles it, but the name is still yours to take — shadowing a global helper on the configuration object is harmless. <VersionReq version="4.1.9" />
 
 Instances are memoized per configuration object, which means replacing `Avo.configuration` resets your plugin's config along with everything else — useful when you need a clean slate in tests.
 


### PR DESCRIPTION
Follows [avo#4721](https://github.com/avo-hq/avo/pull/4721) (shipped in `4.1.9`), which narrowed `register_configuration`'s collision check.

## What drifted

`docs/4.0/plugins.md` told plugin authors the namespace raises if it "collides with a method `Avo::Configuration` **already defines**". Core now only counts methods `Avo::Configuration` *owns*:

```ruby
if existing.nil? && Avo::Configuration.method_defined?(name) &&
    Avo::Configuration.instance_method(name).owner == Avo::Configuration
```

The practical difference is real, not academic: `amazing_print` defines `Kernel#ai`, so every object in an app that bundles it responds to `ai` — including `Avo::Configuration`. Under the old rule that made `:ai` unavailable, which is the namespace `avo-ai` actually registers. The docs as written would have told an author to pick a different name.

## Change

Kept the exclusivity paragraph (corrected to "defines itself") and added one paragraph covering the globally-mixed-in case, with a `<VersionReq version="4.1.9" />` badge.

Verified against the gem source (`lib/avo/plugin_manager.rb`) and the spec added in that PR, not the PR description.

## Notes

- No `upgrade.md` entry: the fix removes a boot-time raise and asks nothing of the reader.
- The generated LLM files (`docs/public/*/llms.txt`, `docs-map.md`) are gitignored here and built by `yarn build`, so there's nothing to commit for them. `generate-docs-map.js` runs clean against this change; `generate-llms-txt.js` needs `node_modules`, which this environment doesn't have.
- `yarn dev` was not run — no `node_modules` in this environment. The only new markup is `<VersionReq>`, which is globally registered in `docs/.vitepress/theme/index.js:78`.

### Also reviewed from 2026-08-13, no docs change needed

| Change | Why |
| ------ | --- |
| [avo#4720](https://github.com/avo-hq/avo/pull/4720) `use_browser_timezone` off in test env | Already documented in `customization-api.md` via #639 |
| [avo#4710](https://github.com/avo-hq/avo/pull/4710) shortcuts modal `avo-ai` rename | Covered by the docs rename in #630 |
| [avo#4719](https://github.com/avo-hq/avo/pull/4719) `Avo::AI` spelling | Source-comment only; docs examples use `Avo::FeedView` |
| [avo#4659](https://github.com/avo-hq/avo/pull/4659) getting-started welcome screen redesign | Dev-only `/avo` home page; no docs page describes it |
| [avo#4718](https://github.com/avo-hq/avo/pull/4718) `bin/dev` port fallback | Contributor tooling |
| workspace #181 / #185 / #184 | Rename already reflected in docs; the rest are agent rules and an i18n convention documented in #634 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRtnVaFyBAWYnYnTtRZekA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> Updates **`docs/4.0/plugins.md`** so plugin authors see the same namespace rules as Avo **4.1.9** (`register_configuration` only treats names as taken when they collide with methods **`Avo::Configuration` defines itself**, not every method the object responds to).
> 
> The exclusivity sentence is tightened (“defines itself”), and a new paragraph explains that globally mixed-in helpers (e.g. `Kernel#ai` from `amazing_print`) do **not** block a plugin namespace, with a `<VersionReq version="4.1.9" />` badge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b399d5aeec68a04951e2d0bdebb267a4e15736c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->