### PR TITLE
Fix REST API docs conflating two authorization failures

### DIFF
--- a/docs/4.0/rest-api.md
+++ b/docs/4.0/rest-api.md
@@ -244,14 +244,19 @@ end
 
 With that policy, an admin's `GET /api/resources/v1/comments` returns every comment; a regular user's returns only their own.
 
-Policy scoping requires all of the following. If any is missing, the query is **not** scoped and every record is returned:
+Policy scoping requires all three of the following. If any is missing, the query is handed back untouched — it is **not** scoped, every record is returned, and nothing raises:
 
 | Requirement | Where |
 | --- | --- |
 | The `avo-authorization` add-on installed | `Gemfile` |
 | The `avo-authorization` feature enabled on your license | Your Avo plan |
 | An authorization client configured | `config.authorization_client = :pundit` |
-| A user resolved by `config.current_user_method` | See [Set the current user](#set-the-current-user) |
+
+:::info A `nil` user fails differently
+Those three are configuration — miss one and the query is silently unscoped. A missing **user** is the opposite failure: with Pundit configured, scoping still runs, so `nil` reaches your `Scope#resolve` and the usual `user.admin?` raises `NoMethodError`. You get a 500, not a leak — the same trap described under [Authentication examples](#authentication-examples).
+
+Both have one cure: make sure [`config.current_user_method`](#set-the-current-user) resolves to a real user on every API request.
+:::
 
 :::warning A denied action redirects instead of rendering JSON
 Policy *methods* (`index?`, `update?`, …) returning `false` raise `Avo::NotAuthorizedError`, which Avo handles by setting a flash message and issuing a **302 redirect** — behavior meant for the HTML admin panel. An API client sees a redirect to your root URL, not a JSON error.


### PR DESCRIPTION
## The error

The Authorization section on `docs/4.0/rest-api.md` listed four requirements for policy scoping under one blanket claim: *"If any is missing, the query is **not** scoped and every record is returned."*

True for the three configuration rows. False for the fourth — a `nil` user. Two different failures were being described as one.

## What the code actually does

**Add-on absent / feature unlicensed / nil client → silent leak.** `apply_policy` returns the query untouched:

- `external/avo/lib/avo/services/authorization_service.rb:13` — core's stub `apply_policy(user, query)` returns `query`.
- `gems/avo-authorization/lib/avo/authorization/authorization_service.rb:96-108` — returns `model` when `skip_authorization`, which is `!Avo::Current.license.enabled_feature?("avo-authorization")`.
- `gems/avo-authorization/lib/avo/authorization/clients/nil_client.rb:17` — returns `model`.

**A `nil` user with Pundit configured → a 500.** `apply_policy` does not skip; the `nil` is passed straight through to the app's own scope, where the usual `user.admin?` raises `NoMethodError`:

- `gems/avo-authorization/lib/avo/authorization/clients/pundit_client.rb:23-33`

One refinement on the original description of that last file: it prefers `policy_class::Scope.new(user, model).resolve` when a policy class is known — which is the common case on the resource path, since `AuthorizationService#initialize` derives one — and only falls back to `Pundit.policy_scope!(user, model)` when none is. Both branches hand the `nil` user to the app's `Scope#resolve`, so the outcome is the same; the wording avoids naming a single entry point. Nothing else contradicted the reported behavior. Neither branch is wrapped in a rescue that would soften it: `apply_policy` rescues only `Avo::NoPolicyError`, and `avo-api`'s `ResourcesController` has no `rescue_from` covering `NoMethodError`.

Strictly, the 500 depends on the app's scope touching `user` — a scope like `scope.where(published: true)` would resolve fine with `nil`. The new text says "the usual `user.admin?`", matching the phrasing the page already uses for this trap under Authentication examples.

## The fix

The table keeps the three configuration prerequisites and their "every record is returned" consequence. The `nil` user moves into its own `:::info` callout stating plainly that it is the opposite failure, and cross-referencing the existing warning rather than repeating it.

```markdown
Policy scoping requires all three of the following. If any is missing, the query is handed back untouched — it is **not** scoped, every record is returned, and nothing raises:

| Requirement | Where |
| --- | --- |
| The `avo-authorization` add-on installed | `Gemfile` |
| The `avo-authorization` feature enabled on your license | Your Avo plan |
| An authorization client configured | `config.authorization_client = :pundit` |

:::info A `nil` user fails differently
Those three are configuration — miss one and the query is silently unscoped. A missing **user** is the opposite failure: with Pundit configured, scoping still runs, so `nil` reaches your `Scope#resolve` and the usual `user.admin?` raises `NoMethodError`. You get a 500, not a leak — the same trap described under [Authentication examples](#authentication-examples).

Both have one cure: make sure [`config.current_user_method`](#set-the-current-user) resolves to a real user on every API request.
:::
```

No other restructuring, and no mention of the API-token feature that does not exist yet.

## Verification

- `npx vitepress build docs` — passes (48s, no errors; the two pre-existing postcss `start value` notices are unrelated).
- Both in-page anchors resolve in the built HTML (`#authentication-examples`, `#set-the-current-user`).
- `yarn generate-llms-4 && node scripts/generate-docs-map.js 4.0` per AGENTS.md — reran, output unchanged (those files index pages, not prose), so nothing extra to commit.

The `avo-rest-api` skill shipped in `gems/avo-api` was checked for the same error and is already correct — it names only the three configuration prerequisites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
