### PR TITLE
Teach custom fields the collapsable Show wrapper, not hidden-input

### DIFF
--- a/docs/4.0/custom-fields.md
+++ b/docs/4.0/custom-fields.md
@@ -354,17 +354,13 @@ progress[value]::-moz-progress-bar {
 }
 ```
 
-## Use pre-built Stimulus controllers
+## Collapse long content on `Show`
 
-Avo ships with a few Stimulus controllers that help you build more dynamic fields.
-
-### Hidden input controller
-
-This controller allows you to hide your content and add a trigger to show it. You'll find it in the Trix field.
+If your field renders something tall — rich text, a rendered document, a long code listing — hand `collapsable: true` to the field wrapper. Avo clips the value to a short, faded preview with a `More content` link that expands it (and a `Less content` link that collapses it back), the same wrapper every [WYSIWYG and markdown field](./fields.html#wysiwyg-markdown-editors) uses, so your field reads like the built-in ones.
 
 <Image src="/assets/img/4_0/stimulus/hidden_input_trix.webm" dark-src="/assets/img/4_0/stimulus/hidden_input_trix-dark.webm" width="1000" height="278" alt="A Trix field on an Avo Show view with long content collapsed behind a “More content” link that, when clicked, reveals the rich text." prompt="the Trix field hiding long content behind a more content link on show" />
 
-You should add the `:always_show` `attr_reader` and `@always_show` instance variables to your field.
+Give users a way out of the collapsing by accepting the `always_show` option on your field, the way the built-in rich text fields do:
 
 ```ruby{3,8}
 # app/avo/fields/color_picker_field.rb
@@ -379,12 +375,48 @@ class Avo::Fields::ColorPickerField < Avo::Fields::BaseField
 end
 ```
 
-Next, in your fields `Show` component, you need to do a few things.
+Then pass it through, inverted, from the field's `Show` component:
 
-1. Wrap the field inside a controller tag
-1. Add the trigger that will show the content.
-1. Wrap the value in a div with the `hidden` class applied if the condition `@field.always_show` is `false`.
-1. Add the `content` target (`data-hidden-input-target="content"`) to that div.
+```erb{3}
+<%# app/components/avo/fields/color_picker_field/show_component.html.erb %>
+
+<%= field_wrapper(**field_wrapper_args, collapsable: !@field.always_show) do %>
+  <div style="background-color: <%= @field.value %>"
+    class="h-6 px-1 rounded-md text-white text-sm flex items-center justify-center leading-none"
+  >
+    <%= @field.value %>
+  </div>
+<% end %>
+```
+
+The wrapper only reveals the toggle when the content is actually taller than the preview, so short values render in full with no link.
+
+:::info
+`collapsable` applies on the `Show` view only — the field wrapper ignores it on `Index` and `Edit`.
+:::
+
+## Make an editor field resizable
+
+If your field renders an editor on forms, declare the CSS selector of its scrollable viewport. Avo turns that element into a vertically resizable one with a drag handle, and remembers the height per field in the browser's local storage:
+
+```ruby{3}
+# app/avo/fields/my_editor_field.rb
+class Avo::Fields::MyEditorField < Avo::Fields::BaseField
+  resizable_editor target: ".my-editor__content"
+end
+```
+
+The selector is resolved inside the field wrapper *after* the editor boots, so editors that render themselves client-side work too.
+
+## Use pre-built Stimulus controllers
+
+Avo ships with a few Stimulus controllers that help you build more dynamic fields.
+
+### Hidden input controller
+
+This controller hides content behind a trigger that reveals it — a one-way reveal, unlike the collapsable wrapper above, and it makes no assumptions about how tall the content is. Avo uses it on the getting started screen.
+
+Wrap the field in the controller tag, add the trigger, and give the value's container the `content` target plus the `hidden` class when `always_show` is `false`:
 
 ```erb{4-7,8}
 <%# app/components/avo/fields/color_picker_field/show_component.html.erb %>

--- a/docs/4.0/fields/markdown.md
+++ b/docs/4.0/fields/markdown.md
@@ -169,3 +169,7 @@ field :body, as: :markdown, extra_preview_params: { foo: :bar }
 </Option>
 
 <!-- @include: ./../common/field_options/always_show.md-->
+
+:::info
+The collapsed preview is rendered by the Marksmith editor itself, so it needs `marksmith` **0.6.0 or newer**. On older versions the field always shows its full content and `always_show` has nothing to do.
+:::


### PR DESCRIPTION
[avo#4724](https://github.com/avo-hq/avo/pull/4724) moved the built-in rich text fields onto `field_wrapper(collapsable:)` and the `More content` / `Less content` toggles. #642 documented that for users, but `custom-fields.md` still taught field authors the pre-4724 recipe:

- "This controller allows you to hide your content and add a trigger to show it. **You'll find it in the Trix field.**" — Trix hasn't used `hidden-input` since #4724 ([`trix_field/show_component.html.erb`](https://github.com/avo-hq/avo/blob/main/app/components/avo/fields/trix_field/show_component.html.erb) is one `field_wrapper(**field_wrapper_args, full_width: true, collapsable: !@field.always_show)` line now).
- The sample links `t('avo.show_content')` — "Show content" — while the section's own screenshot shows "More content". The page contradicted itself.
- The supported route core itself uses, `collapsable:`, wasn't documented anywhere for custom fields, nor was `resizable_editor`.

## Changes

**`docs/4.0/custom-fields.md`**

- New `## Collapse long content on Show` — `field_wrapper(**field_wrapper_args, collapsable: !@field.always_show)`, the `always_show` passthrough, and the note that the toggle only appears when content is genuinely taller than the preview (`trix_body_controller.js` reveals it above 50px). Deep-links to the [WYSIWYG & Markdown editors](https://docs.avohq.io/4.0/fields.html#wysiwyg-markdown-editors) section added in #642. Carries the Trix screenshot, whose alt text already described this behavior.
- New `## Make an editor field resizable` — the `resizable_editor target:` class method from `Avo::Fields::Concerns::HasResizableEditor`, now on `BaseField` and so available to custom fields.
- `### Hidden input controller` stays, minus the false Trix claim, described as the one-way reveal it still is (core uses it on the getting started screen). Its color-picker example is unchanged.

**`docs/4.0/fields/markdown.md`**

- `always_show` was included on this page by #642, but the collapsed preview comes from Marksmith's own show partial — `wysiwyg_more_less_content_spec.rb` skips the field below marksmith 0.5.2, and avo locks 0.6.0. Added an info callout naming the version.

## Verification

`npx vitepress build docs` passes (dead links fail the build), and the generated `custom-fields.html` carries `#collapse-long-content-on-show`, `#make-an-editor-field-resizable`, and `#hidden-input-controller`, with the cross-link resolving to `fields.html#wysiwyg-markdown-editors`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPNzCyhGTqr1kJWy8nyG2Y)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior impact.
> 
> **Overview**
> **Custom field docs** now teach the post–#4724 pattern for long **Show** content: use `field_wrapper(..., collapsable: !@field.always_show)` (with `always_show` on the field class), link to the WYSIWYG/Markdown section, and note that the toggle only appears when content exceeds the preview and only on **Show**. A new section documents **`resizable_editor target:`** for form editors.
> 
> The **`hidden-input`** Stimulus section is reframed as a one-way reveal (not the Trix approach) and no longer claims Trix uses it; setup steps are simplified.
> 
> **Markdown field docs** add a callout that collapsed preview and **`always_show`** require **marksmith 0.6.0+**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6f59d39d026e4d9a702a1fcfdc01aba184724d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->