### PR TITLE
Document avo-api's built-in API tokens (AVO-1650)

### DIFF
--- a/docs/4.0/rest-api.md
+++ b/docs/4.0/rest-api.md
@@ -9,7 +9,7 @@ outline: [2, 3]
 
 The `avo-api` add-on exposes a JSON REST API for every Avo resource. It reuses your resources' field definitions, view visibility rules, and Pundit policies, so a resource you already built for the admin panel is available over HTTP — list, read, create, update, and delete.
 
-This page covers installation, mounting, authentication, how the current user is established, authorization, and the request/response format.
+This page covers installation, mounting, API tokens, authentication, how the current user is established, authorization, and the request/response format.
 
 :::info Add-on
 The REST API ships as the separate `avo-api` gem. [See the add-on page →](https://avohq.io/addons/json-api)
@@ -47,6 +47,21 @@ Pass `--version` to namespace under something other than `v1`:
 ```bash
 rails generate avo_api:generate --version v2
 ```
+
+### Install the API tokens table
+
+Then install the credential store:
+
+```bash
+rails generate avo_api:install
+rails db:migrate
+```
+
+This writes one migration, creating the `avo_api_tokens` table. There is no initializer setting, environment variable, or credential to add — the feature needs none.
+
+:::info This step is additive
+`avo_api:install` does not replace `avo_api:generate`. One delivers the resource controllers, the other the tokens table, and a working API wants both. Skip it only if your app brings its own credential scheme and wants no tokens at all — and then [replace the authentication hook](#bring-your-own-authentication) too, so nothing goes looking for a token that can't exist.
+:::
 
 ## Mount the API
 
@@ -113,9 +128,13 @@ DELETE /api/resources/v1/teams/:id    # Delete a team
 
 The path segment is the resource's `route_key` (e.g. `blog_posts`, `product_categories`).
 
+:::info API tokens are not served over the API
+The token resource is skipped when routes are drawn, so no version namespace gets a `tokens` endpoint. Tokens are managed in the panel only — a credential can neither mint nor revoke credentials, and so cannot outlive being revoked.
+:::
+
 ## Authentication
 
-Every request runs through `setup_authentication`, a hook on `BaseResourcesController`. **The default implementation raises**, so the API is closed until you override it — every request gets `401 Unauthorized`:
+Every request runs through `setup_authentication`, a hook on `BaseResourcesController`. **The default implementation accepts a valid API token** and rejects everything else with `401 Unauthorized`:
 
 ```json
 { "error": "Unauthorized" }
@@ -123,13 +142,103 @@ Every request runs through `setup_authentication`, a hook on `BaseResourcesContr
 
 Raise `Avo::Api::AuthenticationError` anywhere in the hook to reject a request with that response.
 
-:::warning No built-in token authentication
-`avo-api` ships no token model, no `Authorization: Bearer` handling, and no API-key store. `setup_authentication` is the single extension point — the credential scheme is yours to implement. The examples below show the common ones.
+### Create a token
+
+Once the [tokens table is installed](#install-the-api-tokens-table), an **API tokens** entry appears in the Avo sidebar. Create a token there with a name and, optionally, an expiry date.
+
+The token belongs to whoever created it. The form has no owner field, and a token cannot be moved to another owner afterwards, so a crafted request cannot mint a credential belonging to somebody else.
+
+**The secret is shown once**, on the new token's page immediately after creation, with a copy button. Only a digest of it is stored, so nothing can show it again — not a console, not a support tool, not a database dump. Miss it and there is no recovery beyond minting a replacement and revoking the one you lost.
+
+What the list shows afterwards is a short leading slice of the secret (`avo_a1B2c3D4...`), enough to tell two tokens apart and far too little to guess one.
+
+### Send the token
+
+Present the secret as a bearer credential in the `Authorization` header, over HTTPS:
+
+```bash
+curl https://example.com/api/resources/v1/teams \
+  -H "Authorization: Bearer avo_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6q7R8s9T0u1V"
+```
+
+:::danger Use TLS, always
+A token is a replayable, full-privilege bearer credential: anyone holding it acts as its owner, with all of that owner's access, until the token expires or is revoked. There is nothing bound to a device, an IP, or a request body to stop a copy of it working. Send it only to `https://` endpoints.
+:::
+
+Only that header, and only that scheme, is read. A credential in a query string is not read at all, so the request is rejected exactly like one carrying no credential.
+
+:::warning A token sent in a URL is already compromised
+Rejecting it doesn't undo the disclosure — by the time the request reached Avo it was in your web server's access log, and likely in a proxy log and a browser history too. Treat any token that has appeared in a URL as leaked: revoke it and mint a replacement.
+:::
+
+### Token lifecycle
+
+A token's status is derived from two timestamps, never stored, so there is no lifecycle field to drift out of step:
+
+| Status | When | Authenticates |
+| --- | --- | --- |
+| **Active** | Not revoked, and either no expiry or an expiry still in the future | Yes |
+| **Expired** | The expiry instant has passed | No |
+| **Revoked** | The Revoke action was run on it | No |
+
+Expiry is optional — leave it blank and the token never expires. Revocation is permanent: the **Revoke** action on the token resource marks the token and keeps the record, and nothing can un-revoke it. A token that is both revoked and past its expiry reports **Revoked**.
+
+Each successful request stamps the token's **Last used** column, which is the fastest way to tell a token that was never wired up from one that stopped working.
+
+Deleting a token's owner also stops the token: a token whose owner can no longer be resolved is rejected, so a request never proceeds with nobody attached to it.
+
+:::info Every rejection looks the same
+Absent, malformed, unknown, expired, revoked, and orphaned credentials all produce the identical `401` and `{ "error": "Unauthorized" }` body — the response tells a caller nothing about which one it was.
+
+So debug a `401` from the panel, not from the response. Check the token's **Status** first (expired and revoked are the common answers), then whether its owner still exists, then **Last used** to see whether the request reached this token at all.
+:::
+
+### A token acts as its owner
+
+An authenticated request runs as the token's owner, and **every policy that owner is subject to applies to it unchanged**. That is the whole access model: there is no per-token scoping, no permission ceiling, and no grant matrix to configure.
+
+Two things follow. A token is exactly as powerful as the person who created it — an administrator's token reaches everything an administrator reaches. And restricting what a token can do means restricting its owner, or giving it an owner with less access; see [Authorization](#authorization).
+
+### Your app's own authentication still runs
+
+Token traffic is not exempt from whatever you put in [`config.authenticate_with`](./authentication.html). Avo can't tell an authentication check there from an IP allowlist, a tenant assignment, or a maintenance gate, so the block is **satisfied rather than skipped**: where Devise is present and the token's owner is a Devise-mapped model, the owner is signed in for that one request (`store: false`, so no session is written) and a standard session check passes on its own terms. Everything else in the block still runs, and a token request your rules reject stays rejected.
+
+If your block can't be satisfied that way — another authentication library, or a check against a scope the owner isn't in — guard it yourself:
+
+```ruby
+# config/initializers/avo.rb
+Avo.configure do |config|
+  config.authenticate_with do
+    next if Avo::Api.token_request? # [!code highlight]
+
+    authenticate_user!
+  end
+end
+```
+
+`Avo::Api.token_request?` is supported public API and returns `true` while a valid API token is authenticating the request in flight. Guard on it rather than on anything inside the gem's controllers.
+
+### Keep the credential safe
+
+Three rules, two of them above: send it only over TLS, and treat a token that has appeared in a URL as leaked. The third is about the one moment the plaintext exists at all.
+
+:::warning The one-time reveal transits your session store
+The plaintext secret is never written to the tokens table, but it does ride the flash from the create request to the page that displays it. That means it passes through whatever session store the app is configured with. Rails' default cookie store keeps it in the visitor's own encrypted cookie; a **server-side store writes it to disk** (or to Redis) for that one hop. The page itself is sent `Cache-Control: no-store` and opts out of Turbo's snapshot cache, but neither reaches your session store.
+:::
+
+Who may mint and revoke tokens is your app's authorization decision, and the default is permissive — see [Who may manage tokens](#who-may-manage-tokens).
+
+## Bring your own authentication
+
+Override `setup_authentication` on `BaseResourcesController` to use a different scheme. Your override wins by ordinary inheritance, and omitting `super` opts out of tokens entirely.
+
+:::warning `super` changed meaning
+In an override of `setup_authentication`, `super` used to **reject** the request. It now **accepts a valid API token**. Check every existing override before upgrading — see the [upgrade note](./upgrade.html).
 :::
 
 ### Set the current user
 
-Authenticating the *request* is only half the job. Avo's authorization — Pundit policies and policy scopes — runs against `Avo::Current.user`, and **`setup_authentication` does not set it**. If you verify a credential but never establish a user, `Avo::Current.user` stays `nil` and every policy scope receives `nil`.
+Authenticating the *request* is only half the job. Avo's authorization — Pundit policies and policy scopes — runs against `Avo::Current.user`, and **a hand-rolled `setup_authentication` does not set it**. If you verify a credential but never establish a user, `Avo::Current.user` stays `nil` and every policy scope receives `nil`. (The built-in token path does this for you: a token resolves to its owner, and a token whose owner can't be resolved is rejected rather than let through as nobody.)
 
 `Avo::Current.user` is assigned from whatever [`config.current_user_method`](./authentication.html) resolves to, evaluated in the controller instance:
 
@@ -170,7 +279,7 @@ A global `config.current_user_method do … end` block is the alternative, but i
 
 ### Authentication examples
 
-**Bearer token**, resolving to a user — see the snippet above.
+**Your own bearer token**, resolving to a user — see the snippet above. Use this when the credential lives in your app rather than in Avo's tokens table.
 
 **HTTP Basic** with Devise. `sign_in(user, store: false)` is what makes `current_user` return the user for the rest of the request, so no `current_user` override is needed here:
 
@@ -270,6 +379,58 @@ rescue_from Avo::NotAuthorizedError do
 end
 ```
 :::
+
+### Who may manage tokens
+
+`avo-api` adds no setting for this. The token resource obeys your app's existing authorization exactly like any other resource, and the gem ships no policy and generates none — policy method names are configurable and the client need not be Pundit, so a supplied file would be wrong for those apps.
+
+:::danger Without an authorization client, every panel user can mint a token
+And a token carries its owner's full privileges over every record. If `avo-authorization` isn't installed, isn't enabled on your license, or no `config.authorization_client` is set, nothing stands between a user who can sign in to Avo and a credential that reaches your whole API. That's your app's configuration rather than anything this feature decides, but decide it deliberately.
+:::
+
+The opposite is just as true. With [`config.explicit_authorization`](./authorization.html#explicit_authorization) at its default of `true`, a resource whose policy class is missing is **denied**, so the token resource is unreachable until you write one — the same rule that applies to every other resource in that app.
+
+Each built-in action is gated by its own policy method, and that one method controls both whether the action renders and whether it can be run — a hidden Revoke button cannot be run by a direct request either. Write the policy as you would for any model:
+
+```ruby
+# app/policies/avo/api/token_policy.rb
+class Avo::Api::TokenPolicy < ApplicationPolicy
+  def index?   = true
+  def show?    = true
+  def create?  = true          # anyone who may create one gets a token owned by themselves
+  def new?     = create?
+  def update?  = mine?
+  def edit?    = update?
+  def destroy? = mine?
+  def act_on?  = true          # gates the Actions menu as a whole
+  def revoke?  = mine?         # gates the Revoke action specifically
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve = user.admin? ? scope.all : scope.where(owner: user)
+  end
+
+  private
+
+  def mine?
+    return true if user.admin?
+    # Avo asks this against the model class, not a row, when it decides whether
+    # to offer an action on an index view. There is nothing to own yet, so the
+    # honest answer is "yes, in principle" — the per-record check that runs
+    # before the action touches anything is what actually decides.
+    return true unless record.is_a?(ActiveRecord::Base)
+
+    record.owner == user
+  end
+end
+```
+
+That grants administrators every token while limiting everyone else to their own — they see, edit, and revoke the tokens they created and nothing more.
+
+:::info This is one client's shape
+The example is Pundit's. Other authorization clients express the same rules their own way, and if you renamed methods through [`config.authorization_methods`](./authorization.html#using-different-policy-methods), use your names — the gem checks through the resource's authorization service, not through any particular library.
+:::
+
+Tokens record their owner polymorphically, so `scope.where(owner: user)` works whatever your user model is called.
 
 ## Reading data
 
@@ -505,7 +666,7 @@ The API returns these status codes:
 | `200` | Success |
 | `201` | Created |
 | `302` | A policy method denied the action — a redirect, not JSON (see [Authorization](#authorization)) |
-| `401` | Authentication failed or missing |
+| `401` | Authentication failed or missing — an absent, malformed, unknown, expired, revoked, or orphaned token all look the same ([why](#token-lifecycle)) |
 | `404` | Record not found, out of policy scope, or the `avo-api` feature isn't enabled on your license |
 | `422` | Validation errors |
 

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -34,6 +34,55 @@ end
 
 Migrating to TailwindCSS 4? See the [TailwindCSS 4 Migration Guide](./tailwind-4-migration).
 
+## Unreleased — `avo-api` API tokens
+
+<Option name="`super` in a `setup_authentication` override now accepts a valid API token">
+
+### Breaking Change
+
+`avo-api` ships [API tokens](./rest-api.html#authentication). The default `setup_authentication` on `BaseResourcesController` used to raise, closing the API until you replaced it. It now **accepts a request carrying a valid API token**, authenticated as that token's owner, and rejects everything else.
+
+That changes what `super` means inside an existing override.
+
+### Action Required
+
+Grep `app/controllers/avo/api/` for `setup_authentication` and check every override that calls `super`. An override that never calls it is unaffected.
+
+Drop the `super` call to opt out of tokens entirely and leave your own scheme in sole charge:
+
+```ruby
+# app/controllers/avo/api/resources/v1/base_resources_controller.rb
+def setup_authentication
+  super # [!code --]
+  authenticate_with_my_scheme!
+end
+```
+
+Keep it to accept tokens alongside your scheme — but note a token then reaches everything its owner reaches, since [a token acts as its owner](./rest-api.html#a-token-acts-as-its-owner).
+
+</Option>
+
+<Option name="`avo-api` now ships a migration">
+
+### Breaking Change
+
+The tokens table is new, and the token resource appears in the Avo sidebar by default as soon as the gem is upgraded — before the table exists.
+
+### Action Required
+
+Install it:
+
+```bash
+rails generate avo_api:install
+rails db:migrate
+```
+
+Until you do, opening the **API tokens** screen, or sending any request with an `Authorization: Bearer …` header, queries a table that isn't there and errors. This is additive to `avo_api:generate`, which still owns the resource controllers.
+
+If you don't want tokens at all, [replace the authentication hook](./rest-api.html#bring-your-own-authentication) so the token lookup never runs.
+
+</Option>
+
 ## Unreleased — browser time zone on by default
 
 <Option name="`use_browser_timezone` now defaults to `true`">


### PR DESCRIPTION
The REST API page told readers that `avo-api` ships no token model and that `setup_authentication` raises by default. Both are now false. This documents the token layer as built, verified against the implementation on `avo-1650/feature/token-authentication` rather than against the plan.

## `docs/4.0/rest-api.md`

- **Installation** — new `### Install the API tokens table` step: `rails generate avo_api:install` + `rails db:migrate`, stated as **additive** to `avo_api:generate`, with the "no initializer setting, env var, or credential" fact.
- **Endpoints** — a callout that the token resource is skipped when routes are drawn, so a credential can neither mint nor revoke credentials.
- **Authentication** — the default now *accepts* a valid token. New subsections:
  - `Create a token` — panel, owner assigned not chosen, secret shown **once**, recovery is a replacement, what the truncated display prefix is.
  - `Send the token` — `Authorization: Bearer avo_…` with an `https://` example, a `:::danger` on TLS (replayable full-privilege bearer credential), and the query-string rule plus a `:::warning` that such a token is already in the access log and must be replaced.
  - `Token lifecycle` — status table (Active / Expired / Revoked), optional expiry, permanent revocation, last-used, orphaned owner, and the uniform-`401` callout doubling as the troubleshooting order.
  - `A token acts as its owner` — no per-token scoping, no permission ceiling, deliberately.
  - `Your app's own authentication still runs` — `config.authenticate_with` is satisfied, not skipped, with the `Avo::Api.token_request?` guard for hooks that can't be.
  - `Keep the credential safe` — the reveal transits the session store, so a server-side store writes it to disk transiently.
- **Bring your own authentication** (new `##`, holding the existing `Set the current user` and `Authentication examples` subsections unchanged) — leads with the `super` warning.
- **Authorization → Who may manage tokens** — the gem ships no policy and generates none; each action gated by its own method (`revoke?` for Revoke, `act_on?` for the Actions menu), one method governing both render and run; a worked Pundit example flagged as one client's shape; and the opposite default stated as plainly — with no authorization client, **every panel user can mint a token carrying full privileges over every record**.
- **Error handling** — the `401` row now names the six rejections that look identical.
- Removed the `:::warning No built-in token authentication` block.

## `docs/4.0/upgrade.md`

`AGENTS.md` requires an upgrade entry for a silent behavior change, so this adds `## Unreleased — avo-api API tokens` with two `<Option>` blocks:

1. **`super` in a `setup_authentication` override now accepts a valid API token** — leads the section, with what to grep for and the `[!code --]` diff that opts back out.
2. **`avo-api` now ships a migration** — the resource appears in the sidebar before the table exists, so run the installer.

## Where the code differed from the brief I was given

- **The `config.authenticate_with` bridge is Devise-shaped.** `bridge_to_app_authentication` returns early unless `::Devise` is defined *and* the owner matches a Devise mapping (`gems/avo-api/app/controllers/avo/api/resources/resources_controller.rb:121-126`). "Satisfied, not skipped" is true, but only automatic for Devise-mapped owners — the page says so, and gives the `token_request?` guard as the path for everyone else.
- **A query-parameter credential is "not read", which is what makes it rejected.** `bearer_credential` returns `nil` for anything that isn't a `Bearer ` `Authorization` header, so such a request is refused exactly like an empty one. The gem's skill says "ignored"; both describe the same code, and the page states the mechanism and the consequence.
- **The policy example needs to survive being asked against the model class.** The Revoke action's `authorize` block runs with no record on the index (`gems/avo-api/app/avo/actions/avo_api/revoke_token.rb:15-17`), so a naive `record.owner == user` would hide the action there. The worked example mirrors the shape the gem's own dummy policy uses, with the comment explaining why.
- **No table means an error, not a `401`.** `Token.authenticate` queries unguarded, so an app that upgrades without running the installer and receives any `Authorization: Bearer …` request hits a missing table. That is what the second upgrade `<Option>` is for.

## Notes

- Branch `avo-1650/docs/rest-api-token-authentication` already exists on the remote, carrying the **closed** WIP PR #633. That one documents a design that did not ship (`avo:api:generate`, `--skip-tokens`, a generated policy, a permission ceiling, a `_schema` endpoint, `config.api.*`). Nothing here builds on it; this branch is off `main`.
- `npx vitepress build docs` passes.
- `yarn generate-llms-4 && node scripts/generate-docs-map.js 4.0` produce no diff — no page was added or renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
