### PR TITLE
Document the 4.1.10 editor changes

### DIFF
--- a/docs/4.0/fields.md
+++ b/docs/4.0/fields.md
@@ -168,7 +168,17 @@ All of these fields render their value through the same collapsible wrapper (the
 
 ### Resizable editors
 
-On forms, every editor's viewport can be resized vertically by dragging its bottom-end resize handle. The height is remembered per resource and field (in the browser's local storage) and restored the next time the form renders.
+On forms, every editor's viewport can be resized vertically by dragging its bottom-end resize handle. It opens 20rem tall and never goes below 11rem. The height is remembered in the browser's local storage — scoped to the Avo mount path, the resource (or action) and the field — and restored the next time that form renders.
+
+Change the two heights by defining the CSS custom properties in a [stylesheet you register with Avo](./asset-manager):
+
+```css
+/* app/assets/stylesheets/avo_custom.css */
+:root {
+  --avo-resizable-editor-default-height: 30rem;
+  --avo-resizable-editor-min-height: 15rem;
+}
+```
 
 Custom editor fields can opt in from their field class:
 

--- a/docs/4.0/fields/code.md
+++ b/docs/4.0/fields/code.md
@@ -46,7 +46,9 @@ Customize the syntax highlighting using the language method.
 
 <Option name="`height`">
 
-Customize the height of the editor.
+Customize the height of the editor on the <Show /> view.
+
+On <Edit /> and <New /> the editor renders in a [resizable viewport](./../fields.html#resizable-editors) instead, so this option doesn't apply there — the height comes from the viewport's default (or whatever height the user last dragged it to).
 
 #### Default value
 

--- a/docs/4.0/fields/tip_tap.md
+++ b/docs/4.0/fields/tip_tap.md
@@ -12,3 +12,7 @@ The `TipTap` field is deprecated in favor of the [Rhino](./rhino) field.
 The Rhino field is a fork of the TipTap editor with some additional features and improvements.
 
 The Rhino field is fully integrated with Avo and provides a seamless experience for managing rich text content using the [ActiveStorage](https://guides.rubyonrails.org/active_storage_overview.html) integration and the [Media Library](./../media-library).
+
+## Options
+
+<!-- @include: ./../common/field_options/always_show.md-->

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -4,6 +4,41 @@ We'll update this page when we release new Avo 4 versions.
 
 If you're looking for the Avo 3 to Avo 4 upgrade guide, please visit [the dedicated page](./avo-3-avo-4-upgrade).
 
+## Upgrade to 4.1.10
+
+<Option name="`code` and `easy_mde` collapse their content on `Show`">
+
+The `code` and `easy_mde` fields now render on the <Show /> view through the same collapsible wrapper the rich text fields use: the value is clipped to a short, faded preview with a **More content** link that expands it and a **Less content** link that collapses it back. They previously rendered the full value.
+
+**Action required:** None unless you want the full value visible on load. Pass `always_show: true` on the field to skip the collapsing:
+
+```ruby
+# app/avo/resources/product.rb
+field :custom_css, as: :code, always_show: true # [!code ++]
+```
+
+See [WYSIWYG & Markdown editors](./fields.html#wysiwyg-markdown-editors) for the behavior every editor field now shares.
+
+</Option>
+
+<Option name="Editors render in a bounded, resizable viewport on forms">
+
+On <Edit /> and <New />, every editor field (`trix`, `rhino`, `lexxy`, `markdown`, `easy_mde`, `tip_tap` and `code`) now renders inside a viewport that opens 20rem tall, scrolls its overflow, and can be dragged taller or shorter by its bottom-end handle. Editors previously grew with their content. Each height is stored in the browser's local storage and restored the next time that form renders.
+
+**Action required:** None. If the default size doesn't suit your content, set the heights globally in a [stylesheet you register with Avo](./asset-manager):
+
+```css
+/* app/assets/stylesheets/avo_custom.css */
+:root {
+  --avo-resizable-editor-default-height: 30rem; /* [!code ++] */
+  --avo-resizable-editor-min-height: 15rem; /* [!code ++] */
+}
+```
+
+Note that the `code` field's [`height`](./fields/code.html#height) option now only applies on the <Show /> view — on forms the viewport's height wins.
+
+</Option>
+
 ## Upgrade to 4.1.7
 
 <Option name="`config.visible` now controls Media Library access, not just the menu item">


### PR DESCRIPTION
Daily docs sweep over yesterday's changes in `avo-hq/avo` and `avo-hq/workspace`.

[avo#4724](https://github.com/avo-hq/avo/pull/4724) ("Unify WYSIWYG and code fields behind a collapsable show wrapper") shipped in **v4.1.10**. The editor overview added in #642 covers the shared `Show` behavior and the `resizable_editor` opt-in, but four things it changed had no page:

| Change | Where it's now documented |
| --- | --- |
| `code` and `easy_mde` collapse their value on <Show /> (they rendered it in full before) | new `## Upgrade to 4.1.10` section |
| Every editor renders in a bounded, resizable viewport on forms — previously they grew with their content | same section |
| The viewport's default (20rem) and minimum (11rem) heights are CSS custom properties a host app can override | `fields.md` → *Resizable editors*, plus the upgrade note |
| The `code` field's `height` option now only applies on <Show /> — on forms the viewport wins (`.CodeMirror:not(.resizable-editor__viewport)`) | `fields/code.md` → `height` |

Also adds the `always_show` option to `fields/tip_tap.md`. The field supports it and the shared-behavior table on the Fields page lists `tip_tap`, but its own page documented no options at all.

Everything here was read off the merged code — `HasResizableEditor`, `FieldWrapperComponent#add_resizable_editor_attributes`, `resizable-editor.css`, `resizable_editor_controller.js`, and the `collapsable:` call sites in the four show components.

### Checked and found nothing to change

- **avo**: v4.1.10 bump and the nanoid dependency bump — no customer-facing surface.
- **workspace**: [#204](https://github.com/avo-hq/workspace/pull/204) (`avo-calendar` in-place month row expansion + week duration blocks) is already covered by `calendar-view.md` and the two unreleased `avo-calendar` upgrade notes, including the chip tooltip when `on_click` skips the preview. The `avo-licensing` loader rebuild and version bump are internal.

### One thing I left alone

`fields/easy_mde.md` documents a `height` option that the field passes into its options JSON but `easy_mde_controller.js` never reads — it looks inert, and has been since before this change. Out of scope for this sweep, but worth a look.

`npx vitepress build docs` passes; the new anchors (`#wysiwyg-markdown-editors`, `#resizable-editors`, `#height`, `#always_show`) all resolve.

---
_Generated by [Claude Code](https://claude.ai/code/session_011gn7WNCMqvCWygmsge6UyP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or application code changes.
> 
> **Overview**
> Documents **v4.1.10** editor UX that shipped in avo#4724: `code` and `easy_mde` now use the same collapsible **Show** wrapper as other editor fields, and all editors on **Edit/New** sit in a bounded, vertically resizable viewport (20rem default, 11rem minimum) with per-field heights stored in local storage.
> 
> Adds **`## Upgrade to 4.1.10`** in the upgrade guide with migration notes (`always_show: true`, CSS vars `--avo-resizable-editor-default-height` / `--avo-resizable-editor-min-height`). Expands **Resizable editors** on the Fields page with those defaults and override instructions. Clarifies that **`code` `height`** applies only on **Show** (forms use the resizable viewport). Adds **`always_show`** to the Tip Tap field options page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f27be9bed141ce4cbe974c108a1bb85b442c5269. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->