### PR TITLE
Fold the released upgrade notes under their versions

### DIFF
--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -4,6 +4,24 @@ We'll update this page when we release new Avo 4 versions.
 
 If you're looking for the Avo 3 to Avo 4 upgrade guide, please visit [the dedicated page](./avo-3-avo-4-upgrade).
 
+## Upgrade to `avo-calendar` `4.0.3`
+
+<Option name="`+N more` no longer opens the week view">
+
+In the month view, the **+N more** toggle under a crowded day now expands that week row in place to reveal every event, with a **Show less** control to fit it back. It previously navigated to that day's week view. See [Read a crowded day](./calendar-view.html#read-a-crowded-day).
+
+**Action required:** None — the behavior change is visual only, and the week view stays one click away in the header's Month/Week toggle.
+
+</Option>
+
+<Option name="Week view becomes a scrollable time grid">
+
+Hour-based events now stretch to their duration — overlapping events share the day column side by side — instead of rendering as fixed chips on their start hour, and the grid scrolls inside the viewport, opening at 07:00 under a pinned day-header row. See [Month and week views](./calendar-view.html#month-and-week-views).
+
+**Action required:** None — the change is visual only. An event without an `ends_at` renders as a one-hour block.
+
+</Option>
+
 ## Upgrade to 4.1.7
 
 <Option name="`config.visible` now controls Media Library access, not just the menu item">
@@ -34,73 +52,6 @@ end
 
 Migrating to TailwindCSS 4? See the [TailwindCSS 4 Migration Guide](./tailwind-4-migration).
 
-## Unreleased — `avo-calendar` month and week view changes
-
-<Option name="`+N more` no longer opens the week view">
-
-In the month view, the **+N more** toggle under a crowded day now expands that week row in place to reveal every event, with a **Show less** control to fit it back. It previously navigated to that day's week view. See [Read a crowded day](./calendar-view.html#read-a-crowded-day).
-
-**Action required:** None — the behavior change is visual only, and the week view stays one click away in the header's Month/Week toggle.
-
-</Option>
-
-<Option name="Week view becomes a scrollable time grid">
-
-Hour-based events now stretch to their duration — overlapping events share the day column side by side — instead of rendering as fixed chips on their start hour, and the grid scrolls inside the viewport, opening at 07:00 under a pinned day-header row. See [Month and week views](./calendar-view.html#month-and-week-views).
-
-**Action required:** None — the change is visual only. An event without an `ends_at` renders as a one-hour block.
-
-</Option>
-
-## Unreleased — browser time zone on by default
-
-<Option name="`use_browser_timezone` now defaults to `true`">
-
-### Breaking Change
-
-Server-side dates and times now render in [each visitor's own time zone](./customization.html#time-and-currency) by default instead of the app's `Time.zone`. Avo detects the browser's zone via a cookie; the first page a browser loads soft-reloads once through Turbo and shows a one-time alert that times are now displayed in the visitor's zone.
-
-**Action required:** None if per-visitor times are what you want — most apps do. Displayed values only change for users whose browser zone differs from the app zone; nothing about stored data changes.
-
-The option defaults to `false` in the test environment, so browser/system tests are unaffected — the first-load soft reload would otherwise race them.
-
-### Maintaining Previous Behavior
-
-Pin every visitor to the app's configured zone:
-
-```ruby
-# config/initializers/avo.rb
-Avo.configure do |config|
-  config.use_browser_timezone = false # [!code ++]
-end
-```
-
-</Option>
-
-## Unreleased — resizable sidebar
-
-<Option name="Sidebar labels truncate instead of wrapping">
-
-### Breaking Change
-
-The sidebar is now [resizable](./customization.html#resizable-sidebar), and as part of that change sidebar link, section, and group labels render on a single line with an ellipsis when they overflow, instead of wrapping onto multiple lines. The full label shows in a tooltip on hover.
-
-**Action required:** None for most apps. If your navigation relied on long labels wrapping, either shorten the labels or point users at the drag handle to widen the sidebar.
-
-Hosts with an accessibility conformance obligation can disable the drag handle with [`sidebar[:resizable]`](./customization-api.html#sidebar).
-
-</Option>
-
-<Option name="`.container-small` is now `max-width`-based">
-
-### Breaking Change
-
-`.container-small` (the wrapper around show and edit pages) used a fixed width; it now fills its container up to a `max-width` so content adapts when the sidebar is wide. If you override `.container-small`'s `width` from your own stylesheets, the new Avo-owned `max-width` now clamps it — override `max-width` instead.
-
-**Action required:** None unless you override `.container-small`.
-
-</Option>
-
 ## Upgrade to 4.1.4
 
 <Option name="The back to top pill is enabled by default">
@@ -123,6 +74,29 @@ end
 ```
 
 The direction-aware reveal is gone for good — `threshold` is now the only thing that decides when the pill shows up.
+
+</Option>
+
+<Option name="`use_browser_timezone` now defaults to `true`">
+
+### Breaking Change
+
+Server-side dates and times now render in [each visitor's own time zone](./customization.html#time-and-currency) by default instead of the app's `Time.zone`. Avo detects the browser's zone via a cookie; the first page a browser loads soft-reloads once through Turbo and shows a one-time alert that times are now displayed in the visitor's zone.
+
+**Action required:** None if per-visitor times are what you want — most apps do. Displayed values only change for users whose browser zone differs from the app zone; nothing about stored data changes.
+
+Since `4.1.8` the option defaults to `false` in the test environment, so browser/system tests are unaffected — the first-load soft reload would otherwise race them. On `4.1.4` through `4.1.7` it is on in test as well; set `config.use_browser_timezone = !Rails.env.test?` if you stay on one of those and your system specs started flaking.
+
+### Maintaining Previous Behavior
+
+Pin every visitor to the app's configured zone:
+
+```ruby
+# config/initializers/avo.rb
+Avo.configure do |config|
+  config.use_browser_timezone = false # [!code ++]
+end
+```
 
 </Option>
 
@@ -149,6 +123,30 @@ end
 ```
 
 Setting it on a dashboard does not turn it on for that dashboard's cards — the two controls are independent opt-ins under the same name.
+
+</Option>
+
+## Upgrade to 4.0.20
+
+<Option name="Sidebar labels truncate instead of wrapping">
+
+### Breaking Change
+
+The sidebar is now [resizable](./customization.html#resizable-sidebar), and as part of that change sidebar link, section, and group labels render on a single line with an ellipsis when they overflow, instead of wrapping onto multiple lines. The full label shows in a tooltip on hover.
+
+**Action required:** None for most apps. If your navigation relied on long labels wrapping, either shorten the labels or point users at the drag handle to widen the sidebar.
+
+Hosts with an accessibility conformance obligation can disable the drag handle. The off-switch was `config.sidebar_resizable` on `4.0.20` and `4.0.21`; from `4.0.22` it moved into the grouped config as [`sidebar[:resizable]`](./customization-api.html#sidebar) and the old name no longer works.
+
+</Option>
+
+<Option name="`.container-small` is now `max-width`-based">
+
+### Breaking Change
+
+`.container-small` (the wrapper around show and edit pages) used a fixed width; it now fills its container up to a `max-width` so content adapts when the sidebar is wide. If you override `.container-small`'s `width` from your own stylesheets, the new Avo-owned `max-width` now clamps it — override `max-width` instead.
+
+**Action required:** None unless you override `.container-small`.
 
 </Option>
 


### PR DESCRIPTION
Daily docs sweep over yesterday's changes in `avo-hq/avo` and `avo-hq/workspace`.

The only code change in the window was [workspace#204](https://github.com/avo-hq/workspace/pull/204) (`avo-calendar` in-place month row expansion + week duration blocks), which **shipped yesterday as `avo-calendar` `4.0.3`**. Its upgrade note was written while it was unreleased and still said so. Per [`AGENTS.md`](https://github.com/avo-hq/docs.avohq.io/blob/main/AGENTS.md) — *"Unreleased changes get a plain descriptive `##` heading … when the release ships, fold them under the `## Upgrade to X.Y.Z` heading"* — that fold is now due.

Checking the page for the same drift turned up two more sections that shipped a while ago and never got folded:

| Section | Shipped in | Evidence | Now |
| --- | --- | --- | --- |
| `avo-calendar` month and week view changes | `avo-calendar` `4.0.3` (2026-08-16) | tag `avo-calendar-v4.0.3` contains workspace#204 | `` ## Upgrade to `avo-calendar` `4.0.3` ``, moved to the top (newest first) |
| browser time zone on by default | Avo `4.1.4` (2026-08-10) | `@use_browser_timezone = true` lands in [avo#4703](https://github.com/avo-hq/avo/pull/4703); earliest tag containing it is `v4.1.4` | merged into the existing `## Upgrade to 4.1.4` |
| resizable sidebar | Avo `4.0.20` (2026-07-28) | [avo#4665](https://github.com/avo-hq/avo/pull/4665) carries both the resize handle and the `.container-small` change; earliest tag is `v4.0.20` | new `## Upgrade to 4.0.20`, slotted between `avo-dashboards` `4.0.9` and `4.0.18` |

Two accuracy fixes fell out of pinning the versions:

- The time-zone note said the option "defaults to `false` in the test environment" flatly. That's a `4.1.8` change ([avo#4720](https://github.com/avo-hq/avo/pull/4720)) — on `4.1.4`–`4.1.7` it is on in test too, which is exactly the window where someone's system specs start flaking. The note now says so and gives the one-line pin.
- The sidebar note pointed at `sidebar[:resizable]`, which didn't exist in `4.0.20` — the off-switch was `config.sidebar_resizable` until [avo#4671](https://github.com/avo-hq/avo/pull/4671) grouped the sidebar config in `4.0.22`. Unlike `sidebar_toggle_visible`, the flat name got no back-compatible accessor (`Avo::Configuration` keeps a shim only for the toggle), so an app that set it is silently ignored on `4.0.22`+. The note names both spellings and says the old one stopped working.

No `<Option>` names changed, so every `<Option>` anchor is stable; only the three `##` heading anchors moved, and nothing in `docs/` links to them (`grep -rn "upgrade.html#"`).

### Checked and found nothing to change

- **avo**: nothing merged yesterday. The last change, [avo#4725](https://github.com/avo-hq/avo/pull/4725) (nanoid bump), has no customer-facing surface.
- **workspace**: `calendar-view.md` already documents everything workspace#204 shipped — `on_click`, the duration-stretched blocks, side-by-side overlaps, the grid opening at 07:00, and the in-place row expansion with **Show less**. Verified against `calendar_view_type_component.rb`, `calendar_scroll_controller.js` (`hour` value defaults to `7`) and `RECORDS_LIMIT = 500`. The `avo-calendar` `4.0.3` version bump is the release itself.

### Note for a human

`docs/4.0/upgrade.md` has no entry for the `4.0.22` sidebar config regrouping itself (`config.sidebar_toggle_visible` / `sidebar_resizable` / `sidebar_default_width` → `config.sidebar`). The toggle kept a shim, the other two didn't. I covered the `resizable` half where it was relevant above rather than writing a `4.0.22` section from scratch in a sweep PR, but it probably wants one.

`npx vitepress build docs` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wouj2L4TQdLHRX2Y1wm7MR)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to the upgrade guide; no application code or runtime behavior changes.
> 
> **Overview**
> **`docs/4.0/upgrade.md`** no longer uses **Unreleased** headings for changes that already shipped. Those notes are folded under **`## Upgrade to …`** sections in newest-first order: **`avo-calendar` `4.0.3`** (month **+N more** in-place expansion and scrollable week time grid), **`4.1.4`** (browser timezone default merged with the existing back-to-top section), and a new **`4.0.20`** block (resizable sidebar label truncation and **`.container-small`** max-width).
> 
> The **`use_browser_timezone`** copy now distinguishes **`4.1.4`–`4.1.7`** (timezone on in test, with a one-line pin for flaky system specs) from **`4.1.8+`** (defaults off in test). The sidebar note documents **`config.sidebar_resizable`** on **`4.0.20`/`4.0.21`** versus **`sidebar[:resizable]`** from **`4.0.22`**, where the flat name stops working.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0ab5d6bd5aed595cb5d2f772fce16a4f5bd1a07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->