### PR TITLE
docs: document that `stacked: false` wins over sidebar and width defaults

### DIFF
--- a/docs/4.0/field-options-api.md
+++ b/docs/4.0/field-options-api.md
@@ -428,7 +428,7 @@ field :last_name,  width: 50
 Unlisted values fall back to the full row width.
 
 :::info
-Any `width` below `100` automatically marks the field as [`stacked`](#stacked).
+Any `width` below `100` automatically marks the field as [`stacked`](#stacked), unless you declare `stacked: false` yourself.
 :::
 
 </Option>
@@ -443,6 +443,8 @@ field :meta, as: :key_value, stacked: true
 
 - **Type:** Boolean
 - **Default:** `nil` — falls back to the `config.field_wrapper_layout` initializer option (`:inline` unless changed to `:stacked`)
+
+A declaration on the field always wins. Places that stack by default — sidebars, the record preview, a field with a `width` below `100` — honour `stacked: false`.
 
 </Option>
 

--- a/docs/4.0/field-options.md
+++ b/docs/4.0/field-options.md
@@ -275,7 +275,7 @@ field :last_name,  width: 50
 field :years_of_experience # full width
 ```
 
-Setting any `width` below `100` automatically marks the field as [`stacked`](./field-options-api.html#stacked) — the label moves above the value so the field fits the narrower column. See the [supported values](./field-options-api.html#width) in the reference.
+Setting any `width` below `100` automatically marks the field as [`stacked`](./field-options-api.html#stacked) — the label moves above the value so the field fits the narrower column. Declare `stacked: false` on the field if you'd rather keep the label beside the value. See the [supported values](./field-options-api.html#width) in the reference.
 
 ### Stack the label above the value
 
@@ -283,6 +283,12 @@ For some fields, it might make more sense to use all of the horizontal area to d
 
 ```ruby
 field :meta, as: :key_value, stacked: true
+```
+
+The option works the other way around too. Avo stacks fields on its own in a few places — inside a [`sidebar`](./fields-layout.html#move-compact-fields-to-a-sidebar), in the record preview, and whenever a field has a `width` below `100` — and `stacked: false` opts a field out of all of them.
+
+```ruby
+field :name, as: :text, stacked: false
 ```
 
 #### `inline` layout (default)

--- a/docs/4.0/fields-layout.md
+++ b/docs/4.0/fields-layout.md
@@ -271,7 +271,7 @@ Every field has two layout modes for how its label sits relative to its value. *
 field :meta, as: :key_value, stacked: true
 ```
 
-Fields inside a `sidebar` are stacked automatically. To stack every field across the app, set `config.field_wrapper_layout = :stacked`. See [`stacked`](./field-options-api#stacked) in the field options reference and [global stacked layout](./field-options#global-stacked-layout) in the guide for the full details.
+Fields inside a `sidebar` are stacked automatically — pass `stacked: false` on a field to keep its label beside the value. To stack every field across the app, set `config.field_wrapper_layout = :stacked`. See [`stacked`](./field-options-api#stacked) in the field options reference and [global stacked layout](./field-options#global-stacked-layout) in the guide for the full details.
 
 ## Multi-column rows with `width`
 

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -34,6 +34,28 @@ end
 
 Migrating to TailwindCSS 4? See the [TailwindCSS 4 Migration Guide](./tailwind-4-migration).
 
+## Unreleased — `stacked: false` is honored everywhere
+
+<Option name="`stacked: false` now opts a field out of sidebar and width stacking">
+
+### Breaking Change
+
+A field declared `stacked: false` used to be ignored in the places Avo stacks on its own — inside a `sidebar`, in the record preview, and on any field with a `width` below `100`. The field's own declaration now wins over those defaults, so such a field renders inline. See [`stacked`](./field-options-api.html#stacked).
+
+### Action Required
+
+**If you never pass `stacked: false`**, nothing changes — the defaults are untouched.
+
+**If you do**, the fields that carry it move from stacked to inline. Drop the option to keep them stacked.
+
+```ruby
+# app/avo/resources/user.rb
+field :name, as: :text, stacked: false # [!code --]
+field :name, as: :text # [!code ++]
+```
+
+</Option>
+
 ## Unreleased — `avo-calendar` month and week view changes
 
 <Option name="`+N more` no longer opens the week view">

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -4,6 +4,28 @@ We'll update this page when we release new Avo 4 versions.
 
 If you're looking for the Avo 3 to Avo 4 upgrade guide, please visit [the dedicated page](./avo-3-avo-4-upgrade).
 
+## Upgrade to 4.1.11
+
+<Option name="`stacked: false` now opts a field out of sidebar and width stacking">
+
+### Breaking Change
+
+A field declared `stacked: false` used to be ignored in the places Avo stacks on its own — inside a `sidebar`, in the record preview, and on any field with a `width` below `100`. The field's own declaration now wins over those defaults, so such a field renders inline. See [`stacked`](./field-options-api.html#stacked).
+
+### Action Required
+
+**If you never pass `stacked: false`**, nothing changes — the defaults are untouched.
+
+**If you do**, the fields that carry it move from stacked to inline. Drop the option to keep them stacked.
+
+```ruby
+# app/avo/resources/user.rb
+field :name, as: :text, stacked: false # [!code --]
+field :name, as: :text # [!code ++]
+```
+
+</Option>
+
 ## Upgrade to 4.1.7
 
 <Option name="`config.visible` now controls Media Library access, not just the menu item">
@@ -33,28 +55,6 @@ end
 
 
 Migrating to TailwindCSS 4? See the [TailwindCSS 4 Migration Guide](./tailwind-4-migration).
-
-## Unreleased — `stacked: false` is honored everywhere
-
-<Option name="`stacked: false` now opts a field out of sidebar and width stacking">
-
-### Breaking Change
-
-A field declared `stacked: false` used to be ignored in the places Avo stacks on its own — inside a `sidebar`, in the record preview, and on any field with a `width` below `100`. The field's own declaration now wins over those defaults, so such a field renders inline. See [`stacked`](./field-options-api.html#stacked).
-
-### Action Required
-
-**If you never pass `stacked: false`**, nothing changes — the defaults are untouched.
-
-**If you do**, the fields that carry it move from stacked to inline. Drop the option to keep them stacked.
-
-```ruby
-# app/avo/resources/user.rb
-field :name, as: :text, stacked: false # [!code --]
-field :name, as: :text # [!code ++]
-```
-
-</Option>
 
 ## Unreleased — `avo-calendar` month and week view changes
 


### PR DESCRIPTION
Docs for [avo-hq/avo#4727](https://github.com/avo-hq/avo/pull/4727), which makes a field's own `stacked:` declaration win over the places Avo stacks on its own — inside a `sidebar`, in the record preview, and on any field with a `width` below `100`. `stacked: false` was silently ignored in all three.

The default (stacked) does not change. What changes is that you can opt out of it, so the docs now say so where each default is introduced.

## Changes

| Page | Change |
| --- | --- |
| `4.0/upgrade.md` | New `## Upgrade to 4.1.11` entry. Anyone already writing `stacked: false` sees those fields move from stacked to inline, so it states the change and how to keep the old look. |
| `4.0/field-options.md` | The `width` paragraph notes the opt-out; the stacked section gains a short paragraph plus a `stacked: false` sample covering all three defaults. |
| `4.0/fields-layout.md` | "Fields inside a `sidebar` are stacked automatically" now names the opt-out. |
| `4.0/field-options-api.md` | The `stacked` `<Option>` states that a field declaration always wins; the `width` callout notes the opt-out. |

## Verification

- `npx vitepress build docs` — build complete, no errors.
- `yarn generate-llms-4 && node scripts/generate-docs-map.js 4.0` — re-run; no changes to the committed output.
- Behavior verified against the gem source (`Avo::FieldWrapperComponent#stacked?` and `Avo::Fields::BaseField#initialize` on the linked PR's branch), not restated from existing prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
