### PR TITLE
Document the week view's current-time line and centred opening scroll

### DIFF
--- a/docs/4.0/calendar-view.md
+++ b/docs/4.0/calendar-view.md
@@ -167,7 +167,7 @@ end
 
 ## Month and week views
 
-The header's Month/Week toggle switches between a month grid and a week time grid (carried in the `calendar_period` query param). In the week view, all-day and multi-day events sit in the all-day lane at the top, and hour-based events render as blocks stretched to their duration — an event without an end renders as one hour. Overlapping events share the day column side by side, each block showing its title under the start time. The grid scrolls under the pinned day-header row and all-day lane, and opens at 07:00.
+The header's Month/Week toggle switches between a month grid and a week time grid (carried in the `calendar_period` query param). In the week view, all-day and multi-day events sit in the all-day lane at the top, and hour-based events render as blocks stretched to their duration — an event without an end renders as one hour. Overlapping events share the day column side by side, each block showing its title under the start time. The grid scrolls under the pinned day-header row and all-day lane, and opens with the current time centred. When the week on screen is the current one, a red line runs across the day columns at the current time — a dot marking today's — and keeps itself up to date.
 
 <Image src="/assets/img/4_0/calendar-view/week.webp" dark-src="/assets/img/4_0/calendar-view/week-dark.webp" width="1456" height="806" alt="The week view — event blocks stretched to their duration, three overlapping events sharing a day column side by side." />
 


### PR DESCRIPTION
Companion to avo-hq/workspace#213 (AVO-1730): the calendar week view gains a red current-time line across the day columns with a dot on today's, and opens with the current time centred instead of at 07:00. Two sentences updated on the calendar guide page. Merge when the next avo-calendar version ships.