### PR TITLE
Reframe the i18n page around naming things, add the key map

### DIFF
--- a/docs/4.0/i18n.md
+++ b/docs/4.0/i18n.md
@@ -5,7 +5,42 @@ outline: [2, 3]
 
 # Localization (i18n)
 
-Avo leverages Rails' powerful `I18n` translations module.
+Avo names everything for you out of the box: resources and actions after their class names, fields after their ids, and the buttons and headings around them from Avo's own locale files, shipped in 19 languages through Rails' `I18n` module. When you want different copy, there are two ways to set it — and this page covers both.
+
+**Drive the copy from your locale files.** Everything you build — resources, fields, actions, scopes, cards, dashboards, tabs, panels — resolves its copy from a predictable i18n key before anything else. One YAML file can rename the whole admin:
+
+```yaml
+# config/locales/avo.es.yml
+es:
+  avo:
+    resource_translations:
+      user:
+        one: "Usuario"
+        other: "Usuarios"
+        fields:
+          created_at: "Fecha de creación"
+    action_translations:
+      toggle_inactive:
+        name: "Alternar inactivo"
+```
+
+If your app serves multiple languages, definitely work this way: every string lives in the locale files, and adding a language means adding a file, never touching a resource. It's just as useful in a single-language app for renaming things in bulk without editing code.
+
+**Or set the copy in code, with the built-in properties.** `self.name` and `self.message` on an action, `name:`, `help:` and `placeholder:` on a field, `label:` on a card. Use these when you want the string next to the thing it describes, or when a label needs data — they accept lambdas with Avo's [execution context](./execution-context.html):
+
+```ruby
+# app/avo/actions/toggle_inactive.rb
+class Avo::Actions::ToggleInactive < Avo::BaseAction
+  self.name = "Toggle inactive"
+  self.message = -> { "Toggle #{record.name}?" }
+end
+```
+
+The two compose — [a single cascade](#how-avo-resolves-a-label) decides which wins — so you can start with strings in code and move them into locale files when the second language arrives.
+
+:::info Naming records is different
+`self.title = :name` on a resource picks which **attribute** stands in for a record — the heading on its <Show /> page, its label in a `belongs_to` select. That's data, not copy, so i18n doesn't enter into it. This page is about the copy around your records.
+:::
 
 :::warning Translations are used exactly as you write them
 Avo renders a resolved resource or field translation verbatim. It only humanizes the name it generates for you when no translation is found. Write `one: 'Usuario'` and you get `Usuario`; write `one: 'usuario'` and you get `usuario`. This also means acronyms and proper nouns survive -- `'Payment Intent ID'` stays `Payment Intent ID` instead of becoming `Payment intent id`.
@@ -16,6 +51,44 @@ If you're serving Avo using multiple languages and you're using the locale in yo
 :::
 
 Avo ships its own locale files (`avo.en.yml` plus 18 other languages) bundled inside the gem and loads them into the `I18n` module automatically, so `bin/rails avo:install` doesn't copy them into your app. When you want editable copies under `config/locales`, run the [locale generator](#customize-the-locale).
+
+## How Avo resolves a label {#how-avo-resolves-a-label}
+
+Every label goes through the same cascade. The first layer that has a value wins:
+
+1. **The value at the call site** — `field :dates, name: "Period"`, or `card Avo::Cards::UsersMetric, label: "Active users"`.
+2. **The i18n key** — derived per the [key map](#key-map) below, or set explicitly with `self.translation_key` / `translation_key:`.
+3. **The class attribute** — `self.name`, `self.message`, `self.label`, `self.description` on actions, scopes, cards, and dashboards.
+4. **What Avo generates** — the humanized class name or field id, or Avo's own translated string (`avo.run`, `avo.save`, …).
+
+Not every layer exists everywhere — resources have no naming attribute, and actions take nothing at the call site — but the order never changes: an explicit call-site value beats the locale file, and the locale file beats a class attribute. That last part is what lets you keep English defaults in code and translate over them without touching the class.
+
+## The key map {#key-map}
+
+Every key Avo derives, in one place:
+
+| You're naming | Avo looks up | Keys under it | Comes from |
+| --- | --- | --- | --- |
+| [Resource](#localizing-resources) | `avo.resource_translations.<class_path>` | `zero`/`one`/`other`, plus the `fields`, `tabs`, `panels` and `save` subtrees | Avo |
+| [Field](#localizing-fields) | `avo.resource_translations.<resource>.fields.<field_id>`, then `avo.field_translations.<field_id>` | `zero`/`one`/`other`, `help`, `placeholder`, `include_blank` | Avo |
+| [Action](#localizing-actions) | `avo.action_translations.<class_path>` | `name`, `message`, `confirm_button_label`, `cancel_button_label`, `description` | Avo |
+| [Tab](#localizing-tabs-and-panels) | `avo.resource_translations.<resource>.tabs.<slug>` | the title itself | Avo |
+| [Panel](#localizing-tabs-and-panels) | `avo.resource_translations.<resource>.panels.<slug>` | the title itself | Avo |
+| [Save button](#localizing-buttons-label) | `avo.resource_translations.<resource>.save`, then `avo.save` | the label itself | Avo |
+| [Scope](#localizing-scopes-cards-and-dashboards) | `avo.scope_translations.<class_path>` | `name`, `description` | `avo-scopes` |
+| [Card](#localizing-scopes-cards-and-dashboards) | `avo.card_translations.<class_path>` | `label`, `description`, `discreet_description` | `avo-dashboards` |
+| [Dashboard](#localizing-scopes-cards-and-dashboards) | `avo.dashboard_translations.<class_path>` | `name`, `description` | `avo-dashboards` |
+
+[Filters](./basic-filters.html) are the one thing with no derived key yet — name them with a lambda, as shown in [Where your own keys go](#safe-keys).
+
+### How the paths are derived
+
+- **`<class_path>`** — the class name minus its DSL container prefix (`Avo::Resources::`, `Avo::Actions::`, `Avo::Scopes::`, `Avo::Cards::`, `Avo::Dashboards::`), underscored. A namespace becomes a slash: `Avo::Resources::User` → `user`, `Avo::Actions::City::Update` → `city/update`.
+- **`<field_id>`** — the field's first argument: `field :created_at` → `created_at`.
+- **`<slug>`** — the tab's or panel's `title:`, downcased with non-alphanumerics turned into `_`: `title: "Contact information"` → `contact_information`.
+- **`<resource>`** — the `<class_path>` of the resource the field, tab, panel, or save button belongs to.
+
+Every derived path can be replaced with your own: `self.translation_key = "..."` on the class, or `translation_key: "..."` on a `field`, `tab`, or `panel`.
 
 ## Localizing resources
 
@@ -59,18 +132,18 @@ end
 ```
 
 ```yaml
-# avo.sv.yml
-sv:
+# avo.es.yml
+es:
   avo:
     action_translations:
       toggle_inactive:
-        name: "Växla inaktiv"
-        message: "Är du säker på att du vill växla inaktiv status?"
-        confirm_button_label: "Växla"
-        cancel_button_label: "Avbryt"
-        description: "Växlar den inaktiva statusen för användaren"
+        name: "Alternar inactivo"
+        message: "¿Seguro que quieres alternar el estado inactivo?"
+        confirm_button_label: "Alternar"
+        cancel_button_label: "Cancelar"
+        description: "Alterna el estado inactivo del usuario"
       city/update:
-        name: "Uppdatera stad"
+        name: "Actualizar ciudad"
 ```
 
 Namespaced actions use the same underscored, slash-joined path as resources — `Avo::Actions::City::Update` resolves to `avo.action_translations.city/update`.
@@ -79,31 +152,25 @@ You can still set `self.name`, `self.message`, and the button labels as strings 
 
 ## Localizing scopes, cards, and dashboards
 
-Scopes, dashboard cards, and dashboards follow the same convention, from the add-on gems that provide them.
-
-| Entity | Key | Attributes |
-| --- | --- | --- |
-| Scope | `avo.scope_translations.<class_path>` | `name`, `description` |
-| Card | `avo.card_translations.<class_path>` | `label`, `description`, `discreet_description` |
-| Dashboard | `avo.dashboard_translations.<class_path>` | `name`, `description` |
+Scopes, dashboard cards, and dashboards follow the same convention, from the add-on gems that provide them — their keys and attributes are in the [key map](#key-map).
 
 ```yaml
-# avo.sv.yml
-sv:
+# avo.es.yml
+es:
   avo:
     scope_translations:
       admins:
-        name: "Administratörer"
-        description: "Endast administratörer"
+        name: "Administradores"
+        description: "Solo administradores"
     card_translations:
       users_metric:
-        label: "Antal användare"
-        description: "Över alla team"
+        label: "Número de usuarios"
+        description: "En todos los equipos"
       sales/monthly:
-        label: "Månadsförsäljning"
+        label: "Ventas mensuales"
     dashboard_translations:
       dashy:
-        name: "Instrumentpanel"
+        name: "Panel de control"
 ```
 
 Each accepts `self.translation_key` to override the derived path, and each falls back to the class attribute — which may still be a String or a lambda — when no translation is present. Namespaced classes use the same slash-joined path as resources and actions.
@@ -180,16 +247,16 @@ en:
 When no explicit `help:`, `placeholder:`, or `include_blank:` is set on the field, Avo also resolves those from sibling keys under the same `translation_key`:
 
 ```yaml
-# avo.sv.yml
-sv:
+# avo.es.yml
+es:
   avo:
     field_translations:
       dates:
-        one: "Datumintervall"
-        other: "Datumintervall"
-        help: "Valfritt. Standardperiod: 1 vecka tillbaka till idag."
-        placeholder: "Välj datum"
-        include_blank: "Ingen"
+        one: "Rango de fechas"
+        other: "Rangos de fechas"
+        help: "Opcional. Período estándar: desde hace 1 semana hasta hoy."
+        placeholder: "Elige las fechas"
+        include_blank: "Ninguna"
 ```
 
 ```ruby
@@ -330,16 +397,7 @@ The reverse needs a little care. Avo resolves resource and field names with `I18
 
 ### Where your own keys go
 
-Six roots exist for keys you write. Avo derives these paths itself and ships nothing under them:
-
-| Root | Fills in | Comes from |
-| --- | --- | --- |
-| `avo.resource_translations.<class_path>` | [Resource](#localizing-resources) names, plus scoped `fields`, `tabs`, `panels` and `save` | Avo |
-| `avo.action_translations.<class_path>` | [Action](#localizing-actions) names, messages and button labels | Avo |
-| `avo.field_translations.<field_id>` | [Field](#localizing-fields) labels, help, placeholder and blank option | Avo |
-| `avo.scope_translations.<class_path>` | [Scope](#localizing-scopes-cards-and-dashboards) names and descriptions | `avo-scopes` |
-| `avo.card_translations.<class_path>` | [Card](#localizing-scopes-cards-and-dashboards) labels and descriptions | `avo-dashboards` |
-| `avo.dashboard_translations.<class_path>` | [Dashboard](#localizing-scopes-cards-and-dashboards) names and descriptions | `avo-dashboards` |
+Six roots exist for keys you write — the `*_translations` roots in the [key map](#key-map). Avo derives those paths itself and ships nothing under them, so nothing of Avo's can collide with what you put there.
 
 `avo.resource_translations.<resource>` nests one level further — `.fields.<field_id>`, `.tabs.<slug>`, `.panels.<slug>` and `.save` — and it's the one place Avo expects a subtree of your own.
 
@@ -409,7 +467,7 @@ The locale generator covers Avo core. Add-on gems keep their own strings under t
 | Intelligence | `avo.intelligence.*` | |
 | Scopes | `avo.scopes.*` | [Localization](./scopes.html#localization) |
 
-The keys deep-merge into the same `avo` tree as core's, so one `sv.yml` per gem — or a single file carrying all of them — works fine.
+The keys deep-merge into the same `avo` tree as core's, so one `es.yml` per gem — or a single file carrying all of them — works fine.
 
 Advanced Search is the one gem that ships no locale file at all, and it doesn't need one: every key it renders lives under `avo.global_search.*` or is `avo.all`, and Avo core translates all of them in each of its bundled locales.
 


### PR DESCRIPTION
Follows up on [AVO-1430](https://linear.app/avo-hq/issue/AVO-1430/improve-i18n-from-mike-guestit): the i18n work shipped and the page documented each feature, but it read as a list of localization features rather than the story — that most copy customization in Avo can be driven from i18n files.

## What changed

- **New intro** framing the two ways to set copy: drive it from locale files (the way to go for multi-language apps, and for bulk renames in single-language ones), or use the built-in properties (`self.name`, `help:`, `label:`…) when you want proximity to the code or data-dependent labels. Plus a callout separating `self.title` (which attribute represents a record — data, not copy) from the rest of the page.
- **"How Avo resolves a label"** — the single cascade, verified against the gem source: call-site value → i18n key → class attribute → generated fallback.
- **"The key map"** — one table of all nine derived keys (resource, field, action, tab, panel, save button, scope, card, dashboard) with the attributes each accepts and which gem provides it, followed by the derivation rules (`<class_path>` = class name minus its container prefix, underscored, namespaces becoming slashes; field ids; tab/panel title parameterization). Filters are called out as the one entity with no derived key yet.
- Removed the two smaller tables that restated parts of the map; they link to it now.
- Demo language is Spanish throughout (was a mix of Swedish and Spanish).

Every pattern was checked against `avo`, `avo-scopes`, and `avo-dashboards` source rather than restated from the old prose. LLM files regenerated (no content delta); VitePress build is green.