### PR TITLE
Document the calendar's Today control and correct sidebar stacking

### DIFF
--- a/docs/4.0/calendar-view.md
+++ b/docs/4.0/calendar-view.md
@@ -183,8 +183,18 @@ If you'd rather skip the popover, set `on_click: :show` or `on_click: :edit` to 
 
 ## Navigation and filtering
 
-- The header's arrows navigate by month or week; the anchor date is carried in the `calendar_date` query param. The **Today** button jumps back to the current date.
+- The header's arrows navigate by month or week; the anchor date is carried in the `calendar_date` query param. The **Today** button jumps back to the current date, keeping the period you pressed it in.
 - Filters and scopes applied on the index also apply to the calendar. Pagination does not — the calendar always shows the whole visible range (capped at 500 records).
+
+### Pressing Today on today's own range
+
+A month grid bleeds a few days of its neighbours, so today can be on screen in a month it doesn't belong to — **Today** still takes you to its own month rather than pointing at the leaked cell.
+
+When the grid already shows today's own month or week, though, there is nothing to fetch, and the press is answered in the browser instead of by a reload. If today has scrolled out of sight it comes back to the middle of the viewport, and then it pops: the day number and the circle behind it scale up twice while a wash of the accent drains out of the cell. A press with today already in sight skips the scroll and pops on the spot.
+
+In the week view today's column is a pinned header that never leaves the screen, so what gets centred there is the current hour instead. Navigating is never accompanied by a pop — the arriving grid speaks for itself — and Cmd/Ctrl-click (or Shift/Alt) still opens today's range in a new tab or window, leaving the current page where it was.
+
+Two cases have nothing to reveal, and both are quiet rather than broken: `hide_weekends` can drop today from the grid entirely, and visitors who ask for reduced motion get the same jumps without the animation.
 
 :::info
 There is no drag-to-reschedule yet.

--- a/docs/4.0/fields-layout.md
+++ b/docs/4.0/fields-layout.md
@@ -212,7 +212,7 @@ end
 
 <Image src="/assets/img/4_0/resource-sidebar/sidebar.webp" dark-src="/assets/img/4_0/resource-sidebar/sidebar-dark.webp" width="980" height="461" alt="Resource Show view with a main panel on the left and a sidebar on the right holding the avatar and Is active fields" />
 
-Sidebar fields are always stacked — label above value — because the narrower column requires it.
+Sidebar fields stack by default — label above value — because the narrower column requires it. A field declaring [`stacked: false`](./field-options-api#stacked) keeps its label beside the value even there.
 
 ## Organize fields under tabs
 


### PR DESCRIPTION
Daily docs sweep over yesterday's (2026-08-17) changes in `avo-hq/avo` and `avo-hq/workspace`. Two of them left the docs saying something that is no longer true.

## Calendar — the Today control

[`Add Today control to calendar navigation` (avo-hq/workspace#211)](https://github.com/avo-hq/workspace/pull/211) gave the Today button real behaviour when the grid is already on today's own range: rather than refetching the grid already on screen, the press is answered in the browser — today scrolls to the middle of the viewport if it is out of sight, then the day number and the circle behind it pop.

`docs/4.0/calendar-view.md` still described it as one line — "jumps back to the current date" — so this adds a short subsection under **Navigation and filtering** covering:

| Behaviour | Detail |
| --------- | ------ |
| Today's own range | Press is handled client-side; scroll-into-view then pop |
| Month grid bleed | Today visible in a neighbouring month still navigates to its own month |
| Week view | Today's column is a pinned header, so the **current hour** is what gets centred |
| Navigation | No pop rides along with a transition; modified clicks still open a new tab/window |
| Quiet cases | `hide_weekends` can drop today from the grid; reduced motion drops the animation |

## Fields — `stacked: false` in a sidebar

[`fix: let stacked: false win over sidebar and width defaults` (avo-hq/avo#4727)](https://github.com/avo-hq/avo/pull/4727) reordered `Avo::FieldWrapperComponent#stacked?` so a field's own declaration beats the layout default a parent component passes in.

`docs/4.0/fields-layout.md` said sidebar fields are "**always** stacked" — accurate before the fix, not after. The field options reference (`field-options-api.md`) and this same page's own labels section already documented the opt-out, so this line was the one place left contradicting them.

## Checked and not needed

- [`Bring the skills docs-drift checker into the gem` (avo-hq/avo#4728)](https://github.com/avo-hq/avo/pull/4728) — internal tooling, no customer-facing surface.
- [`Add current time line to calendar week view` (avo-hq/workspace#213)](https://github.com/avo-hq/workspace/pull/213) — already documented in #652.
- [`reject symlinks from spec.files in every gemspec` (avo-hq/workspace#210)](https://github.com/avo-hq/workspace/pull/210) — packaging fix, no docs surface.

## Verification

`npx vitepress build docs` completes clean. Prose-only changes; the one new link (`./field-options-api#stacked`) uses the same form already used elsewhere in `fields-layout.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJTBQrE7uKJuLzjpemJhnk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> **Calendar view** docs now describe what **Today** actually does beyond “jump to the current date”: it keeps the current month/week period, still navigates to today’s own month when today appears only from neighbour-month bleed, and when the grid is already on today’s range it avoids a reload in favour of scroll-into-view plus a highlight animation (week view centres the current hour instead). The new subsection also notes no pop on navigation, modified-click new-tab behaviour, and quiet handling for `hide_weekends` and reduced motion.
> 
> **Fields layout** corrects sidebar stacking: fields stack by default in a sidebar, but **`stacked: false`** can keep label beside value there, with a link to the field options API—replacing the old “always stacked” wording that conflicted with the gem fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5a9a5f326f7265fd30b28d39787f96183bd0381. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->