### PR TITLE
Rename avo-calendar gem to avo-calendar_view on the Calendar view page

### DIFF
--- a/docs/4.0/calendar-view.md
+++ b/docs/4.0/calendar-view.md
@@ -14,7 +14,7 @@ Display a resource's records on a month or week calendar, right on the <Index />
 ## Requirements
 
 - Avo 4
-- `avo-calendar` gem (paid add-on)
+- `avo-calendar_view` gem (paid add-on)
 
 ## Installation
 
@@ -22,7 +22,7 @@ Display a resource's records on a month or week calendar, right on the <Index />
 
 ```ruby
 # Gemfile
-gem "avo-calendar", source: "https://packager.dev/avo-hq/"
+gem "avo-calendar_view", source: "https://packager.dev/avo-hq/"
 ```
 
 Then run `bundle install`.


### PR DESCRIPTION
Companion to avo-hq/workspace#214, which renames the `avo-calendar` gem to `avo-calendar_view`. Updates the gem name in the Requirements list and the install snippet. The page's `addon_link` already points to https://avohq.io/addons/calendar-view.

Hold merging until the first `avo-calendar_view` release is published on the packager.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only rename with no runtime or API changes in this repo.
> 
> **Overview**
> Updates the Calendar view documentation to match the **`avo-calendar` → `avo-calendar_view`** gem rename (companion to the workspace change).
> 
> The **Requirements** bullet and the **Installation** `Gemfile` snippet now reference `avo-calendar_view` with the same packager source. No other install or configuration steps on the page change; the addon link was already correct.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b71c2f38d31c302a90bda8c63b4ac39a46e0112f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->