### PR TITLE
Document what empty_message actually does on each basic filter type

### DIFF
--- a/docs/4.0/basic-filters-api.md
+++ b/docs/4.0/basic-filters-api.md
@@ -82,15 +82,27 @@ The block is evaluated through [`Avo::ExecutionContext`](./execution-context) wi
 
 <Option name="`self.empty_message`" headingSize="3">
 
-The message shown in the panel when [`options`](#options) returns an empty collection.
+A string each filter type puts to its own use: an empty-state message on boolean filters, the blank option's label on select filters, and the input placeholder on text and date/time filters.
 
 ```ruby
 self.empty_message = "Please select a country to view options."
 ```
 
+| Base class | Where `empty_message` renders |
+| --- | --- |
+| `Avo::Filters::BooleanFilter` | The message shown in the panel when [`options`](#options) returns an empty collection |
+| `Avo::Filters::SelectFilter` | The label of the blank option at the top of the dropdown |
+| `Avo::Filters::MultipleSelectFilter` | Not used |
+| `Avo::Filters::TextFilter` | The text input's placeholder |
+| `Avo::Filters::DateTimeFilter` | The picker input's placeholder |
+
 - **Type:** String
-- **Default:** `nil` — falls back to the translated default
-- **i18n key:** `avo.no_options_available` ("No options available")
+- **Default:** `nil` — the boolean filter's empty state falls back to the translated default, the select filter's blank option to `"—"`; text and date/time inputs render no placeholder
+- **i18n key:** `avo.no_options_available` ("No options available") — the boolean filter's empty-state fallback
+
+:::warning
+The select filter's blank option is always rendered — `empty_message` only labels it. A falsy value doesn't remove the option; its label falls back to `"—"`.
+:::
 
 </Option>
 

--- a/docs/4.0/basic-filters.md
+++ b/docs/4.0/basic-filters.md
@@ -419,7 +419,7 @@ Checking that the current filter is `blank?` matters: it keeps the user's own se
 
 <DemoVideo demo-video="https://youtu.be/M2RsNPPFOio?t=347" />
 
-When `options` returns an empty collection — for example, the cities filter before a country is selected — Avo shows a generic "no options" message. Customize it with `self.empty_message`:
+On a boolean filter, when `options` returns an empty collection — for example, the cities filter before a country is selected — Avo shows a generic "no options" message. Customize it with [`self.empty_message`](./basic-filters-api#self.empty_message):
 
 ```ruby{4}
 # app/avo/filters/course_city.rb
@@ -430,6 +430,8 @@ class Avo::Filters::CourseCity < Avo::Filters::BooleanFilter
   # ...
 end
 ```
+
+The other filter types put `self.empty_message` to different uses — the blank option's label on select filters, the input placeholder on text and date/time filters. See [the per-type breakdown](./basic-filters-api#self.empty_message) in the API reference.
 
 ## Show or hide a filter conditionally
 


### PR DESCRIPTION
## What was wrong

Both basic-filter pages described `self.empty_message` as "the message shown in the panel when `options` returns an empty collection". That is only true for the boolean filter — the other filter types repurpose the same attribute for their own inputs (verified against the avo core views; permalinks in the linked issue).

## What it says now

**`docs/4.0/basic-filters-api.md`** — the `self.empty_message` `<Option>` block now carries a per-base-class table:

| Base class | Where `empty_message` renders |
| --- | --- |
| `BooleanFilter` | Empty-state message when `options` returns an empty collection |
| `SelectFilter` | Label of the blank option at the top of the dropdown |
| `MultipleSelectFilter` | Not used |
| `TextFilter` | The text input's placeholder |
| `DateTimeFilter` | The picker input's placeholder |

The `avo.no_options_available` i18n fallback is now scoped to the boolean filter's empty state, and a `:::warning` calls out the sharp edge on select filters: the blank option is always rendered — a falsy `empty_message` doesn't remove it, the label just falls back to `"—"`.

**`docs/4.0/basic-filters.md`** — the "Show a message when there are no options" section keeps the boolean example as the lead (it matches the demo video), scopes the intro sentence to boolean filters, links `self.empty_message` to its API entry, and closes with one line pointing at the per-type breakdown.

Build verified with `npx vitepress build docs` (no errors).

Part of avo-hq/avo#4732

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior modifications.
> 
> **Overview**
> Corrects misleading docs that treated **`self.empty_message`** as only the boolean filter’s “no options” panel message.
> 
> **`basic-filters-api.md`** now explains that the same attribute is reused per base class (table for boolean empty state, select blank-option label, text/datetime placeholders, multiple select unused), narrows **`avo.no_options_available`** to the boolean fallback, and documents select-filter behavior: the blank option always appears; falsy **`empty_message`** only changes the label to **`"—"`**.
> 
> **`basic-filters.md`** scopes the “no options” section to boolean filters, links to the API entry, and points readers to the per-type breakdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e98957eeec92639567c175ebf65985580fa608f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->