### PR TITLE
Document belongs_to behavior in actions

### DIFF
--- a/docs/4.0/actions.md
+++ b/docs/4.0/actions.md
@@ -127,7 +127,7 @@ You may use the [custom controls](./custom-controls.html) feature to show action
 
 ## Collect input with fields
 
-An action can define fields, shown to the user in the action's modal. They work the same way as fields on resources. When the action runs on a single record the fields are hydrated from that record; otherwise they're plain form inputs. The submitted values arrive in `handle` as the `fields` argument.
+An action can define fields, shown to the user in the action's modal. Most work the same way as fields on resources. When the action runs on a single record the fields are hydrated from that record; otherwise fields that do not depend on a record render as plain form inputs. Association fields are an exception, as described below. The submitted values arrive in `handle` as the `fields` argument.
 
 ```ruby
 # app/avo/actions/toggle_inactive.rb
@@ -140,6 +140,47 @@ end
 ```
 
 Check out the [Fields page](./fields.md) for everything fields can do.
+
+### Choose an associated record in a collection action
+
+A [`belongs_to` field](./associations/belongs_to.html) needs one current record to resolve its association. It works when you run the action from a record's <Show /> view or select exactly one record on the <Index /> view because Avo hydrates the action with that record. It cannot render when you select multiple records or run a standalone action because there is no single current record.
+
+For a short list of choices, use a [`select` field](./fields/select.html) with options loaded when the form renders:
+
+```ruby
+# app/avo/actions/assign_user.rb
+class Avo::Actions::AssignUser < Avo::BaseAction
+  def fields
+    field :user_id,
+      as: :select,
+      options: -> { User.order(:name).pluck(:name, :id) },
+      include_blank: true
+  end
+
+  def handle(query:, fields:, **)
+    query.each do |record|
+      record.update! user_id: fields[:user_id]
+    end
+
+    succeed "Assigned the selected records."
+  end
+end
+```
+
+For a long list that needs search, use a [`tags` field with `fetch_values_from`](./fields/tags.html#fetch_values_from) in select mode:
+
+```ruby
+# app/avo/actions/assign_user.rb
+def fields
+  field :user_id,
+    as: :tags,
+    mode: :select,
+    enforce_suggestions: true,
+    fetch_values_from: "/avo/resources/users/action_options"
+end
+```
+
+The endpoint receives the search text in `params[:q]` and returns objects with `value` and `label` keys. Both alternatives submit the selected ID as `fields[:user_id]`.
 
 ## Write the `handle` method
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- explain that `belongs_to` action fields require a single hydrated record
- document supported Show and single-selection Index contexts
- add `select` and searchable `tags` alternatives for bulk and standalone actions

## Validation

- `yarn generate-llms-4`
- `node scripts/generate-docs-map.js 4.0`
- `yarn build`
- manually verified the section, code examples, and guide-to-API callout in the local VitePress site
- `git diff --check origin/main...HEAD`

## Walkthrough

[belongs_to_action_guidance.mp4](https://cursor.com/agents/bc-72963705-3b20-4624-92c4-95337a1e0da7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbelongs_to_action_guidance.mp4)

Linear: [AVO-1739](https://linear.app/avo-hq/issue/AVO-1739/add-docs-about-belongs-to-behavior-on-actions)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [AVO-1739](https://linear.app/avo-hq/issue/AVO-1739/add-docs-about-belongs-to-behavior-on-actions)

<div><a href="https://cursor.com/agents/bc-72963705-3b20-4624-92c4-95337a1e0da7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72963705-3b20-4624-92c4-95337a1e0da7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

