### PR TITLE
Add upgrade notes for the avo-calendar_view rename and dot-style events

### DIFF
--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -4,6 +4,53 @@ We'll update this page when we release new Avo 4 versions.
 
 If you're looking for the Avo 3 to Avo 4 upgrade guide, please visit [the dedicated page](./avo-3-avo-4-upgrade).
 
+## Upgrade to `avo-calendar_view` `4.0.9`
+
+<Option name="Single-day timed events render with a dot instead of a filled chip">
+
+On the month grid, an hour-based event that fits inside one day box now renders unfilled, with its [`color`](./calendar-view.html#color) shown as a dot beside the time — the way calendar apps mark timed events. It previously rendered as a filled chip tinted with that color. All-day and multi-day events are unchanged and keep the filled pill. See [All-day and hour-based events](./calendar-view.html#all-day-and-hour-based-events).
+
+**Action required:** None — the change is visual only, and no option changed its meaning.
+
+</Option>
+
+## Upgrade to `avo-calendar_view` `4.0.8`
+
+<Option name="The `avo-calendar` gem is renamed to `avo-calendar_view`">
+
+### Breaking Change
+
+The calendar add-on now ships under the gem name `avo-calendar_view`. `avo-calendar` stops at `4.0.7` and gets no further releases, so `bundle update` won't pick this up on its own — the Gemfile has to be edited by hand.
+
+Only the packaging changes. The view type is still `:calendar`, and [`self.calendar_view`](./calendar-view.html#configuration) keeps every option it had.
+
+### Action Required
+
+Rename the gem in your `Gemfile` and run `bundle install`:
+
+```ruby
+# Gemfile
+gem "avo-calendar", source: "https://packager.dev/avo-hq/" # [!code --]
+gem "avo-calendar_view", source: "https://packager.dev/avo-hq/" # [!code ++]
+```
+
+Resources that enable the calendar need no edit:
+
+```ruby
+# app/avo/resources/event.rb
+self.view_types = [:table, :calendar]
+self.calendar_view = {
+  starts_at: :starts_at,
+  ends_at: :ends_at
+}
+```
+
+:::info
+Only the documented DSL above is covered by this guarantee. If your app reaches into the gem's internals — a stylesheet targeting `avo-calendar/application`, or a reference to the `Avo::Calendar` namespace — those are now `avo-calendar_view/application` and `Avo::CalendarView`.
+:::
+
+</Option>
+
 ## Upgrade to 4.1.11
 
 <Option name="`stacked: false` now opts a field out of sidebar and width stacking">


### PR DESCRIPTION
Daily docs sweep over yesterday's (2026-08-18) commits in `avo-hq/avo` and `avo-hq/workspace`. Most of the day was already documented — this fills the one gap that was left.

## The gap

`avo-calendar` was renamed to `avo-calendar_view` in [workspace#214](https://github.com/avo-hq/workspace/pull/214), shipping as **`avo-calendar_view` 4.0.8**. b71c2f3 updated the Requirements and Installation blocks on the Calendar view page to the new gem name, but nothing was added to the upgrade log.

That leaves existing customers without a signal. `avo-calendar` stops at `4.0.7` and receives no further releases, so `bundle update` is silent — there's no deprecation warning and no failing boot, the gem just quietly stops moving. The Gemfile has to be edited by hand, and the upgrade page is where a reader looks for that.

## What's added

Two entries at the top of `docs/4.0/upgrade.md`, newest first:

| Version | Entry | Action required |
| --- | --- | --- |
| `avo-calendar_view` `4.0.9` | Single-day timed events render with a dot instead of a filled chip | None — visual only |
| `avo-calendar_view` `4.0.8` | The `avo-calendar` gem is renamed to `avo-calendar_view` | Rename the gem in the Gemfile |

The 4.0.8 entry carries the Gemfile diff, and states explicitly that **only the packaging changed** — the view type is still `:calendar` and `self.calendar_view` keeps every option — so nobody edits resources that don't need it. An `:::info` callout covers the two internals that did move (`avo-calendar/application` → `avo-calendar_view/application`, `Avo::Calendar` → `Avo::CalendarView`) for apps that reach past the documented DSL.

The 4.0.9 entry follows the precedent of the existing `avo-calendar` `4.0.3` section, which documents visual-only changes with an explicit "Action required: None".

## Everything else from 2026-08-18 — checked, no docs needed

| Change | Verdict |
| --- | --- |
| [avo#4734](https://github.com/avo-hq/avo/pull/4734) boolean filters show the translated default empty message | **Docs were already right.** `basic-filters-api.md` already documented `empty_message` as `nil` → falls back to `avo.no_options_available`, and the guide's example is literally a `BooleanFilter`. The fix made the code match the docs (`empty_message` → `get_empty_message` in the partial). |
| [avo#4733](https://github.com/avo-hq/avo/pull/4733) clearing the last applied filter with session persistence | Internal JS controller fix, no API surface. |
| [workspace#215](https://github.com/avo-hq/workspace/pull/215) dot-style events | Already documented on the Calendar view page by b37a9ae — upgrade entry added here. |
| [workspace#203](https://github.com/avo-hq/workspace/pull/203) avo-ai ruby_llm 1.16 → 2.0 | Already covered by the `avo-1706-ruby-llm-2` docs work (#644): the `ruby_llm_*` tables, model registry, and provider pinning are all on the AI page. |
| [workspace#216](https://github.com/avo-hq/workspace/pull/216) dashboards refresh icon spin direction | CSS animation direction only. |

## Verification

- Swept the whole site for stale references: the only remaining `avo-calendar` string is the historical `## Upgrade to \`avo-calendar\` \`4.0.3\`` heading, left as-is since that's the name the gem had at that version. No `Avo::Calendar` references anywhere.
- Verified the rename's user-facing surface against the gem source rather than the PR description — confirmed the DSL is unchanged and that 4.0.7 is the last version under the old name.
- `npx vitepress build docs` completes clean; all three anchor targets (`#color`, `#configuration`, `#all-day-and-hour-based-events`) resolve to real ids on the built Calendar view page, and the diff markers and callout render.

---
_Generated by [Claude Code](https://claude.ai/code/session_013sFZVDW2YhMFLrpSTAUfcE)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to the upgrade guide; no application code or runtime behavior is modified in this PR.
> 
> **Overview**
> **Docs only:** `docs/4.0/upgrade.md` gets two new sections at the top (newest first), filling the gap where the Calendar view page was updated for the new gem name but the upgrade guide had no signal.
> 
> **`avo-calendar_view` 4.0.8** documents the breaking packaging rename: `avo-calendar` stops at 4.0.7, so customers must edit the `Gemfile` manually; `:calendar` and `self.calendar_view` are unchanged. Includes a Gemfile diff, reassurance that resources need no edits, and an info callout for internal references (`avo-calendar/application` → `avo-calendar_view/application`, `Avo::Calendar` → `Avo::CalendarView`).
> 
> **`avo-calendar_view` 4.0.9** documents a visual-only change: single-day hour-based events on the month grid render as an unfilled row with a color dot instead of a filled chip; all-day/multi-day pills are unchanged. **Action required: none.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b9871b18abb6f10fe9c6b01e6710cac67e181b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->