### PR TITLE
fix: show a working save_record override for HTTP resources

### DIFF
--- a/docs/4.0/http-resource-api.md
+++ b/docs/4.0/http-resource-api.md
@@ -51,6 +51,10 @@ self.http_adapter = {
 Unlike the other adapter options, `endpoint` is used verbatim — it does not accept a proc and is not evaluated through `Avo::ExecutionContext`.
 :::
 
+:::warning Must be absolute
+The endpoint needs a host. A missing, blank, or relative value (`nil`, `""`, `"/users"`) raises [`Avo::HttpError`](./http-resource.html#handle-api-errors) before any request is sent, so the controller shows a flash message instead of failing inside `Net::HTTP` on a nil address.
+:::
+
 :::info Request behavior
 Index requests always carry `page` and `per_page` query parameters — the names are not configurable. Use [`query_params`](#query_params) to send additional parameters. Requests time out after 10 seconds and raise an error.
 :::

--- a/docs/4.0/http-resource.md
+++ b/docs/4.0/http-resource.md
@@ -170,10 +170,12 @@ class Avo::AuthorsController < Avo::Core::Controllers::Http
     headers = Avo::ExecutionContext.new(target: resource.headers).handle
     body = { author: @record.as_json }
 
+    # HTTParty has no default timeout — the client sets one on its own class, so
+    # a hand-rolled request has to bound itself.
     response = if action_name == "create"
-      HTTParty.post(endpoint, body: body, headers: headers)
+      HTTParty.post(endpoint, body: body, headers: headers, timeout: 10)
     else
-      HTTParty.patch("#{endpoint}/#{@record.id}", body: body, headers: headers)
+      HTTParty.patch("#{endpoint}/#{@record.id}", body: body, headers: headers, timeout: 10)
     end
 
     response.success?

--- a/docs/4.0/http-resource.md
+++ b/docs/4.0/http-resource.md
@@ -87,6 +87,8 @@ self.http_adapter = {
 
 If the headers must be computed at request time — rotating tokens, per-user credentials — pass a proc returning the hash instead.
 
+Every request carries them: index, show, and count, as well as the create, update, and destroy requests the controller makes.
+
 ## Map sorting and filtering to query params
 
 If you want Avo's sorting UI (or any UI state) forwarded to the API, build the query string with [`query_params`](./http-resource-api.html#query_params). The proc has access to controller `params`, and its result is merged into the request's query string:
@@ -136,7 +138,7 @@ The controller rescues the exception and displays the message as a flash error i
 
 ## Customize create, update, and destroy
 
-Out of the box, the HTTP controller persists changes through the resource's client — `POST` to the endpoint on create, `PATCH` to `endpoint/:id` on update, and `DELETE` to `endpoint/:id` on destroy. The default implementation looks like this:
+Out of the box, the HTTP controller persists changes through the resource's client — `POST` to the endpoint on create, `PATCH` to `endpoint/:id` on update, and `DELETE` to `endpoint/:id` on destroy, each carrying the resource's [`headers`](#send-authentication-headers). The default implementation looks like this:
 
 ```ruby
 def save_record
@@ -162,20 +164,26 @@ If your API needs different paths, extra parameters, or conditional logic, overr
 # app/controllers/avo/authors_controller.rb
 class Avo::AuthorsController < Avo::Core::Controllers::Http
   def save_record
-    auth_headers = {
-      "Authorization" => "Bearer #{ENV.fetch("API_KEY")}"
-    }
+    # Build the URL from the resource's own endpoint, and evaluate its headers
+    # the same way the client does — `headers` may be a proc.
+    endpoint = resource.endpoint
+    headers = Avo::ExecutionContext.new(target: resource.headers).handle
+    body = { author: @record.as_json }
 
     response = if action_name == "create"
-      MyCustomApi.post("/authors", body: @record.as_json, headers: auth_headers)
+      HTTParty.post(endpoint, body: body, headers: headers)
     else
-      MyCustomApi.patch("/authors/#{@record.id}", body: @record.as_json, headers: auth_headers)
+      HTTParty.patch("#{endpoint}/#{@record.id}", body: body, headers: headers)
     end
 
     response.success?
   end
 end
 ```
+
+:::warning Request an absolute URL
+Avo configures no `base_uri`, so a relative path — `HTTParty.post("/authors", ...)` — has no host to connect to and fails inside `Net::HTTP` on a nil address, long after the form was submitted. Always request the resource's full `endpoint`.
+:::
 
 ## Debug console
 

--- a/docs/4.0/http-resource.md
+++ b/docs/4.0/http-resource.md
@@ -175,7 +175,10 @@ class Avo::AuthorsController < Avo::Core::Controllers::Http
     response = if action_name == "create"
       HTTParty.post(endpoint, body: body, headers: headers, timeout: 10)
     else
-      HTTParty.patch("#{endpoint}/#{@record.id}", body: body, headers: headers, timeout: 10)
+      # `to_param` + encoding, like the client: a raw id breaks the moment a
+      # resource obfuscates it (see `model_class_eval`) or it contains a
+      # reserved character.
+      HTTParty.patch("#{endpoint}/#{ERB::Util.url_encode(@record.to_param)}", body: body, headers: headers, timeout: 10)
     end
 
     response.success?


### PR DESCRIPTION
Follow-up to [AVO-1745](https://linear.app/avo-hq/issue/AVO-1745), where creating an HTTP user on avodemo crashed with `undefined method 'include?' for nil` from Net::HTTP.

The app's `save_record` requested a relative path (`post("")`) off a client with no `base_uri`, so the request had no host. The **guide's example has the same shape** — `MyCustomApi.post("/authors", ...)` — which is where the pattern came from.

- The override example now builds from `resource.endpoint` and evaluates `resource.headers` through `Avo::ExecutionContext` (the headers option accepts a proc), plus a warning explaining why a relative path cannot work.
- `http-resource-api.md` documents that `endpoint` must be absolute: a missing, blank, or relative value raises `Avo::HttpError` before the request is sent (shipping in `avo-http_resource`, avo-hq/workspace#219).
- The headers section now says writes carry the configured headers too — they previously reached only index/show/count, fixed in the same gem PR.

`npx vitepress build docs` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes with no runtime or security impact.
> 
> **Overview**
> **Documentation fixes** for HTTP Resources so custom `save_record` overrides and adapter options match real client behavior and avoid the relative-URL / nil-host failures seen in production.
> 
> The guide’s **`save_record` example** no longer uses relative paths on a client with no `base_uri`. It now builds URLs from `resource.endpoint`, evaluates `resource.headers` via `Avo::ExecutionContext` (including proc headers), uses `HTTParty` with an explicit **10s timeout**, and adds a warning that hand-rolled requests must use absolute URLs.
> 
> The **API reference** documents that **`endpoint` must be absolute** — missing, blank, or relative values raise `Avo::HttpError` before any request (behavior described as shipping in `avo-http_resource`). The **headers** section clarifies that configured headers apply to **create, update, and destroy** as well as index/show/count, and the default CRUD section cross-links that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c35355fb34896a0c8c2c03173fd1b8efadd1c0b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->