### PR TITLE
Document how Avo displays HEIC and other non-web image formats

### DIFF
--- a/docs/4.0/common/file_other_common.md
+++ b/docs/4.0/common/file_other_common.md
@@ -1,8 +1,8 @@
 ## Displaying images
 
-Avo displays an attachment browsers can paint — PNG, JPEG, GIF, and anything else listed in `Rails.application.config.active_storage.web_image_content_types` — straight from storage.
+Avo displays an attachment straight from storage — PNG, JPEG, GIF, WebP, AVIF, and everything else browsers know how to paint.
 
-Every other format Active Storage counts as an image (HEIC and HEIF straight off an iPhone, TIFF, PSD) is displayed through an Active Storage variant, which renders it as PNG. Only Safari decodes HEIC, so the original would be a broken image in Chrome, Edge, and Firefox.
+Four formats they don't get converted first: `image/heic` and `image/heif` (what an iPhone shoots by default), `image/tiff`, and `image/vnd.adobe.photoshop`. Avo displays those through an Active Storage variant, which renders them as PNG. Only Safari decodes HEIC, so the original would be a broken image in Chrome, Edge, and Firefox.
 
 :::warning
 Converting needs an image processor installed — [libvips](https://github.com/libvips/libvips) built with `libheif`, or ImageMagick with the HEIC delegate. Without one the variant can't be processed and the image won't render. See [Active Storage's requirements](https://guides.rubyonrails.org/active_storage_overview.html#requirements).

--- a/docs/4.0/common/file_other_common.md
+++ b/docs/4.0/common/file_other_common.md
@@ -1,3 +1,13 @@
+## Displaying images
+
+Avo displays an attachment browsers can paint — PNG, JPEG, GIF, and anything else listed in `Rails.application.config.active_storage.web_image_content_types` — straight from storage.
+
+Every other format Active Storage counts as an image (HEIC and HEIF straight off an iPhone, TIFF, PSD) is displayed through an Active Storage variant, which renders it as PNG. Only Safari decodes HEIC, so the original would be a broken image in Chrome, Edge, and Firefox.
+
+:::warning
+Converting needs an image processor installed — [libvips](https://github.com/libvips/libvips) built with `libheif`, or ImageMagick with the HEIC delegate. Without one the variant can't be processed and the image won't render. See [Active Storage's requirements](https://guides.rubyonrails.org/active_storage_overview.html#requirements).
+:::
+
 ## Authorization
 
 :::info


### PR DESCRIPTION
Companion to avo-hq/avo#4738.

Avo now serves images browsers can't paint (HEIC/HEIF off an iPhone, TIFF, PSD) through an ActiveStorage variant, which renders them as PNG; web image types keep serving the original. The new section lands in `common/file_other_common.md`, so it shows on both the `file` and `files` field pages, and warns that the conversion needs an image processor with HEIC support installed.

`npx vitepress build docs` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 179a32254a46b386c8bd7d9c809c69521df83cc7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->