### PR TITLE
Document number field display formats

### DIFF
--- a/docs/4.0/field-options-api.md
+++ b/docs/4.0/field-options-api.md
@@ -193,7 +193,7 @@ Formatter blocks are executed in [`Avo::ExecutionContext`](./execution-context.h
 Formats the field's value on **every** view — including the value rendered inside inputs on the form views.
 
 ```ruby
-field :price, as: :number, format_using: -> { view_context.number_to_currency(value) }
+field :code, as: :text, format_using: -> { value.to_s.upcase }
 ```
 
 - **Type:** Proc
@@ -220,6 +220,7 @@ View-scoped variants of [`format_using`](#format_using). Each one formats the va
 
 ```ruby
 field :is_writer, format_display_using: -> { value.present? ? "👍" : "👎" }
+field :price, as: :number, format_display_using: -> { number_to_currency(value) }
 ```
 
 - **Type:** Proc

--- a/docs/4.0/field-options.md
+++ b/docs/4.0/field-options.md
@@ -120,10 +120,10 @@ field :is_writer, format_display_using: -> { value.present? ? '👍' : '👎' }
 
 ### With Rails helpers
 
-You can format using Rails helpers like `number_to_currency` (note that `view_context` is used to access the helper):
+You can call Rails helpers such as `number_to_currency` directly inside a formatter. Use a display formatter when the result is not a valid form input value:
 
 ```ruby
-field :price, as: :number, format_using: -> { view_context.number_to_currency(value) }
+field :price, as: :number, format_display_using: -> { number_to_currency(value) }
 ```
 
 ## Parse the value before saving

--- a/docs/4.0/fields/number.md
+++ b/docs/4.0/fields/number.md
@@ -53,6 +53,44 @@ Set the `step` attribute.
 Any number.
 </Option>
 
+<Option name="`format`">
+
+Formats the value on the <Index /> and <Show /> views. Form inputs always keep the raw number.
+
+#### Default value
+
+`nil`
+
+#### Possible values
+
+`:delimited`, `:currency`, `:percentage`, or `:human`.
+</Option>
+
+## Formatting numbers
+
+Use `format` for the common display formats provided by Rails:
+
+```ruby
+field :population, as: :number, format: :delimited
+field :price, as: :number, format: :currency
+field :margin, as: :number, format: :percentage
+field :downloads, as: :number, format: :human
+```
+
+`format: :currency` uses `Avo.configuration.currency`. The other punctuation and wording come from Rails i18n, so delimiters and decimal separators follow the current locale.
+
+On the <Index /> view, formatted numbers and their headers are end-aligned. Bare number fields remain unformatted and start-aligned, which is useful for identifier- or year-shaped values. All number columns use tabular figures so their digits line up between rows.
+
+For formatting that these four values do not cover, use [`format_display_using`](../field-options.html#on-specific-views). Rails helpers are available directly inside the block:
+
+```ruby
+field :price_in_cents,
+  as: :number,
+  format_display_using: -> { number_to_currency(value / 100.0) }
+```
+
+`format_display_using` affects only <Index /> and <Show />, so the <Edit /> and <New /> inputs keep a valid raw numeric value. A custom display formatter takes precedence when it is combined with `format`.
+
 ## Examples
 
 ```ruby


### PR DESCRIPTION
# Description

Documents the new number field display formats introduced by AVO-1385.

- Documents all supported `format:` values
- Explains display-only formatting and table alignment
- Covers locale and currency behavior
- Points custom formatting users to `format_display_using`
- Fixes an unsafe example that applied currency formatting to form inputs
- Removes the unnecessary `view_context` prefix from Rails helper examples

Linear: AVO-1385

## Verification

- VitePress build passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 564658f21ab73d75ec9daee9466fda10313688cc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->