### PR TITLE
docs(ai): the assistant answers with your schema instead of inspecting first

### DIFF
--- a/docs/4.0/ai-agents-and-tools.md
+++ b/docs/4.0/ai-agents-and-tools.md
@@ -8,7 +8,7 @@ outline: [2, 3]
 
 Avo AI is built from two kinds of pieces. **Agents** are the model-facing side: each one pairs a system prompt with a set of tools and drives a conversation with the provider. **Tools** are the Rails-facing side: typed abilities that run inside your application, against your policies, and report back to the model.
 
-This page is the reference for both — which agents exist, what every tool does, and how conversations get their names. For the narrative of how a chat turn unfolds (inspect-first, confirmation cards, authorization), see [How the assistant works](./ai.html#how-the-assistant-works).
+This page is the reference for both — which agents exist, what every tool does, and how conversations get their names. For the narrative of how a chat turn unfolds (schema, confirmation cards, authorization), see [How the assistant works](./ai.html#how-the-assistant-works).
 
 ## The agents
 
@@ -25,7 +25,7 @@ A second, much smaller agent does exactly one job: reading a conversation's mess
 It runs on three occasions:
 
 - automatically, after the first message of a new conversation
-- when you pick **Rename again with AI** from the ⋯ menu, in the chat bar or on a chat page
+- when you pick **Rename with AI** from the ⋯ menu, in the chat bar or on a chat page
 - when you ask the assistant to rename the conversation without giving it a name
 
 All three go through the `rename_conversation` tool, so [excluding that tool](./ai.html#take-a-tool-away) switches the renamer off along with it — unless you registered a replacement under the same wire name (as [ejecting it](./ai.html#replace-a-shipped-tool-with-your-own-copy) does), in which case the renamer uses your copy. Naming a chat by hand keeps working.
@@ -40,7 +40,7 @@ A tool's name is the stable part of it: the model calls the tool by that name, e
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------- |
 | `ask_user`                   | Asks you one clarifying question — free-form, or with clickable options — then ends the turn                         | —                 |
 | `schema_inspector`           | Reports the database structure — scoped to the resources the signed-in user is allowed to see                        | read-only         |
-| `resource_inspector`         | Reads one resource's real columns, associations, and scopes; unlocks querying and writing that resource              | read-only         |
+| `resource_inspector`         | The deep report on one resource: field types, actions, filters, associations, attachments                           | read-only         |
 | `active_record_query`        | Runs read-only, paginated, policy-scoped queries against a resource — filters, scopes, grouping, and free-text search through the resource's own [configured search](./search.html) | read-only         |
 | `active_storage_insights`    | Storage reports — totals, orphans, duplicates, growth, biggest files — and finding/showing files                     | read-only         |
 | `active_storage_attachment`  | Attaches or detaches a Media Library blob (or a chat upload) on a record's attachment; can also fetch a URL onto one | immediately¹      |
@@ -76,11 +76,13 @@ A tool only accepts from the model the arguments listed in its schema — a reso
 
 That is a deliberate security boundary. There is no argument the model could invent to act as a different user, and no id it could pass to rename or read a conversation other than the one it is speaking in. Combined with [authorization at the tool layer](./ai.html#how-the-assistant-works), it means a prompt-injection attempt riding in on your data has no lever to reach beyond what the chat's owner could already do in the Avo UI.
 
-### The inspection gate
+### Schema comes back with the answer
 
-The query and write tools refuse to touch a resource until `resource_inspector` has run for it in the conversation. The gate is enforced in the tools — not merely requested in the prompt — and is what makes the assistant work from your real columns and scopes instead of guessed ones. Excluding `resource_inspector` turns the gate off along with the tool — the queries and writes then proceed uninspected rather than refusing.
+Every result the query, write, and action tools return carries the resource it touched under `resource_schema`: its real columns and their types, the model's named scopes, and the attributes a create cannot omit. Success or error alike — a query that names a column you don't have comes back with the ones you do. This is done in the tools, not merely requested in the prompt, and is what makes the assistant work from your real columns and scopes instead of guessed ones, without spending a round trip asking first.
 
-`run_action` sits behind the same gate, and adds two of its own: the resource's `act_on?` policy method and the action's `self.authorize` block, both checked when the run is proposed and again when you confirm it. See [What it's allowed to run](./ai.html#what-it-s-allowed-to-run).
+It is sent once per resource per turn, and only for resources the signed-in user is allowed to list. `resource_inspector` remains for the deeper report — field types, a resource's actions and filters, its associations and attachments — when the assistant wants structure it cannot get from a result. Excluding it costs you that report, not the grounding: every result still comes back with its schema.
+
+`run_action` adds two checks of its own: the resource's `act_on?` policy method and the action's `self.authorize` block, both checked when the run is proposed and again when you confirm it. See [What it's allowed to run](./ai.html#what-it-s-allowed-to-run).
 
 ## Renaming conversations
 
@@ -90,7 +92,7 @@ After that, renaming is a chat feature like any other:
 
 - **"rename this conversation to 'Q3 invoices'"** — the assistant passes your exact wording to `rename_conversation` and the title applies immediately.
 - **"rename this conversation"** — with no name given, the assistant triggers the renamer agent instead of inventing a title itself. The regenerated title reflects where the conversation actually went, not just how it started.
-- **Rename again with AI** does the same regeneration without involving the assistant. It sits in the ⋯ menu, both in the chat bar and on a full-page chat.
+- **Rename with AI** does the same regeneration without involving the assistant. It sits in the ⋯ menu, both in the chat bar and on a full-page chat.
 - **Rename chat**, in the same menu, skips the model entirely: the title becomes editable in place and what you type is what it's called. See [The conversation menu](./ai.html#the-conversation-menu).
 
 Wherever the conversation's name is on screen, it updates live when a rename lands — the chat's tab in the floating bar, the breadcrumb on its full-page view, and the title, name field, and breadcrumb on its resource page.

--- a/docs/4.0/ai-what-you-can-ask.md
+++ b/docs/4.0/ai-what-you-can-ask.md
@@ -10,7 +10,7 @@ A catalog of what the Avo AI assistant can do, with a prompt for each one. Every
 
 The resource and field names in the examples are placeholders. Substitute your own: the assistant reads your resources, your columns, and your scopes at the moment you ask, so the vocabulary that works is the vocabulary of your admin.
 
-For how a turn actually unfolds — inspect-first, confirmation cards, authorization — see [How the assistant works](./ai.html#how-the-assistant-works). For the tool-by-tool reference, see [Agents and tools](./ai-agents-and-tools.html).
+For how a turn actually unfolds — schema, confirmation cards, authorization — see [How the assistant works](./ai.html#how-the-assistant-works). For the tool-by-tool reference, see [Agents and tools](./ai-agents-and-tools.html).
 
 ## Find records
 
@@ -152,7 +152,7 @@ The files stay on the message, so you can keep asking about them later in the co
 
 New conversations title themselves after your first message. See [Renaming conversations](./ai-agents-and-tools.html#renaming-conversations).
 
-You don't have to ask, either. The ⋯ menu next to the title renames the conversation without the assistant — **Rename chat** to type the title yourself, **Rename again with AI** to have one generated — and the bar's menu adds **Copy as markdown**, which puts the conversation on your clipboard as plain text. See [The conversation menu](./ai.html#the-conversation-menu).
+You don't have to ask, either. The ⋯ menu next to the title renames the conversation without the assistant — **Rename chat** to type the title yourself, **Rename with AI** to have one generated — and the bar's menu adds **Copy as markdown**, which puts the conversation on your clipboard as plain text. See [The conversation menu](./ai.html#the-conversation-menu).
 
 ## What it won't do
 

--- a/docs/4.0/ai.md
+++ b/docs/4.0/ai.md
@@ -437,7 +437,11 @@ That writes `app/tools/crm_tool.rb`, defining `CrmTool` — a `RubyLLM::Tool` th
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------- |
 | `Avo::Ai::ToolSupport` | `json_result` for the reply shape, plus resource lookup and schema introspection helpers |
 | `Avo::Ai::ToolAuthorization` | The acting user, and the gates to reach data through: `require_acting_user!`, `authorized_relation`, `authorize_record_action!` |
-| `Avo::Ai::InspectionAware` | Answers with the touched resource's real columns, scopes, and required attributes under `resource_schema` — once per run per resource |
+| `Avo::Ai::InspectionAware` | Answers with the touched resource's real columns, scopes, and required attributes under `resource_schema` — once per run per resource. It reads the resource name from your tool's own `resource:` argument |
+
+:::warning Include `InspectionAware` in the tool class itself
+It wraps your `execute` by prepending to the class it's included in. Included in a concern your tools share, the wrapper ends up *behind* each tool's own `execute` and never runs — no error, just results that quietly arrive without their schema.
+:::
 
 Fill in the `description` — the model reads it to decide whether to call the tool, and a vague one is the usual reason a tool never gets called — then the `parameters` schema and `execute`.
 

--- a/docs/4.0/ai.md
+++ b/docs/4.0/ai.md
@@ -202,7 +202,7 @@ Every message you send starts a fresh turn against the provider, built from thre
 
 **The system prompt is rebuilt on every turn.** It's assembled from the ERB files under `app/prompts/`, so it always reflects the current date, the signed-in user, the record the chat is attached to, and any instructions you've added. Nothing about your schema is baked in ahead of time.
 
-**It inspects before it queries.** The first time a conversation touches a resource, the assistant asks for that resource's real columns, associations, and scopes, then builds its query from the answer. This is enforced by the tools, not merely requested in the prompt: the query and write tools refuse to run against a resource that hasn't been inspected in this conversation. It's why the first question about a resource takes an extra beat, and why the assistant uses your scopes — `cancelled`, `published` — instead of guessing at column filters.
+**It works from your real schema, not a guess at it.** Every query, write, and action result carries the resource's real columns, model scopes, and required attributes back to the assistant — so it builds what comes next from your names. This is done by the tools, not merely requested in the prompt: it arrives with the answer rather than being asked for first, which is why a question rarely spends a round trip on structure, and why the assistant uses your scopes — `cancelled`, `published` — instead of guessing at column filters. A query that gets a column wrong comes back with the real ones attached, so the retry is built from names too.
 
 **Reading.** Query results are paginated, and the assistant is told to answer "how many" from the result's total count rather than by counting rows, so a capped result set doesn't become a wrong number. When a query returns exactly one record, the UI renders a card for it — title and a link — and the assistant is told not to repeat the fields in prose.
 
@@ -415,10 +415,10 @@ A name that isn't one of the twelve raises `ArgumentError` at boot, listing the 
 
 Nothing is protected. `ask_user` and `write_history` are chat infrastructure rather than data tools, and excluding them is allowed: the assistant loses the ability to ask you a clarifying question, or to list and undo the writes it made in the conversation. That's a decision you're free to make — just make it deliberately.
 
-Excluding `resource_inspector` takes the [inspection gate](./ai-agents-and-tools.html#the-inspection-gate) with it: the tool is the only way the gate can ever be satisfied, so with it gone, queries and writes proceed without an inspection instead of refusing forever. Less introspection, not a dead assistant — but the assistant now works from guessed columns rather than real ones.
+Excluding `resource_inspector` costs less than it sounds like it should. The [schema every result carries](./ai-agents-and-tools.html#schema-comes-back-with-the-answer) doesn't come from that tool, so queries and writes still work from your real columns and scopes. What you lose is the deeper report — field types, a resource's actions and filters, its associations and attachments — for the questions where the assistant wants structure a result can't give it.
 
 :::warning Excluding `rename_conversation` turns AI titling off entirely
-That tool is what applies a title, so removing it stops the [conversation renamer](./ai-agents-and-tools.html#renaming-conversations) too, not just the assistant's ability to rename on request: new conversations are no longer auto-titled after the first message, and **Rename again with AI** stops having an effect. Conversations keep the *Untitled chat* placeholder until someone names them. **Rename chat** still works — that one never goes through a model.
+That tool is what applies a title, so removing it stops the [conversation renamer](./ai-agents-and-tools.html#renaming-conversations) too, not just the assistant's ability to rename on request: new conversations are no longer auto-titled after the first message, and **Rename with AI** stops having an effect. Conversations keep the *Untitled chat* placeholder until someone names them. **Rename chat** still works — that one never goes through a model.
 
 The exception is a replacement: register your own tool under the `rename_conversation` wire name — which is exactly what [ejecting it](#replace-a-shipped-tool-with-your-own-copy) sets up — and titling continues through your copy.
 :::
@@ -437,7 +437,7 @@ That writes `app/tools/crm_tool.rb`, defining `CrmTool` — a `RubyLLM::Tool` th
 | ------------------------------ | ----------------------------------------------------------------------------------------------------------- |
 | `Avo::Ai::ToolSupport` | `json_result` for the reply shape, plus resource lookup and schema introspection helpers |
 | `Avo::Ai::ToolAuthorization` | The acting user, and the gates to reach data through: `require_acting_user!`, `authorized_relation`, `authorize_record_action!` |
-| `Avo::Ai::InspectionAware` | `inspection_tracker`, the per-run record of which resources have been inspected |
+| `Avo::Ai::InspectionAware` | Answers with the touched resource's real columns, scopes, and required attributes under `resource_schema` — once per run per resource |
 
 Fill in the `description` — the model reads it to decide whether to call the tool, and a vague one is the usual reason a tool never gets called — then the `parameters` schema and `execute`.
 
@@ -462,7 +462,7 @@ Entries are class **names**, not constants: this initializer runs before your ow
 
 Three things the server decides for you, whatever the entry says:
 
-- **The acting user, the conversation, and the inspection tracker are injected server-side.** `user:` is passed to your initializer when it accepts one, and `chat` / `inspection_tracker` are set afterwards if your tool declares the accessors (the generated one declares `chat`). `user:`, `chat:` and `inspection_tracker:` keys in an `extra_tools` entry are stripped, so the initializer can't hand your tool a different user than the one who's chatting.
+- **The acting user, the conversation, and the inspection tracker are injected server-side.** `user:` is passed to your initializer when it accepts one, and `chat` / `inspection_tracker` are set afterwards if your tool declares the accessors (the generated one declares `chat` and picks up `inspection_tracker` from `Avo::Ai::InspectionAware`). `user:`, `chat:` and `inspection_tracker:` keys in an `extra_tools` entry are stripped, so the initializer can't hand your tool a different user than the one who's chatting.
 - **Authorization is yours to call.** Nothing in the gem stops a tool reading the whole table — reach data through `authorized_relation` and `authorize_record_action!` so your tool sees exactly what the signed-in user sees in Avo, and rescue `Avo::Ai::ToolAuthorization::IdentityError` to report "not allowed" as a result instead of failing the run.
 - **Two tools can't share a wire name.** Registering a tool whose name collides with a shipped one raises when the roster is built. To replace a shipped tool, exclude it first — that's what [ejecting](#replace-a-shipped-tool-with-your-own-copy) does for you.
 
@@ -574,7 +574,7 @@ The list is scoped to the signed-in user. It's not an admin view of everyone's c
 The ⋯ button next to a conversation's title opens its menu. It's in the chat window's title bar and on the full-page chat, and both carry the same two rename entries:
 
 - **Rename chat** makes the title editable in place — the panel's header in the bar, the last breadcrumb on a chat page. **Enter** commits and **Esc** cancels in both. Clicking away differs: in the bar it cancels the edit, on the chat page it commits it. An empty title is refused, so a conversation always keeps a name.
-- **Rename again with AI** hands the conversation back to the [renamer agent](./ai-agents-and-tools.html#renaming-conversations) for a fresh title, without going through the assistant. The title shimmers while the renamer runs, and the new name lands everywhere the old one showed.
+- **Rename with AI** hands the conversation back to the [renamer agent](./ai-agents-and-tools.html#renaming-conversations) for a fresh title, without going through the assistant. The title shimmers while the renamer runs, and the new name lands everywhere the old one showed.
 
 Renaming needs no policy of its own — owning the chat is the entire permission, and you only ever see your own.
 


### PR DESCRIPTION
Docs for avo-hq/workspace#227, which replaces the assistant's inspect-first gate with schema that comes back attached to every answer.

## What changed for the reader

**`ai.md`** — "It inspects before it queries" was the narrative bullet describing how a turn unfolds, and it is no longer what happens. Rewritten as working from your real schema: every query, write and action result carries the resource's real columns, model scopes and required attributes, so the assistant builds what comes next from your names without spending a round trip asking first. A query that gets a column wrong now comes back with the real ones attached, so the retry is grounded too.

**`ai-agents-and-tools.md`** — "The inspection gate" section replaced by "Schema comes back with the answer". The old text described a rule that no longer exists ("the query and write tools refuse to touch a resource until `resource_inspector` has run for it"). The new one says what is sent, when it is *not* re-sent (once per resource per turn), and that it only covers resources the signed-in user may list. `run_action`'s own two authorization checks are unchanged and stay where they were.

The `resource_inspector` row in the tool table no longer claims it "unlocks querying and writing that resource" — it is the deeper report now: field types, actions, filters, associations, attachments.

**`ai-what-you-can-ask.md`** — the cross-reference calling a turn "inspect-first".

## Also

The ⋯ menu entry is now **Rename with AI**, not "Rename again with AI" — "again" read as a repeat of something the reader may never have done. Updated on all three pages that quote it.

## Verification

`npx vitepress build docs` — clean.

https://claude.ai/code/session_017hB3u4azv9bMt9tzMywaQY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration impact.
> 
> **Overview**
> Updates Avo AI documentation to match behavior where **query, write, and action results attach `resource_schema`** (columns, scopes, required attributes) instead of requiring **`resource_inspector` before other tools run**.
> 
> **`ai.md`** rewrites the “how a turn works” bullet from inspect-first to schema-with-the-answer, including wrong-column retries. **`excluded_tools`** guidance for `resource_inspector` now says you lose the deep report, not column grounding. Custom-tool docs describe **`Avo::Ai::InspectionAware`** as emitting `resource_schema` once per resource per turn.
> 
> **`ai-agents-and-tools.md`** replaces **“The inspection gate”** with **“Schema comes back with the answer”**, narrows **`resource_inspector`** to the deep report (actions, filters, associations), and keeps **`run_action`** authorization unchanged.
> 
> Cross-links on **`ai-what-you-can-ask.md`** and related pages switch **inspect-first** → **schema**. The ⋯ menu label is standardized to **Rename with AI** (was “Rename again with AI”) on all pages that quote it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d70d97b43a6e7393cfc290cbb54f17fbb8d0852a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->