### PR TITLE
Document Media Library files and conversations as chat context

### DIFF
--- a/docs/4.0/ai-agents-and-tools.md
+++ b/docs/4.0/ai-agents-and-tools.md
@@ -14,7 +14,7 @@ This page is the reference for both — which agents exist, what every tool does
 
 ### The chat agent
 
-The chat agent powers every conversation — the floating bar, full-page chats, and chats attached to a record. On every message it rebuilds its system prompt from the ERB files under `app/prompts/` (which is what keeps the current date, signed-in user, and attached record fresh) and assembles its tool roster for the signed-in user who owns the chat.
+The chat agent powers every conversation — the floating bar, full-page chats, and chats attached to a record. On every message it rebuilds its system prompt from the ERB files under `app/prompts/` (which is what keeps the current date, signed-in user, and [attached subject](./ai.html#what-you-start-the-chat-from) fresh) and assembles its tool roster for the signed-in user who owns the chat.
 
 The roster is built per run, not baked in: what the assistant can do in a conversation always reflects your current [tool configuration](./ai.html#choose-which-tools-the-assistant-gets), and every call it then makes is authorized against your policies at that moment.
 
@@ -85,6 +85,8 @@ The query and write tools refuse to touch a resource until `resource_inspector` 
 ## Renaming conversations
 
 A new conversation starts without a name and gets one automatically after your first message — the renamer reads the opening of the conversation and titles it.
+
+The renamer is its own agent and never receives the conversation's images, so it's given the names of any files you attached alongside the text. A message whose whole subject is the file it carries — "what do you see here?" — is titled from the filename rather than from a question that names nothing. A reply that isn't a plausible title (one that asks a question, or runs long) is dropped instead of applied, so the conversation stays *Untitled chat* rather than being named after the model's request to see the image.
 
 After that, renaming is a chat feature like any other:
 

--- a/docs/4.0/ai-what-you-can-ask.md
+++ b/docs/4.0/ai-what-you-can-ask.md
@@ -124,16 +124,29 @@ Required inputs you didn't mention arrive as empty fields on the card for you to
 
 Files are referenced by blob id, and the Media Library URL carries one: `/avo/media-library/260/edit` is blob 260. The assistant never uploads bytes itself — a file gets in either by riding along on your message or through a URL you confirm. Purging a file stays a manual action. See [Files and attachments](./ai.html#files-and-attachments) and [Getting new files in](./ai.html#getting-new-files-in).
 
-## Ask about the record you're on
+## Ask about the page you're on
 
-Start a chat from a record's page and "this" is already resolved — for the whole conversation, not just the first message.
+Start a chat from a page whose subject is one thing and "this" is already resolved — for the whole conversation, not just the first message.
+
+From a record's page:
 
 - **"What is this?"**
 - **"Who owns it?"**
 - **"Set its status to active"**
 - **"Is anything missing here?"**
 
-A ribbon above the composer names the attached record, and the ✕ at its end starts the chat without it. See [The record you start from](./ai.html#the-record-you-start-from).
+From one [Media Library](./media-library.html) file's page:
+
+- **"What is this?"**
+- **"Where is this used?"** — every record the file is attached to
+- **"Attach this to the latest post's cover"**
+
+From a conversation's page, starting a new chat from the bar:
+
+- **"Summarize this"**
+- **"What did we decide here?"**
+
+A ribbon above the composer names the subject, and the ✕ at its end — or <kbd>Backspace</kbd> in an empty composer — starts the chat without it. See [What you start the chat from](./ai.html#what-you-start-the-chat-from).
 
 ## Ask about a file you sent
 

--- a/docs/4.0/ai.md
+++ b/docs/4.0/ai.md
@@ -200,7 +200,7 @@ signed in.
 
 Every message you send starts a fresh turn against the provider, built from three things: a system prompt, the conversation so far, and a set of tools. The model can't see your database — it only ever learns about your data by calling a tool and reading what comes back.
 
-**The system prompt is rebuilt on every turn.** It's assembled from the ERB files under `app/prompts/`, so it always reflects the current date, the signed-in user, the record the chat is attached to, and any instructions you've added. Nothing about your schema is baked in ahead of time.
+**The system prompt is rebuilt on every turn.** It's assembled from the ERB files under `app/prompts/`, so it always reflects the current date, the signed-in user, [what the chat was started from](#what-you-start-the-chat-from), and any instructions you've added. Nothing about your schema is baked in ahead of time.
 
 **It inspects before it queries.** The first time a conversation touches a resource, the assistant asks for that resource's real columns, associations, and scopes, then builds its query from the answer. This is enforced by the tools, not merely requested in the prompt: the query and write tools refuse to run against a resource that hasn't been inspected in this conversation. It's why the first question about a resource takes an extra beat, and why the assistant uses your scopes — `cancelled`, `published` — instead of guessing at column filters.
 
@@ -525,25 +525,50 @@ Each place that renders the icon passes a `classes` local, because the sizes dif
 
 The icon on the chat pages' breadcrumb isn't part of the partial and stays an avocado.
 
-## The record you start from
+## What you start the chat from
 
-Start a conversation from a record's page and the assistant already knows which record you mean. You can ask "who owns this?", "what is this?", or "rename this to Q3 pricing" without naming the record or waiting for a lookup.
+Start a conversation from a page whose subject is one thing and the assistant already knows what you mean. You can ask "who owns this?", "what is this?", or "rename this to Q3 pricing" without naming it or waiting for a lookup. Three kinds of page carry a subject:
 
-A ribbon above the composer names the record, so it's never a guess: the resource and the record's title, sitting behind the message box. On pages that aren't a single record — an index, a dashboard, a new-record form — there is no ribbon and no button, because there is nothing to attach.
+| Started from                                        | What the chat carries               | What "this", "it", or a question with no subject resolves to |
+| --------------------------------------------------- | ----------------------------------- | ------------------------------------------------------------ |
+| A record's page                                     | The resource name and the record id | That record                                                   |
+| A [Media Library](./media-library.html) file's page | The Active Storage blob id          | That file                                                     |
+| A conversation's page                               | The chat, itself a record           | That conversation                                             |
 
-**The record stays attached for the whole conversation.** It's the record the chat was *started from*, so you're asked once, when the chat begins — that's why the ribbon is on the new-chat composer only. Every later message still resolves "this record", "it", or a question with no subject at all against the same record. Ask "what is this?" as the fifth message and it works exactly as it does as the first.
+A ribbon above the composer names the subject, so it's never a guess: what it is and what it's called, sitting behind the message box. A record shows its avatar or its initials — the same pair the breadcrumbs show — and a file shows its own thumbnail when it has one. On pages that aren't about a single subject — an index, a dashboard, a new-record form — there is no ribbon and no button, because there is nothing to attach.
 
-Dismiss the ribbon with the ✕ at its end and the chat starts without it. The button next to send toggles it back on, and lights up whenever the record is attached, so the ribbon and the button always agree about what the chat will carry. Every fresh compose view offers the record again: the ✕ applies to the chat you're writing, not to the feature.
+**The subject stays attached for the whole conversation.** It's what the chat was *started from*, so you're asked once, when the chat begins — that's why the ribbon is on the new-chat composer only. Every later message still resolves "this record", "this file", "it", or a question with no subject at all against the same thing. Ask "what is this?" as the fifth message and it works exactly as it does as the first.
 
-It respects your policies, on every message. Only a reference is kept — the resource name and the record id, never the title or any field value. That reference is resolved again on each turn, through the same authorization the assistant's other tools use (`index?` plus your Pundit scope), and the record's title is read fresh at that moment. So a record the user loses access to, or that gets deleted mid-conversation, simply drops out of the prompt instead of lingering as a stale copy of something they can no longer see. The attachment is only a starting point either way — every read and write the assistant then performs is authorized on its own.
+Dismiss the ribbon with the ✕ at its end, or press <kbd>Backspace</kbd> in an empty composer, and the chat starts without it. Backspace only ever removes — pressing it again can't attach the subject back — so clearing the message box can't put back something you meant to drop. The button next to send toggles it back on, and lights up whenever the subject is attached, so the ribbon and the button always agree about what the chat will carry. Every fresh compose view offers the subject again: the ✕ applies to the chat you're writing, not to the feature.
 
-The wording lives in a prompt file like the rest, so you can change how the assistant treats it:
+It respects your policies, on every message. Only a reference is kept — the resource name and the record id, or the blob id — never a title, a filename, or any field value. That reference is resolved again on each turn, through the same authorization the page itself applies — `index?` plus your Pundit scope for a record, Media Library access for a file — and the label is read fresh at that moment. So a subject the user loses access to, or that gets deleted mid-conversation, simply drops out of the prompt instead of lingering as a stale copy of something they can no longer see. The attachment is only a starting point either way — every read and write the assistant then performs is authorized on its own.
+
+### Starting from a Media Library file
+
+Open one file in the [Media Library](./media-library.html) and start a chat from its page: that file is the subject. "What is this?", "where is this used?", and "attach this to the latest post" all resolve to it — and "where is this used?" comes back naming every record the file is attached to, which is the question a file's page most often raises.
+
+The gate is Media Library access, and it's the same one the page itself applies: a user who can open the library can open any file's page in it, so there is no narrower per-file check to add on top. Turn the Media Library off, or narrow its [`visible`](./media-library.html#control-who-can-use-it) block to fewer admins, and the file drops out of every prompt at once rather than the context outliving the access it was granted under.
+
+Only the blob id is stored. The filename and content type are read off the blob on each turn, so a file renamed mid-conversation is named correctly on the very next message.
+
+### Starting from a conversation
+
+A chat is stored as a record, so its own page offers it the way any record's page does. Open a conversation, start a *new* chat from the bar, and "summarize this", "what did we decide here?", or "who was this with?" resolve to the conversation you were reading — no copying and pasting a transcript into the new chat.
+
+### Change how it reads
+
+The wording lives in a prompt file like the rest, so you can change how the assistant treats the subject:
 
 ```bash
 bin/rails generate avo:ai:eject instructions
 ```
 
-Then edit `app/prompts/avo/ai/chat_agent/attached_context.txt.erb`. It receives an `attached_record` local — `{resource:, record_id:, label:}`, or `nil` when the conversation wasn't started from a record — and rendering nothing is a valid way to turn the feature off.
+Then edit `app/prompts/avo/ai/chat_agent/attached_context.txt.erb`. It receives one local per kind of subject, and a page offers one or the other:
+
+- `attached_record` — `{resource:, record_id:, label:}`, on a record's page.
+- `attached_file` — `{blob_id:, filename:, content_type:}`, on a Media Library file's page.
+
+Either is `nil` when the conversation started somewhere else, and rendering nothing is a valid way to turn the feature off.
 
 ## Open the chat
 


### PR DESCRIPTION
Daily docs sweep over yesterday's (2026-08-19) changes in `avo-hq/avo` and `avo-hq/workspace`. Most of the day was already documented — this covers what wasn't.

## What was missing

Yesterday's avo-ai work widened what a chat can be *started from* beyond a record, and none of it had reached the docs:

| Change | Where |
| --- | --- |
| A Media Library file's page attaches that file as the chat's subject | avo-hq/workspace#220 |
| A conversation's own page offers itself, so a new chat from the bar resolves "summarize this" | avo-hq/workspace#220 |
| <kbd>Backspace</kbd> in an empty composer dismisses the context ribbon, one-way | avo-hq/workspace#221 |
| The renamer is given attached filenames, and drops a reply that isn't a plausible title | avo-hq/workspace#220 |

## Changes

**`docs/4.0/ai.md`** — renamed `## The record you start from` to `## What you start the chat from`, since it now covers three kinds of subject, and reworked the section around that:

- A table of the three page kinds, what each stores, and what "this" resolves to.
- `### Starting from a Media Library file` — the authorization story (Media Library access is the gate, deliberately the same one the page itself applies, so narrowing `visible` drops the file out of every prompt at once) and the fact that only the blob id is stored, with the filename re-read each turn.
- `### Starting from a conversation`.
- Backspace as a second way to dismiss the ribbon, and that it's one-way.
- The eject section now documents both prompt locals: `attached_record` and the new `attached_file` (`{blob_id:, filename:, content_type:}`).

**`docs/4.0/ai-what-you-can-ask.md`** — `## Ask about the record you're on` → `## Ask about the page you're on`, with example asks per page kind.

**`docs/4.0/ai-agents-and-tools.md`** — a paragraph in *Renaming conversations* on the renamer seeing filenames and rejecting non-titles (the chat stays *Untitled chat* rather than being named after the model asking to see an image).

Also updated the two inbound references to the renamed anchor.

## One call left to you: an `upgrade.md` entry for the HEIC change?

Not done here, because it would mean adding an unreleased section to a page you keep ordered by release, and you may well have already decided against it when writing #660.

The case for one: `safe_image_url` now routes `image/heic`, `image/heif`, `image/tiff` and `image/vnd.adobe.photoshop` through a variant. For an app with HEIC uploads and **no** image processor, that's a small regression — the original used to be served (broken in Chrome/Edge/Firefox, fine in Safari), and the variant now fails to process, so it's broken in Safari too. The fallback in `safe_blob_representation_url` only rescues `ActionController::UrlGenerationError`, so it doesn't catch a processing failure. `docs/4.0/common/file_other_common.md` already states the processor requirement, so this would be an "Action required: None unless you have HEIC uploads and no libvips/ImageMagick" note rather than new information. Happy to add it if you want it.

Skipping the number-field entry deliberately — `format:` is a pure addition, and the tabular figures on id/number columns are typography already stated on `fields/number.md`.

## Already covered — no change needed

Checked and found current, so nothing was touched for these:

- avo#4739 number field display formats — `docs/4.0/fields/number.md` covers `:delimited`/`:percentage`/`:human`, the absent `:currency`, end-alignment of formatted columns, and tabular figures (#661).
- avo#4738 HEIC/HEIF/TIFF/PSD rendered through a PNG variant — `docs/4.0/common/file_other_common.md` (#660).
- workspace#219 `avo-http_resource` endpoint guard and headers on writes — `docs/4.0/http-resource-api.md` and `docs/4.0/http-resource.md` (#659).
- workspace#206–209 avo-ai tool namespacing, initializer toolset, generator, eject — `docs/4.0/ai.md` (#647).
- avo#4726, workspace#224/#225 — internal tooling, no customer-facing surface.

## Verification

- `npx vitepress build docs` — clean (dead links fail this build; the renamed anchor and new links resolve).
- `yarn generate-llms-4 && node scripts/generate-docs-map.js 4.0` — ran clean; the outputs are gitignored in this repo, so nothing to commit.