### PR TITLE
Document record chips in the AI chat

### DIFF
--- a/docs/4.0/ai-what-you-can-ask.md
+++ b/docs/4.0/ai-what-you-can-ask.md
@@ -16,13 +16,13 @@ For how a turn actually unfolds — inspect-first, confirmation cards, authoriza
 
 | Ask                                              | What you get                                                             |
 | ------------------------------------------------ | ------------------------------------------------------------------------ |
-| "Find the user with the email ada@example.com"   | The matching record, as a card with a link to open it                    |
+| "Find the user with the email ada@example.com"   | The matching record, named inline as a chip you can click                |
 | "Find the user called John Deere"                | The record — found by search, even when the name lives across several columns |
 | "Show me the 5 most recent posts"                | A short list, sorted by the timestamp that matches what you asked about  |
 | "Which users signed up in the last 7 days?"      | A date-filtered list, resolved against the real current time             |
 | "List projects whose name contains 'orbit'"      | A partial-match list                                                     |
 | "Show me every column for post 42"               | The full record, not just the common columns                             |
-| "Who signed up last?"                            | One record, rendered as a card                                           |
+| "Who signed up last?"                            | One record, named inline as a chip                                       |
 
 Ranges, sets, and emptiness all work in the same sentence-shaped way: "orders over $500", "users older than 26", "posts with no author", "projects in draft or review".
 
@@ -32,7 +32,16 @@ Ranges, sets, and emptiness all work in the same sentence-shaped way: "orders ov
 
 **Associations, without SQL.** "Which teams have no members?" and "show me users who have at least one order" are answered by checking whether the association exists, scoped to the child records you're allowed to see.
 
-When a query returns exactly one record, you get a card with its title and a link rather than a paragraph repeating its fields.
+**Records are named inline.** Any record the assistant mentions is rendered as a chip in the
+sentence itself — its picture, its title, and whatever status its resource declares — and clicking
+it opens the record. So "who signed up last?" reads as one sentence with the person in it, not as a
+paragraph followed by a card.
+
+A chip appears because the assistant named that record in its answer, which is why a count never
+brings one along: "how many projects?" names no project, so it shows none.
+
+What a chip carries beyond the title is up to the resource — see
+[Record chips](./ai.html#record-chips).
 
 ## Count and break down
 

--- a/docs/4.0/ai-what-you-can-ask.md
+++ b/docs/4.0/ai-what-you-can-ask.md
@@ -40,6 +40,9 @@ paragraph followed by a card.
 A chip appears because the assistant named that record in its answer, which is why a count never
 brings one along: "how many projects?" names no project, so it shows none.
 
+Ask for several and they come back as a list of rows — "the last three users" is three rows you can
+scan and click, not a bulleted paragraph.
+
 What a chip carries beyond the title is up to the resource — see
 [Record chips](./ai.html#record-chips).
 

--- a/docs/4.0/ai.md
+++ b/docs/4.0/ai.md
@@ -299,7 +299,10 @@ end
 
 Because the body is ordinary Ruby against those two objects, a part can be computed rather than
 read off a column. Keep the computing on the model, though, and let the declaration say only how
-the answer looks — "is it night there?" is a question about a city, not about how one is drawn:
+the answer looks — "is it night there?" is a question about a city, not about how one is drawn.
+The chip is rarely the only place that wants the answer, either: the same `night?` can feed a
+[discreet information](./discreet-information.html) entry on the record's header without
+computing it twice.
 
 ```ruby
 class City < ApplicationRecord

--- a/docs/4.0/ai.md
+++ b/docs/4.0/ai.md
@@ -221,6 +221,13 @@ the sentence, so an answer reads as one thought rather than as a paragraph follo
 A chip appears because the assistant named that record. A count or a total names none, so it brings
 no chip with it.
 
+**A set of records comes back as a list of rows.** When the answer *is* a set — "the last three
+users", "which projects are running", "show me the cities" — the assistant names one record per
+line, and the transcript draws those lines as a stack of rows instead of a bulleted paragraph: the
+same chip, given the whole width, so each row is scannable and clickable end to end the way an
+index table's rows are. A line that carries a sentence beside its record stays an ordinary bullet —
+there the record really is a word in a sentence.
+
 **Declare what it carries.** A chip is a row of parts. Every resource has a default one — the
 record's picture and its title — and `def chip` replaces it, declaring one `part` per piece, the
 same shape as [`fields`](./resources.html#fields):
@@ -353,6 +360,8 @@ When the assistant genuinely can't proceed — a required value you didn't menti
 **Picking several at once.** Some questions take more than one answer — which fields to fill in, which of the matched records to include. Those render as checkboxes instead of buttons, with one **Send** under them and an *Add anything else…* box alongside. Everything goes back as a single reply: the labels you ticked, plus whatever you typed, separated by commas.
 
 Answering a question card is an ordinary turn, never a confirmation. An option can quite legitimately read "Yes", and clicking it answers the question it belongs to — it can't reach back and confirm an update or a delete waiting further up the conversation.
+
+**Once you answer, the card settles.** Its options come off and it goes flat, the way a write card does once you confirm it. The question itself stays above your reply — it is the transcript's record of what was asked — and a page you left open on that card can't answer the same question a second time.
 
 ## Your actions, from the chat
 

--- a/docs/4.0/ai.md
+++ b/docs/4.0/ai.md
@@ -298,16 +298,21 @@ end
 ```
 
 Because the body is ordinary Ruby against those two objects, a part can be computed rather than
-read off a column:
+read off a column. Keep the computing on the model, though, and let the declaration say only how
+the answer looks — "is it night there?" is a question about a city, not about how one is drawn:
 
 ```ruby
+class City < ApplicationRecord
+  def night? # [!code focus]
+    local_hour < 6 || local_hour >= 20 # [!code focus]
+  end # [!code focus]
+end
+
 class Avo::Resources::City < Avo::BaseResource
   def chip
-    night = record.local_hour < 6 || record.local_hour >= 20
-
     part resource.avatar
-    part icon: night ? "tabler/outline/moon" : "tabler/outline/sun",
-         tone: night ? :info : :warning
+    part icon: record.night? ? "tabler/outline/moon" : "tabler/outline/sun", # [!code focus]
+         tone: record.night? ? :info : :warning # [!code focus]
     part resource.record_title
     part record.local_time, tone: :muted
   end

--- a/docs/4.0/ai.md
+++ b/docs/4.0/ai.md
@@ -200,7 +200,7 @@ Every message you send starts a fresh turn against the provider, built from thre
 
 **It inspects before it queries.** The first time a conversation touches a resource, the assistant asks for that resource's real columns, associations, and scopes, then builds its query from the answer. This is enforced by the tools, not merely requested in the prompt: the query and write tools refuse to run against a resource that hasn't been inspected in this conversation. It's why the first question about a resource takes an extra beat, and why the assistant uses your scopes — `cancelled`, `published` — instead of guessing at column filters.
 
-**Reading.** Query results are paginated, and the assistant is told to answer "how many" from the result's total count rather than by counting rows, so a capped result set doesn't become a wrong number. When a query returns exactly one record, the UI renders a card for it — title and a link — and the assistant is told not to repeat the fields in prose.
+**Reading.** Query results are paginated, and the assistant is told to answer "how many" from the result's total count rather than by counting rows, so a capped result set doesn't become a wrong number. Any record the assistant names in its answer is rendered as a chip in the sentence itself — see [Record chips](#record-chips).
 
 **Writing.** Updates and deletes show you a card describing the change and run only when you confirm it; the confirmation applies the change, not the model. Those two work one record at a time — ask for a bulk change and the assistant will say so and ask you to pick. Creates apply immediately, since there's nothing to preview for a record that doesn't exist yet, and creating is the one write it will repeat: "add 15 cities" creates fifteen without stopping between them. Every executed write is recorded in an audit log, and the assistant can undo one through the same confirmation card.
 
@@ -211,6 +211,126 @@ Every message you send starts a fresh turn against the provider, built from thre
 **Authorization is enforced at the tool layer, on every call.** Each read and write goes through your Avo policies for the signed-in user who owns the chat — per-resource and per-field. Instructions are guidance for the model; your policies are what actually decides. A resource the user can't list is invisible to the assistant rather than refused, so it can't be used to probe for what exists.
 
 For the full reference — both agents, every tool and its gates, and how conversations get their names — see [Agents and tools](./ai-agents-and-tools.html).
+
+### Record chips
+
+A record the assistant mentions is drawn inline as a **chip** — its picture, its title, and
+whatever status you choose to put on it — and clicking it opens that record. The chip is part of
+the sentence, so an answer reads as one thought rather than as a paragraph followed by a card.
+
+A chip appears because the assistant named that record. A count or a total names none, so it brings
+no chip with it.
+
+**Declare what it carries.** A chip is a row of parts. Every resource has a default one — the
+record's picture and its title — and `def chip` replaces it, declaring one `part` per piece, the
+same shape as [`fields`](./resources.html#fields):
+
+```ruby
+class Avo::Resources::Project < Avo::BaseResource
+  def chip # [!code focus]
+    part resource.avatar # [!code focus]
+    part resource.record_title # [!code focus]
+    part record.status, tone: :danger # [!code focus]
+  end # [!code focus]
+end
+```
+
+`chip` is an ordinary instance method, so **`record` and `resource` are in scope** — the same two
+names Avo injects into every lambda you write on a resource. Everything a part is built from is
+reached through one of them, so a declaration says out loud where each piece came from and there
+is nothing new to learn:
+
+```ruby
+part resource.avatar              # the picture, or the initials Avo derives
+part resource.record_title        # what Avo calls this record
+part record.status                # anything the record answers to
+part "in review"                  # a literal
+part record.status, tone: :danger # coloured
+part icon: "tabler/outline/moon"  # a glyph, alone or beside text
+```
+
+Because it is an instance method on the hydrated resource, the rest of what Avo hands a lambda is
+there too — `view`, `params`, `request`, `context`, `current_user`, `view_context`, `main_app`,
+`avo`, `helpers` and `t`. Nothing is injected for them; the resource already delegates them.
+
+```ruby
+def chip
+  part resource.avatar
+  part resource.record_title
+  part view_context.number_to_currency(record.budget), tone: :muted # [!code focus]
+  part t("my_app.draft"), tone: :muted if record.draft? # [!code focus]
+end
+```
+
+:::info
+The one thing a `def chip` body does *not* get is a lambda's implicit forwarding to the view
+context, so a bare `number_to_currency(...)` won't resolve — name `view_context`, as above, or
+reach your app's own helpers through `helpers`.
+:::
+
+**A chip renders in two places**, and that is worth knowing before you reach for anything
+request-scoped — it is drawn by two different things:
+
+| When | Rendered by |
+| ---- | ----------- |
+| The answer streaming in, live | a background job, broadcasting over Turbo Stream |
+| Opening or reloading the conversation | the usual controller and request |
+
+The whole vocabulary above works in **both** — including `view_context`, `main_app` and `avo`,
+which Avo lends the chip when there is no request to take them from. Your declaration behaves the
+same whether you watched the answer arrive or came back to the conversation a day later, which is
+the point: a chip that worked on every reload and came back empty mid-stream would be a miserable
+thing to catch.
+
+**Where the title sits is just where you declare it** — there is no "before" or "after" option,
+only order, and no limit on either side:
+
+```ruby
+class Avo::Resources::Issue < Avo::BaseResource
+  def chip
+    part resource.avatar
+    part icon: "tabler/outline/circle-dot", tone: :success # [!code focus]
+    part record.identifier, tone: :muted # [!code focus]
+    part resource.record_title # [!code focus]
+    part record.assignee_name, tone: :muted # [!code focus]
+  end
+end
+```
+
+Because the body is ordinary Ruby against those two objects, a part can be computed rather than
+read off a column:
+
+```ruby
+class Avo::Resources::City < Avo::BaseResource
+  def chip
+    night = record.local_hour < 6 || record.local_hour >= 20
+
+    part resource.avatar
+    part icon: night ? "tabler/outline/moon" : "tabler/outline/sun",
+         tone: night ? :info : :warning
+    part resource.record_title
+    part record.local_time, tone: :muted
+  end
+end
+```
+
+| Argument       | Values                                                                                          |
+| -------------- | ----------------------------------------------------------------------------------------------- |
+| first argument | The part's text — anything, used verbatim. `resource.avatar` is the one value that draws a picture instead |
+| `icon:`        | An [icon](./icons.html) name, e.g. `tabler/outline/moon`                                        |
+| `tone:`        | `:neutral` (default, the record's own ink), `:muted`, `:success`, `:warning`, `:danger`, `:info` |
+
+:::warning
+Defining `chip` replaces the default entirely — including the picture and the title. Declare
+`part resource.avatar` and `part resource.record_title` if you want them, and an empty `def chip`
+renders an empty chip.
+:::
+
+:::info
+A part with neither text nor an icon is skipped, so `part(record.draft? ? "draft" : nil)` is a
+normal thing to write. An unknown `tone:` falls back to `:neutral`. And if `chip` raises, the
+record still renders as a link rather than taking the answer down with it.
+:::
 
 ## Answering the assistant's questions
 
@@ -630,7 +750,7 @@ How much of the assistant's internal work a viewer may see is an authorization d
 
 There are two levels:
 
-- `:off` — the conversation: replies, record cards, confirmation buttons, the assistant's questions, the "Thinking…" indicator, and the collapsed trail with its reasoning trace and progress hints. The default.
+- `:off` — the conversation: replies, record chips, confirmation buttons, the assistant's questions, the "Thinking…" indicator, and the collapsed trail with its reasoning trace and progress hints. The default.
 - `:tools` — everything above plus the system prompt, the tool calls, and the raw tool output.
 
 The reasoning trace deliberately sits on the `:off` side of the line: it narrates the answer the


### PR DESCRIPTION
Pairs with the `avo-ai` change that replaces the chat's record card with an inline chip (AVO-1677). Docs only — nothing here ships until that gem does.

## What changed

**`4.0/ai.md` — new "Record chips" section.** A record the assistant names is drawn inline as a chip rather than as a card under the prose, and a count names no record so it brings no chip. Documents the `def chip` DSL:

```ruby
class Avo::Resources::Project < Avo::BaseResource
  def chip
    part resource.avatar
    part resource.record_title
    part record.status, tone: :danger
  end
end
```

`record` and `resource` are in scope — the same two names Avo already injects into every lambda on a resource — so every part says out loud where it came from and the DSL contributes no vocabulary of its own. Declaration order alone decides where the title sits (no `at:` option, no limit on either side), and defining `chip` replaces the default wholesale, so an empty one renders an empty chip.

**The two render paths, stated explicitly.** A chip is drawn by a background job broadcasting the answer as it streams, and by the ordinary controller on a reload. The whole request-scoped vocabulary — `view_context`, `main_app`, `avo` included — works in both. Worth a paragraph because the failure it prevents is nasty: a declaration built from `view_context` would render perfectly on every reload and come back empty only while the answer streamed.

**A set of records is a list of rows.** When the answer *is* a set — "the last three users", "which projects are running" — the assistant names one record per line and the transcript draws those lines as a stack of rows rather than a bulleted paragraph: the same chip, given the whole width, scannable and clickable end to end like an index table's row. A line carrying a sentence beside its record stays an ordinary bullet.

**The question card settles once you answer it.** Its options come off and it goes flat, the way a write card does on Confirm; the question stays above your reply, and a page left open on that card can't answer the same question twice. Documented in the "Answering the assistant's questions" section.

**`4.0/ai-what-you-can-ask.md`** — the three places that promised a card for a single result now describe the chip, plus a line on asking for several.

## Notes

- `npx vitepress build docs` passes.
- The i18n example uses `t("my_app.draft")`, not `t("avo.draft")` — a docs example is how someone learns to write a top-level `avo.` key, which our locale rules forbid.

https://claude.ai/code/session_01Mr5cbjsUTUvLF8M8q4rqkB

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> **Docs-only** update for Avo 4.0 AI guides, aligned with the `avo-ai` change that replaces record **cards** with inline **chips** in chat (AVO-1677).
> 
> In **`ai.md`**, the reading flow now points to a new **Record chips** section instead of describing a single-record card. That section explains when chips appear (named records vs counts), how multi-record answers render as clickable rows, and the resource **`def chip` / `part`** API (`resource.avatar`, `record.status`, `icon:`, `tone:`), including that a custom `chip` fully replaces the default. It also documents the **two render paths** (live Turbo Stream job vs page reload) and notes that answered **question cards settle** like confirmed write cards.
> 
> **`ai-what-you-can-ask.md`** updates the “Find records” table and prose so single-match prompts promise an inline chip, not a card. **Debug levels** copy switches “record cards” to “record chips.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35ff78ef33ab4e494b37ccd636f2ddbbc27e3a07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
