### PR TITLE
docs(menu): link_to takes a block for sub-items

### DIFF
--- a/docs/4.0/menu-editor-api.md
+++ b/docs/4.0/menu-editor-api.md
@@ -98,8 +98,17 @@ Also accepts the shared [`icon`](#icon), [`color`](#color), [`hotkey`](#hotkey),
 | `true` / `false` | Forces the state. |
 
 :::warning `active` is ignored on sub-items
-For links nested inside a `resource` block, Avo computes the active sub-item itself — inclusively, favoring the most specific (longest) matching path — and a per-link `active:` has no effect.
+For links nested inside a `resource` or `link_to` block, Avo computes the active sub-item itself — inclusively, favoring the most specific (longest) matching path — and a per-link `active:` has no effect.
 :::
+
+Passing a block nests sub-items under the link — see the [sub-items guide](./menu-editor.html#sub-items). The link itself stays clickable, and Avo forces it active while one of its children is.
+
+```ruby
+link_to "Design", path: "/admin/design" do
+  link_to "Chat", path: "/admin/design/chat"
+  link_to "Loader", path: "/admin/design/loader"
+end
+```
 
 </Option>
 

--- a/docs/4.0/menu-editor.md
+++ b/docs/4.0/menu-editor.md
@@ -90,7 +90,7 @@ The `all_resources` helper takes your [authorization](./authorization) rules int
 
 ## Sub-items
 
-You can nest items beneath a `resource` by passing a block. They appear as child items under the resource link in the sidebar. Any item type can be nested; a nested `resource`, `dashboard`, `page`, `board`, or `action` resolves its own URL automatically, so only `link_to` needs an explicit `path:`. A nested `action` also inherits its enclosing resource, so you don't repeat it.
+You can nest items beneath a `resource` or a `link_to` by passing a block. They appear as child items under the parent link in the sidebar, which stays clickable and goes to its own page. Any item type can be nested; a nested `resource`, `dashboard`, `page`, `board`, or `action` resolves its own URL automatically, so only `link_to` needs an explicit `path:`. A nested `action` also inherits its enclosing resource, so you don't repeat it.
 
 ```ruby
 # config/initializers/avo.rb
@@ -103,6 +103,12 @@ Avo.configure do |config|
       page "Avo::Pages::Settings"     # nested page
       board 1                         # nested kanban board
       action Avo::Actions::ExportData # nested action (inherits :projects)
+    end
+
+    # A plain link nests the same way — a custom page and its sub-pages.
+    link_to "Design", path: "/admin/design" do
+      link_to "Chat", path: "/admin/design/chat"
+      link_to "Loader", path: "/admin/design/loader"
     end
   }
 end
@@ -219,7 +225,7 @@ A [collapsable](./menu-editor-api.html#collapsable) section or group already car
 
 ## Icons
 
-The [`icon`](./menu-editor-api.html#icon) option is supported on `section` and on individual menu items (`link_to`, `resource`, `dashboard`, `page`, `form`, `board`, `action`). It is not supported on `group` or on sub-items nested inside a `resource` block.
+The [`icon`](./menu-editor-api.html#icon) option is supported on `section` and on individual menu items (`link_to`, `resource`, `dashboard`, `page`, `form`, `board`, `action`). It is not supported on `group` or on sub-items nested inside a `resource` or `link_to` block.
 
 You can use icons from [Tabler Icons](https://tabler.io/icons) (preferred in Avo 4) or from [Heroicons](https://heroicons.com/) (both `outline` and `solid` variants).
 


### PR DESCRIPTION
Documents the menu change in avo-hq/workspace#229: sub-items were resource-only, and a `link_to` now nests the same way — which is what a custom tool page with sub-pages needs, since it has no resource to hang them off.

- **Menu editor** — the Sub-items section covers both parents, the example grows a nested link, and the icons note names both blocks.
- **Menu editor API** — `link_to` gets its block form, and the "`active` is ignored on sub-items" warning covers links too.

Ships with the gem change; merge after it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Documents that **`link_to` can take a block** to nest sidebar sub-items, matching the behavior already described for **`resource`** — aimed at custom tool pages without a resource parent.
> 
> The **menu editor guide** expands Sub-items to cover both parents, adds a nested **Design** link example, and notes that **`icon`** is not supported on sub-items under **`resource` or `link_to`**. The **API reference** documents the block form, clarifies that per-link **`active:`** is ignored for nested links under either parent, and states the parent link stays clickable while Avo forces it active when a child matches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a0607e92f76254010cc40ed38115a2bda4d58c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->