### PR TITLE
Say the chip DSL is alpha, and point at it from the resource API index

### DIFF
--- a/docs/4.0/ai.md
+++ b/docs/4.0/ai.md
@@ -232,6 +232,15 @@ same chip, given the whole width, so each row is scannable and clickable end to 
 index table's rows are. A line that carries a sentence beside its record stays an ordinary bullet —
 there the record really is a word in a sentence.
 
+:::warning `def chip` is alpha
+The DSL is new and still moving. Expect it to change before it settles — the part vocabulary, the
+tones, and the names on this page are all still up for revision — and expect at least one change
+that a chip you wrote today will not survive untouched. Every one of them will be written down: a
+breaking change to `chip` ships with the release note that says what to do about it, the same as
+any other Avo API. Declare a chip where it earns its keep today, and plan on revisiting those
+declarations at an upgrade.
+:::
+
 **Declare what it carries.** A chip is a row of parts. Every resource has a default one — the
 record's picture and its title — and `def chip` replaces it, declaring one `part` per piece, the
 same shape as [`fields`](./resources.html#fields):

--- a/docs/4.0/resources-api.md
+++ b/docs/4.0/resources-api.md
@@ -837,3 +837,4 @@ Some resource options have enough surface to warrant a dedicated page:
 | `self.cover`          | [Cover and avatar](./cover-and-avatar.html#add-a-cover-photo) |
 | `self.row_controls_config` | [Table view API](./table-view-api.html#row_controls_config) |
 | `self.table_view`     | [Table view API](./table-view-api.html#table_view)        |
+| `def chip`            | [Record chips](./ai.html#record-chips)                    |


### PR DESCRIPTION
Follows #664, which shipped the record-chips docs. Two things that landed after it merged.

## `def chip` is alpha, and the page now says so

The DSL is new and still moving, so a reader deciding whether to declare chips across their resources needs to know what they are signing up for. A warning at the top of the DSL, before the first example:

> The DSL is new and still moving. Expect it to change before it settles — the part vocabulary, the tones, and the names on this page are all still up for revision — and expect at least one change that a chip you wrote today will not survive untouched. Every one of them will be written down: a breaking change to `chip` ships with the release note that says what to do about it, the same as any other Avo API.

Stated as a promise about *how* it will change rather than a vague "may change": the useful thing to tell someone is that breakage is expected and that it will arrive documented, not that the API is unstable in the abstract. The page's own `betaStatus: Beta` covers Avo Intelligence as a whole; this is narrower and belongs where the DSL is taught.

## A pointer from the resource API index

`resources-api.md` has an "Options documented on their own pages" table, and every resource option with its own page is in it — `self.ordering` from **Record reordering** included, so an add-on's option is not out of place there. `def chip` was the one missing.

| Option     | Documented on                           |
| ---------- | --------------------------------------- |
| `def chip` | [Record chips](./ai.html#record-chips)  |

That is the whole of it: `chip` is not documented like `fields` in `resources.md`, because it ships in `avo-ai` and a section on a `license: community` page would promise an API that is not there without the gem. A pointer row is how the other add-on options are found, and now it finds this one too.

`npx vitepress build docs` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only VitePress markdown changes; no runtime or API behavior is modified.
> 
> **Overview**
> Documentation-only follow-up to the record-chips docs: readers get an explicit **alpha** stance on the `def chip` DSL, and the resource API index gains a cross-link like the other add-on options.
> 
> In **`ai.md`**, a VitePress warning is inserted **before** the first `def chip` example. It states the DSL is still moving (parts, tones, naming), that at least one breaking change is expected, and that breakage will ship with release notes like other Avo APIs—narrower than the page-level Avo Intelligence beta notice.
> 
> In **`resources-api.md`**, the “Options documented on their own pages” table adds **`def chip` → [Record chips](./ai.html#record-chips)** so discoverability matches options such as `self.ordering` and `self.table_view`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6674a45c9c736a871d241e04bf9972d5d8f503a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->