### PR TITLE
docs(maps): maps no longer need a Mapbox account

### DIFF
--- a/docs/4.0/customization-api.md
+++ b/docs/4.0/customization-api.md
@@ -174,6 +174,39 @@ config.default_view_type = :grid
 
 </Option>
 
+<Option name="`map_view`">
+
+Defaults for the [map view](./map-view.html) and the [`location`](./fields/location.html) and [`area`](./fields/area.html) fields, which render the same maps.
+
+```ruby
+config.map_view = {
+  styles: :mapbox
+}
+```
+
+<Option name="`styles`" headingSize="4">
+
+The light/dark pair Avo renders maps with. Avo picks a provider on its own — [OpenFreeMap](https://openfreemap.org), free with no account and no API key, or Mapbox when `MAPBOX_ACCESS_TOKEN` is set. Set this to pin one regardless, or to supply your own pair.
+
+```ruby
+config.map_view = {
+  styles: {
+    light: "https://tiles.openfreemap.org/styles/liberty",
+    dark: "https://tiles.openfreemap.org/styles/dark"
+  }
+}
+```
+
+Avo swaps between the two as the color scheme changes. A single map can still override the style with `mapkick_options: {style: "..."}` — that's one style rather than a pair, so Avo leaves that map alone in dark mode.
+
+- **Type:** Symbol or Hash with `light` and `dark` keys
+- **Default:** `nil` — resolves to `:mapbox` when `MAPBOX_ACCESS_TOKEN` is set, `:open_free_map` otherwise
+- **Values:** `:open_free_map`, `:mapbox`, or a `{light:, dark:}` Hash of style URLs
+
+</Option>
+
+</Option>
+
 <Option name="`first_sorting_option`" headingSize="3">
 
 The direction applied the first time a user sorts a column on the <Index /> view.

--- a/docs/4.0/customization.md
+++ b/docs/4.0/customization.md
@@ -98,6 +98,19 @@ end
 
 <Image src="/assets/img/4_0/customization/view-type-table-grid.webm" dark-src="/assets/img/4_0/customization/view-type-table-grid-dark.webm" width="888" height="650" alt="An Avo Posts index with six records per page: the view switcher toggles between table rows and grid cards." prompt="Posts index with 4 per page; GIF toggling table and grid view with annotated view switcher" />
 
+### Map styles
+
+Maps work with no account: Avo renders them with [OpenFreeMap](https://openfreemap.org) by default, and switches to Mapbox styles on its own when `MAPBOX_ACCESS_TOKEN` is set. Pin one with [`map_view.styles`](./customization-api.html#styles), or point it at your own light/dark pair.
+
+```ruby
+# config/initializers/avo.rb
+Avo.configure do |config|
+  config.map_view = {
+    styles: :open_free_map
+  }
+end
+```
+
 ### Sorting direction
 
 The first time a user sorts a column, Avo sorts it descending. Flip that with [`first_sorting_option`](./customization-api.html#first_sorting_option).

--- a/docs/4.0/fields/area.md
+++ b/docs/4.0/fields/area.md
@@ -12,8 +12,12 @@ The `Area` field is used to display a geographical area on a map.
 field :city_center_area, as: :area
 ```
 
-:::warning
-You need to add the `mapkick-rb` (not `mapkick`) gem to your `Gemfile` and have the `MAPBOX_ACCESS_TOKEN` environment variable with a valid [Mapbox](https://account.mapbox.com/auth/signup/) key.
+:::info
+You need to add the `mapkick-rb` (not `mapkick`) gem to your `Gemfile`. That's it — no map account required.
+
+Avo renders maps with [OpenFreeMap](https://openfreemap.org) by default: no registration, no API key, no request limit, and attribution is handled for you.
+
+If you'd rather use Mapbox, set the `MAPBOX_ACCESS_TOKEN` environment variable to a valid [Mapbox](https://account.mapbox.com/auth/signup/) key and Avo will default to Mapbox styles instead. Pin either one — or your own light/dark pair — with [`config.map_view`](../customization-api.html#styles), and override a single map with `mapkick_options: {style: "..."}`.
 :::
 
 ## Description
@@ -56,7 +60,7 @@ Using this option, you can provide a hash of configuration settings supported by
 
 #### Default value
 
-`{}`
+`{style: "https://tiles.openfreemap.org/styles/positron"}` — `"mapbox://styles/mapbox/light-v11"` when `MAPBOX_ACCESS_TOKEN` is set.
 
 #### Possible values
 
@@ -66,10 +70,14 @@ Accepts the options as [specified in the Mapkick gem](https://github.com/ankane/
 field :city_center_area,
   as: :area,
   mapkick_options: {
-    style: "mapbox://styles/mapbox/satellite-v9",
+    style: "https://tiles.openfreemap.org/styles/liberty",
     controls: true
   }
 ```
+
+:::info
+Avo follows the color scheme and swaps the map between its light and dark styles automatically. Pass your own `style` and Avo leaves the map exactly as you set it, dark mode included.
+:::
 </Option>
 
 <Option name="`datapoint_options`">
@@ -102,7 +110,7 @@ field :city_center_area,
   as: :area,
   geometry: :polygon,
   mapkick_options: {
-    style: "mapbox://styles/mapbox/satellite-v9",
+    style: "https://tiles.openfreemap.org/styles/liberty",
     controls: true
   },
   datapoint_options: {

--- a/docs/4.0/fields/location.md
+++ b/docs/4.0/fields/location.md
@@ -15,8 +15,12 @@ field :coordinates, as: :location
 
 <Image src="/assets/img/4_0/fields/location/show-map.webp" dark-src="/assets/img/4_0/fields/location/show-map-dark.webp" width="1192" height="1060" alt="An Avo Map card on the Dashy dashboard showing an embedded Google Maps view of Manhattan with an Open in Maps link and map navigation controls." prompt="page with navigation map" />
 
-:::warning
-You need to add the `mapkick-rb` (not `mapkick`) gem to your `Gemfile` and have the `MAPBOX_ACCESS_TOKEN` environment variable with a valid [Mapbox](https://account.mapbox.com/auth/signup/) key.
+:::info
+You need to add the `mapkick-rb` (not `mapkick`) gem to your `Gemfile`. That's it — no map account required.
+
+Avo renders maps with [OpenFreeMap](https://openfreemap.org) by default: no registration, no API key, no request limit, and attribution is handled for you.
+
+If you'd rather use Mapbox, set the `MAPBOX_ACCESS_TOKEN` environment variable to a valid [Mapbox](https://account.mapbox.com/auth/signup/) key and Avo will default to Mapbox styles instead. Pin either one — or your own light/dark pair — with [`config.map_view`](../customization-api.html#styles), and override a single map with `mapkick_options: {style: "..."}`.
 :::
 
 ## Description
@@ -78,7 +82,8 @@ Using this option, you can provide a hash of configuration settings supported by
 {
   id: "location-map",
   zoom: 15,
-  controls: true
+  controls: true,
+  style: "https://tiles.openfreemap.org/styles/positron" # "mapbox://styles/mapbox/light-v11" when MAPBOX_ACCESS_TOKEN is set
 }
 ```
 
@@ -93,12 +98,17 @@ field :coordinates,
   as: :location,
   stored_as: [:latitude, :longitude],
   mapkick_options: {
-    style: 'mapbox://styles/mapbox/satellite-v9',
+    style: 'https://tiles.openfreemap.org/styles/liberty',
     controls: true
   }
 ```
 
 By using `mapkick_options`, you can tailor the map's look and functionality to suit your application's requirements.
+
+:::info
+Avo follows the color scheme and swaps the map between its light and dark styles automatically. Pass your own `style` and Avo leaves the map exactly as you set it, dark mode included.
+:::
+
 </Option>
 
 <Option name="`zoom`">
@@ -111,7 +121,7 @@ Sets the initial zoom level of the interactive map. It has no effect on static m
 
 #### Possible values
 
-Any integer zoom level supported by Mapbox.
+Any integer zoom level supported by the map style.
 
 ```ruby
 field :coordinates, as: :location, zoom: 12
@@ -123,7 +133,9 @@ field :coordinates, as: :location, zoom: 12
 The `static` option enables the rendering of a static map leveraging the power of the [mapkick-static](https://github.com/ankane/mapkick-static) gem.
 
 :::warning
-You need to add the [mapkick-static](https://github.com/ankane/mapkick-static) gem to your `Gemfile` and have the `MAPBOX_ACCESS_TOKEN` environment variable with a valid [Mapbox](https://account.mapbox.com/auth/signup/) key.
+Static maps are Mapbox-only — they're rendered by Mapbox's Static Images API, which OpenFreeMap has no equivalent for. You need to add the [mapkick-static](https://github.com/ankane/mapkick-static) gem to your `Gemfile` and have the `MAPBOX_ACCESS_TOKEN` environment variable with a valid [Mapbox](https://account.mapbox.com/auth/signup/) key.
+
+The same applies to the <Preview /> view, which always renders a static map.
 :::
 
 

--- a/docs/4.0/map-view.md
+++ b/docs/4.0/map-view.md
@@ -13,7 +13,7 @@ resources to be displayed to the map view they require a `coordinates` field, bu
 
 To enable map view for a resource, you need to add the `map_view` class attribute to a resource. That will add the view switcher to the <Index /> view.
 
-<Image src="/assets/img/4_0/map-view/index.webp" dark-src="/assets/img/4_0/map-view/index-dark.webp" width="2824" height="1742" alt="The Cities resource in map view — the table/map view switcher, a Mapbox map with markers and the adjacent index table." prompt="map view on the Cities index with the view switcher, Mapbox map and adjacent table" />
+<Image src="/assets/img/4_0/map-view/index.webp" dark-src="/assets/img/4_0/map-view/index-dark.webp" width="2824" height="1742" alt="The Cities resource in map view — the table/map view switcher, a map with markers and the adjacent index table." prompt="map view on the Cities index with the view switcher, map and adjacent table" />
 
 ```ruby
 class Avo::Resources::City < Avo::BaseResource
@@ -39,8 +39,12 @@ class Avo::Resources::City < Avo::BaseResource
 end
 ```
 
-:::warning
-You need to add the `mapkick-rb` (not `mapkick`) gem to your `Gemfile` and have the `MAPBOX_ACCESS_TOKEN` environment variable with a valid [Mapbox](https://account.mapbox.com/auth/signup/) key.
+:::info
+You need to add the `mapkick-rb` (not `mapkick`) gem to your `Gemfile`. That's it — no map account required.
+
+Avo renders maps with [OpenFreeMap](https://openfreemap.org) by default: no registration, no API key, no request limit, and attribution is handled for you.
+
+If you'd rather use Mapbox, set the `MAPBOX_ACCESS_TOKEN` environment variable to a valid [Mapbox](https://account.mapbox.com/auth/signup/) key and Avo will default to Mapbox styles instead. Pin either one — or your own light/dark pair — with [`config.map_view`](./customization-api.html#styles), and override a single map with `mapkick_options: {style: "..."}`.
 :::
 
 <Option name="`mapkick_options`">
@@ -48,11 +52,16 @@ You need to add the `mapkick-rb` (not `mapkick`) gem to your `Gemfile` and have 
 The options you pass here are forwarded to the [`mapkick` gem](https://github.com/ankane/mapkick).
 
 - **Type:** Hash
-- **Default:** `{}` — Avo sets `style` to `"mapbox://styles/mapbox/light-v11"` unless you provide one
+- **Default:** `{}` — Avo sets `style` to `"https://tiles.openfreemap.org/styles/positron"` (or `"mapbox://styles/mapbox/light-v11"` when `MAPBOX_ACCESS_TOKEN` is set) unless you provide one
 
 :::info
 Avo always sets the map's `height` (based on the [layout](#map)) — a `height` you pass here is overwritten.
 :::
+
+:::info
+Avo follows the color scheme and swaps the map between its light and dark styles automatically. Pass your own `style` and Avo leaves the map exactly as you set it, dark mode included.
+:::
+
 
 </Option>
 


### PR DESCRIPTION
Docs for **avo-hq/avo#4746**, which makes Avo's maps render without a Mapbox account. Merge alongside it.

Three pages carried the same warning — "you need `MAPBOX_ACCESS_TOKEN` with a valid Mapbox key" — as the very first thing a reader saw. That is no longer true: Avo renders maps with [OpenFreeMap](https://openfreemap.org) by default (no account, no API key, no request cap, commercial use allowed) and only switches to Mapbox styles when the env var is set.

## Changes

**`map-view.md`, `fields/location.md`, `fields/area.md`** — the warning becomes an info block saying no account is needed, and explains the switch. Defaults updated (`positron` rather than `mapbox://styles/mapbox/light-v11`; the `location` and `area` fields never documented a default at all because they fell through to Mapkick's own `mapbox://` fallback). Examples move off `mapbox://styles/mapbox/satellite-v9`.

Each page also gains a note that Avo swaps light/dark automatically for maps it styled, and leaves a map with its own `style:` exactly as set — which is new behavior worth knowing before someone wonders why their satellite map stopped changing.

**`customization-api.md`** — new `map_view` option with a nested `styles`, following the `row_options` shape in `table-view-api.md`. `map_view` is a hash so more map defaults can land there later.

**`customization.md`** — a short "Map styles" section next to the other index-view settings.

## Still Mapbox-only

The `static` warning in `fields/location.md` stays, and now says why: static maps go through `mapkick-static`, which hardcodes `api.mapbox.com/styles/v1`, and OpenFreeMap has no static-image API. It also notes that the <Preview /> view always renders a static map, which was never written down.

## Verification

`npx vitepress build docs` passes. Both new anchors (`#map_view`, `#styles`) generate, `#styles` is unique on the page, and every cross-link resolves — including the `../customization-api.html` ones from the two field pages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3ac3ddc9b098091db837a2169e1c6c81b51c6d5a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->