### PR TITLE
docs(ai): the assistant finds an action without being told its resource

### DIFF
--- a/docs/4.0/ai-agents-and-tools.md
+++ b/docs/4.0/ai-agents-and-tools.md
@@ -47,7 +47,7 @@ A tool's name is the stable part of it: the model calls the tool by that name, e
 | `create_record`              | Creates a record                                                                                                     | immediately       |
 | `update_record`              | Changes a record's attributes                                                                                        | after you confirm |
 | `delete_record`              | Deletes a record                                                                                                     | after you confirm |
-| `run_action`                 | Lists the [actions](./actions.html) a resource registers, and proposes running one on the records you name           | after you confirm |
+| `run_action`                 | Lists the [actions](./actions.html) available — one resource's, or [every action in the app](./ai.html#finding-an-action-without-naming-its-resource) — and proposes running one on the records you name | after you confirm |
 | `write_history`              | Lists the writes made earlier in the conversation and proposes undoing one                                           | after you confirm |
 | `rename_conversation`        | Renames the current conversation — with your exact title, or by regenerating one                                     | immediately       |
 

--- a/docs/4.0/ai.md
+++ b/docs/4.0/ai.md
@@ -398,6 +398,18 @@ Ask for it in whatever words you'd use with a colleague — "archive the Orbit p
 
 [Actions that run without records](./actions.html#run-an-action-without-records) work too — the assistant runs them with no record at all.
 
+### Finding an action without naming its resource
+
+People ask in verbs. "Refresh the models", "send the welcome email", "export everything" — none of those name a resource, and none of them need to. The assistant can list every action registered across the application, each beside the resource that owns it, pick the one that matches what you asked, and run it from there.
+
+This is why an action lands even when the noun in your sentence isn't one of your records. "Refresh the models" reads like a question about your database until you know that `Avo::Resources::AvoAi::Model` registers a **Refresh models** action — and knowing that is the assistant's job, not yours.
+
+The list is scoped like everything else: it only contains actions from resources the signed-in user is allowed to list, so it can never surface an operation from a corner of the app that user can't reach. It's also fetched only when a request looks like an operation — a conversation about editing a blog post never pays for it.
+
+:::info An action two resources share needs you to say which
+Naming the action alone is enough when one resource registers it. When two do, the assistant asks which resource you mean instead of choosing — two resources registering the same action class are two tables with two policies, and the run lands on exactly one of them.
+:::
+
 ### What it's allowed to run
 
 Two gates, both yours, both checked when the run is proposed and again when you confirm it:


### PR DESCRIPTION
Documents the behaviour shipped in avo-hq/workspace#233 (AVO-1753).

## Why

People ask in verbs. "Refresh the models", "send the welcome email", "export everything" — none of those name a resource. Until now the assistant needed one before it could even find out what actions existed, and the actions section read as if you had to supply it.

It no longer does: it can list every action registered across the application, each beside the resource that owns it, and run the matching one.

## What changed

**`4.0/ai.md`** — new `### Finding an action without naming its resource` under "Your actions, from the chat", covering:

- what it means for how you phrase a request
- the worked example from the bug that prompted it ("refresh the models" reads like a database question until you know a resource registers a **Refresh models** action)
- the authorization scoping — the list only holds actions from resources the signed-in user may list
- that it's fetched on demand, not carried in every conversation
- the one case that still needs you: an action class two resources register, where the assistant asks which you mean rather than picking a table

**`4.0/ai-agents-and-tools.md`** — the `run_action` row now says the listing has two scopes and links to the new section.

## Checks

`npx vitepress build docs` completes clean, and the cross-link anchor resolves in the built HTML.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, auth, or data-handling code changes.
> 
> **Overview**
> Documents assistant behavior from AVO-1753: users can trigger actions with verb-only requests (e.g. “refresh the models”) without naming a resource first.
> 
> **`4.0/ai.md`** adds **Finding an action without naming its resource** under “Your actions, from the chat”: app-wide action listing with owning resource, policy scoping to listable resources, on-demand fetch (not every turn), and disambiguation when the same action class is registered on two resources.
> 
> **`4.0/ai-agents-and-tools.md`** updates the `run_action` tools table row to describe both listing scopes and link to that section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d8a7bf3d38d2079fe4210ca36cfc9361e3e811e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->