### PR TITLE
docs(ai): say that the chat needs an identified cable connection

### DIFF
--- a/docs/4.0/ai.md
+++ b/docs/4.0/ai.md
@@ -67,7 +67,41 @@ bin/rails ruby_llm:load_models
 
 Later refreshes don't need the terminal: the Models resource (added to the menu below) ships a standalone **Refresh models** action that pulls the published catalog plus the latest models from every configured provider. There's nothing to restart after a refresh — a background job that meets a model its process doesn't know yet re-reads the registry and retries on its own.
 
-### 4. Add the admin resources to the menu
+### 4. Check the cable connection
+
+The chat updates live over ActionCable, on a stream that is verified against the chat's owner — so the connection has to know who is connected. The installer wires `app/channels/application_cable/connection.rb` for you:
+
+```ruby
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    include Avo::Ai::ConnectionIdentification # [!code focus]
+  end
+end
+```
+
+Identity comes from Warden, which Devise and most Rails auth stacks populate. On a different auth stack, override the lookup:
+
+```ruby
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    include Avo::Ai::ConnectionIdentification
+
+    private
+
+    def avo_ai_verified_user # [!code focus]
+      User.find_by(id: cookies.encrypted[:user_id]) # [!code focus]
+    end # [!code focus]
+  end
+end
+```
+
+:::warning
+Without an identified connection, every chat subscription is refused. The chat still renders and still answers — but nothing arrives until you reload the page, and the assistant's reply, the system prompt, and the auto-generated chat name all appear only after a refresh. If you see that, this is why; `Avo::Ai::ChatChannel refused a subscription` in the logs says the same thing.
+:::
+
+The include only sets `current_user` — it never rejects the connection — so it is safe in an app whose cable also serves logged-out visitors.
+
+### 5. Add the admin resources to the menu
 
 In `config/initializers/avo.rb`, inside the `config.main_menu` block:
 
@@ -81,7 +115,7 @@ end
 
 The resources and controllers ship inside the gem — there's nothing to generate into your app.
 
-### 5. Verify
+### 6. Verify
 
 ```bash
 bin/rails runner "puts Avo::Ai::Chat.count"
@@ -744,6 +778,8 @@ Rows of an [array resource](./array-resource.html) can't be attached — they ha
 ### The page you were on
 
 Every Avo page contributes its own title and path. That is what makes "what is this page?" or "where am I?" answerable on a dashboard, a settings page, or a filtered index — pages that are nobody's record.
+
+The assistant's own pages are the exception. A chat you start from the new-chat page, the chat list, or a conversation carries no page origin — the compose box is where you write a chat, never what it is about. A conversation's page still offers the conversation itself, as [the record it is](#starting-from-a-conversation).
 
 It is a label, not a description: the page origin says *where* the conversation started and never what was on screen. The assistant still queries before stating anything about your data, and page titles are passed to the model as untrusted values, so a record whose name reads like an instruction is text rather than a command.
 


### PR DESCRIPTION
Pairs with avo-hq/workspace#238.

Avo AI's chat updates over an ActionCable stream that is verified against the chat's owner, so the cable connection has to know who is connected. The install steps never mentioned it. An app that misses the wiring gets a chat that renders, answers correctly in the database, and shows none of it until a reload — the assistant's reply, the system prompt and the auto-generated chat name all appear only after a refresh. That is exactly what happened on avohq.io.

New **step 4** covers:

- the wiring the installer now writes (`include Avo::Ai::ConnectionIdentification`)
- how to override `avo_ai_verified_user` for an auth stack that isn't Warden-backed
- a warning describing the symptom, so someone hitting it recognises it, plus the log line to grep for
- a note that the include never rejects the connection, so it is safe in an app whose cable also serves logged-out visitors

Verify moves from step 5 to step 6. Nothing links to the renumbered anchors. `npx vitepress build docs` completes clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> **Avo AI installation docs** now include a dedicated step for **ActionCable identity**, which live chat updates depend on because subscriptions are verified against the chat owner.
> 
> The new **step 4** explains the installer’s `Avo::Ai::ConnectionIdentification` include on `ApplicationCable::Connection`, how to override `avo_ai_verified_user` when auth isn’t Warden-based, a warning that ties the “works in DB but UI only updates after reload” symptom to refused subscriptions (and the `Avo::Ai::ChatChannel refused a subscription` log line), and that the mixin only sets `current_user` without rejecting anonymous cable connections.
> 
> **Verify** and **Add the admin resources** are renumbered to steps 6 and 5. In **What you start the chat from**, assistant-owned pages (new chat, chat list, an open conversation’s compose UI) are called out as **not** carrying page-origin context, while a conversation’s record page still attaches the chat as its subject.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee8b1559d9b1b385edf7ff46b307908996567fdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->