### PR TITLE
docs: container widths renamed to Tailwind's scale (`:large`/`:small` deprecated)

### DIFF
--- a/docs/4.0/customization-api.md
+++ b/docs/4.0/customization-api.md
@@ -403,7 +403,8 @@ Hash keys can be individual views — `:index`, `:show`, `:new`, `:edit`, `:crea
 When a specific key and a group alias target the same view, the specific key wins. Views not mentioned in the hash keep their defaults.
 
 - **Type:** Symbol or Hash
-- **Default:** `{ index: :large, show: :small, new: :small, edit: :small, create: :small, update: :small }`
+- **Values:** `:full`, `:lg`, `:md`, `:sm`
+- **Default:** `{ index: :lg, show: :md, new: :md, edit: :md, create: :md, update: :md }`
 - **Validation:** raises `ArgumentError` for unknown widths or unknown hash keys
 
 </Option>

--- a/docs/4.0/customization-api.md
+++ b/docs/4.0/customization-api.md
@@ -364,7 +364,7 @@ config.container_width = { index: :full }
 | `:full` | —         | —           | Full viewport width                             |
 | `:lg`   | 1536px    | 1536px      | Constrained container (default for index)       |
 | `:md`   | 960px     | 1280px      | Narrower container (default for show / forms)   |
-| `:sm`   | 720px     | 1024px      | Narrow, single-column screens                   |
+| `:sm`   | 720px     | 768px       | Narrow, single-column screens                   |
 
 Below its clamp point a width spans the content area, so `:sm` is the only value
 that narrows anything on a typical laptop.

--- a/docs/4.0/customization-api.md
+++ b/docs/4.0/customization-api.md
@@ -359,11 +359,30 @@ config.container_width = :full
 config.container_width = { index: :full }
 ```
 
-| Value    | Behavior                                    |
-| -------- | ------------------------------------------- |
-| `:large` | Constrained container (default for index)   |
-| `:small` | Narrow container (default for show / forms) |
-| `:full`  | Full viewport width                         |
+| Value   | Behavior                                    |
+| ------- | ------------------------------------------- |
+| `:lg`   | Constrained container (default for index)   |
+| `:md`   | Narrow container (default for show / forms) |
+| `:full` | Full viewport width                         |
+
+:::warning Deprecated in Avo 4.1
+`:large` and `:small` were renamed to `:lg` and `:md` so container widths use the same
+Tailwind scale as every other size option in Avo (`size: :sm`, `width: :xl`, ...), and so
+there is room for narrower widths later. The old names still work and are mapped
+automatically, but they log a deprecation warning and will be removed in Avo 5.
+
+```ruby
+config.container_width = :small                  # [!code --]
+config.container_width = :md                     # [!code ++]
+
+config.container_width = { index: :large }       # [!code --]
+config.container_width = { index: :lg }          # [!code ++]
+```
+
+If you style Avo's container yourself, the CSS classes were renamed to match:
+`.container-large` → `.container-lg`, `.container-small` → `.container-md`, and
+`.container-full-width` → `.container-full`.
+:::
 
 Hash keys can be individual views — `:index`, `:show`, `:new`, `:edit`, `:create`, `:update` — or group aliases:
 

--- a/docs/4.0/customization-api.md
+++ b/docs/4.0/customization-api.md
@@ -359,11 +359,15 @@ config.container_width = :full
 config.container_width = { index: :full }
 ```
 
-| Value   | Behavior                                    |
-| ------- | ------------------------------------------- |
-| `:lg`   | Constrained container (default for index)   |
-| `:md`   | Narrow container (default for show / forms) |
-| `:full` | Full viewport width                         |
+| Value   | Max width | Clamps from | Behavior                                        |
+| ------- | --------- | ----------- | ----------------------------------------------- |
+| `:full` | —         | —           | Full viewport width                             |
+| `:lg`   | 1536px    | 1536px      | Constrained container (default for index)       |
+| `:md`   | 960px     | 1280px      | Narrower container (default for show / forms)   |
+| `:sm`   | 720px     | 1024px      | Narrow, single-column screens                   |
+
+Below its clamp point a width spans the content area, so `:sm` is the only value
+that narrows anything on a typical laptop.
 
 :::warning Deprecated in Avo 4.1
 `:large` and `:small` were renamed to `:lg` and `:md` so container widths use the same
@@ -378,6 +382,10 @@ config.container_width = :md                     # [!code ++]
 config.container_width = { index: :large }       # [!code --]
 config.container_width = { index: :lg }          # [!code ++]
 ```
+
+Note that `:small` maps to `:md`, **not** to `:sm`. The rename kept every existing
+screen at the width it already had; `:sm` is a new, genuinely narrower container that
+nothing gets automatically.
 
 If you style Avo's container yourself, the CSS classes were renamed to match:
 `.container-large` → `.container-lg`, `.container-small` → `.container-md`, and

--- a/docs/4.0/customization.md
+++ b/docs/4.0/customization.md
@@ -205,14 +205,14 @@ Avo.configure do |config|
 end
 ```
 
-Widths are `:large`, `:small`, or `:full`. The hash form accepts individual view keys (`:index`, `:show`, `:new`, `:edit`, `:create`, `:update`) and the group aliases `:forms`, `:display`, and `:single` — specific keys win over aliases. See the [reference](./customization-api.html#container_width) for the full tables.
+Widths are `:lg`, `:md`, or `:full` (`:large` and `:small` still work but are deprecated — see the [reference](./customization-api.html#container_width)). The hash form accepts individual view keys (`:index`, `:show`, `:new`, `:edit`, `:create`, `:update`) and the group aliases `:forms`, `:display`, and `:single` — specific keys win over aliases. See the [reference](./customization-api.html#container_width) for the full tables.
 
 ```ruby
 # All single-record views full-width; index stays large
 config.container_width = { single: :full }
 
 # Mix: single full-width, but show overridden back to small
-config.container_width = { single: :full, show: :small }
+config.container_width = { single: :full, show: :md }
 ```
 
 ### Upgrading from `full_width_container` / `full_width_index_view`

--- a/docs/4.0/customization.md
+++ b/docs/4.0/customization.md
@@ -205,7 +205,7 @@ Avo.configure do |config|
 end
 ```
 
-Widths are `:lg`, `:md`, or `:full` (`:large` and `:small` still work but are deprecated — see the [reference](./customization-api.html#container_width)). The hash form accepts individual view keys (`:index`, `:show`, `:new`, `:edit`, `:create`, `:update`) and the group aliases `:forms`, `:display`, and `:single` — specific keys win over aliases. See the [reference](./customization-api.html#container_width) for the full tables.
+Widths are `:lg`, `:md`, `:sm`, or `:full` (`:large` and `:small` still work but are deprecated — see the [reference](./customization-api.html#container_width)). The hash form accepts individual view keys (`:index`, `:show`, `:new`, `:edit`, `:create`, `:update`) and the group aliases `:forms`, `:display`, and `:single` — specific keys win over aliases. See the [reference](./customization-api.html#container_width) for the full tables.
 
 ```ruby
 # All single-record views full-width; index stays large

--- a/docs/4.0/forms-and-pages-api.md
+++ b/docs/4.0/forms-and-pages-api.md
@@ -87,15 +87,16 @@ Overrides Avo's page container width for this screen. Same values as [`config.co
 self.container_width = :lg
 ```
 
-| Value   | Behavior                                  |
-| ------- | ----------------------------------------- |
-| `:md`   | Narrow, centered container.               |
-| `:lg`   | Wide constrained container.               |
-| `:full` | Spans the full width of the content area. |
+| Value   | Behavior                                       |
+| ------- | ---------------------------------------------- |
+| `:sm`   | Narrow single-column container (720px).        |
+| `:md`   | Medium centered container (960px).             |
+| `:lg`   | Wide constrained container (1536px).           |
+| `:full` | Spans the full width of the content area.      |
 
 - **Type:** Symbol
 - **Default:** `nil` — inherits whatever [`config.container_width`](./customization-api.html#container_width) gives the request's view.
-- **Values:** `:md`, `:lg`, `:full` (the Avo-4.0 names `:small` and `:large` still work but are deprecated)
+- **Values:** `:sm`, `:md`, `:lg`, `:full` (the Avo-4.0 names `:small` and `:large` still work but are deprecated — `:small` maps to `:md`, not `:sm`)
 - **Validation:** raises `ArgumentError` on any other value.
 - **Scope:** on a **page**, applies to that page; a sub-page's own value wins over its main page's. On a **form**, applies only when the form is rendered on its own URL — a form placed on a page takes the page's width.
 

--- a/docs/4.0/forms-and-pages-api.md
+++ b/docs/4.0/forms-and-pages-api.md
@@ -79,6 +79,28 @@ self.id = :app_settings
 
 </Option>
 
+<Option name="`self.container_width`" headingSize="3">
+
+Overrides Avo's page container width for this screen. Same values as [`config.container_width`](./customization-api.html#container_width).
+
+```ruby
+self.container_width = :lg
+```
+
+| Value   | Behavior                                  |
+| ------- | ----------------------------------------- |
+| `:md`   | Narrow, centered container.               |
+| `:lg`   | Wide constrained container.               |
+| `:full` | Spans the full width of the content area. |
+
+- **Type:** Symbol
+- **Default:** `nil` — inherits whatever [`config.container_width`](./customization-api.html#container_width) gives the request's view.
+- **Values:** `:md`, `:lg`, `:full` (the Avo-4.0 names `:small` and `:large` still work but are deprecated)
+- **Validation:** raises `ArgumentError` on any other value.
+- **Scope:** on a **page**, applies to that page; a sub-page's own value wins over its main page's. On a **form**, applies only when the form is rendered on its own URL — a form placed on a page takes the page's width.
+
+</Option>
+
 ## Form methods
 
 <Option name="`fields`">
@@ -161,6 +183,7 @@ end
 ```
 
 - **Type:** instance method you define
+- **Empty or undefined:** the page renders without the sidebar column, and its content spans the container.
 
 :::warning Parsed once at boot
 `navigation` is evaluated a single time during application boot. Don't put conditional or otherwise dynamic logic inside it — it won't be re-evaluated per request.

--- a/docs/4.0/forms-and-pages.md
+++ b/docs/4.0/forms-and-pages.md
@@ -153,6 +153,8 @@ Creates `app/avo/forms/your_form_name.rb`:
 class Avo::Forms::YourFormName < Avo::Forms::Core::Form
   self.title = "Your Form Name"
   self.description = "Manage your your form name"
+  # Applies when this form is opened on its own URL; on a page the page decides.
+  # self.container_width = :lg # :md, :lg or :full
 
   def fields
     field :example, as: :text, default: "Hello World"
@@ -181,6 +183,7 @@ class Avo::Pages::YourPageName < Avo::Forms::Core::Page
   self.title = "Your Page Name"
   self.description = "A page for your page name"
   # self.navigation_label = "Your Page Name"
+  # self.container_width = :lg # :md, :lg or :full
 
   def content
     # form Avo::Forms::AnyFormClass
@@ -419,6 +422,42 @@ def content
   form Avo::Forms::Settings::AppSettings, show_header: false
 end
 ```
+
+## Set the container width
+
+Pages and forms render inside Avo's page container, which is `:md` by default. Widen or narrow it per screen with `container_width` — `:md`, `:lg` or `:full`, the same values as [`config.container_width`](./customization-api.html#container_width).
+
+```ruby
+# app/avo/pages/settings.rb
+class Avo::Pages::Settings < Avo::Forms::Core::Page
+  self.title = "Settings"
+  self.container_width = :lg # applies to this page and its sub-pages
+end
+```
+
+A sub-page's own value wins over its main page's, so one wide area can still hold a narrow screen:
+
+```ruby
+# app/avo/pages/settings/notifications.rb
+class Avo::Pages::Settings::Notifications < Avo::Forms::Core::Page
+  self.container_width = :md
+end
+```
+
+On a form, `container_width` applies when the form is opened on its own URL (linked from the menu, or visited directly). When the form is placed on a page, the page owns the container and the form's value is ignored.
+
+```ruby
+# app/avo/forms/settings/app_settings.rb
+class Avo::Forms::Settings::AppSettings < Avo::Forms::Core::Form
+  self.container_width = :full
+end
+```
+
+Leave it unset to keep whatever `config.container_width` gives the app.
+
+:::info No navigation, no sidebar
+A page whose `navigation` is empty renders without the sidebar column, so its content spans the full container instead of sitting off to one side.
+:::
 
 ## Name the menu entry
 

--- a/docs/4.0/forms-and-pages.md
+++ b/docs/4.0/forms-and-pages.md
@@ -425,7 +425,7 @@ end
 
 ## Set the container width
 
-Pages and forms render inside Avo's page container, which is `:md` by default. Widen or narrow it per screen with `container_width` — `:md`, `:lg` or `:full`, the same values as [`config.container_width`](./customization-api.html#container_width).
+Pages and forms render inside Avo's page container, which is `:md` by default. Widen or narrow it per screen with `container_width` — `:sm`, `:md`, `:lg` or `:full`, the same values as [`config.container_width`](./customization-api.html#container_width).
 
 ```ruby
 # app/avo/pages/settings.rb

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -20,8 +20,10 @@ words `:large` and `:small`, while every other size option in Avo uses Tailwind'
 | `:small` | `:md` |
 | `:full`  | `:full` (unchanged) |
 
-`:small` became `:md` rather than `:sm` deliberately, leaving `:sm` and `:xs` free for
-narrower containers later.
+`:small` became `:md` rather than `:sm` deliberately: it keeps every existing screen at
+the width it already had, and frees the narrower names. A new `:sm` (720px, clamping from
+1024px) ships in the same release for single-column screens — nothing gets it
+automatically, it is opt-in.
 
 ### Action Required
 

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -4,6 +4,57 @@ We'll update this page when we release new Avo 4 versions.
 
 If you're looking for the Avo 3 to Avo 4 upgrade guide, please visit [the dedicated page](./avo-3-avo-4-upgrade).
 
+## Upgrade to 4.1.15
+
+<Option name="`container_width` values renamed to Tailwind's scale">
+
+### Deprecation
+
+`config.container_width` (and `self.container_width` on Avo Forms pages and forms) used the
+words `:large` and `:small`, while every other size option in Avo uses Tailwind's scale —
+`size: :sm`, `width: :xl`, `size: :md`. The widths now use that scale too:
+
+| Before   | After |
+| -------- | ----- |
+| `:large` | `:lg` |
+| `:small` | `:md` |
+| `:full`  | `:full` (unchanged) |
+
+`:small` became `:md` rather than `:sm` deliberately, leaving `:sm` and `:xs` free for
+narrower containers later.
+
+### Action Required
+
+**None immediately.** The old names are still accepted and mapped for you — they log a
+deprecation warning through `Avo.logger` and will be removed in Avo 5. Update them when
+convenient:
+
+```ruby
+# config/initializers/avo.rb
+config.container_width = :small                     # [!code --]
+config.container_width = :md                        # [!code ++]
+
+config.container_width = { index: :large }          # [!code --]
+config.container_width = { index: :lg }             # [!code ++]
+```
+
+```ruby
+# app/avo/pages/settings.rb
+self.container_width = :large                       # [!code --]
+self.container_width = :lg                          # [!code ++]
+```
+
+**If you style Avo's container in your own CSS**, this part is *not* aliased — the emitted
+class names changed and your overrides need renaming:
+
+| Before                  | After              |
+| ----------------------- | ------------------ |
+| `.container-large`      | `.container-lg`    |
+| `.container-small`      | `.container-md`    |
+| `.container-full-width` | `.container-full`  |
+
+</Option>
+
 ## Upgrade to 4.1.11
 
 <Option name="`stacked: false` now opts a field out of sidebar and width stacking">

--- a/docs/4.0/upgrade.md
+++ b/docs/4.0/upgrade.md
@@ -22,7 +22,7 @@ words `:large` and `:small`, while every other size option in Avo uses Tailwind'
 
 `:small` became `:md` rather than `:sm` deliberately: it keeps every existing screen at
 the width it already had, and frees the narrower names. A new `:sm` (720px, clamping from
-1024px) ships in the same release for single-column screens — nothing gets it
+768px) ships in the same release for single-column screens — nothing gets it
 automatically, it is opt-in.
 
 ### Action Required


### PR DESCRIPTION
Companion to avo-hq/avo#4749, which moves `container_width` onto the Tailwind scale every other size option in Avo already uses.

| Before | After |
| --- | --- |
| `:large` | `:lg` |
| `:small` | `:md` |
| `:full` | `:full` (unchanged) |

## What changed here

**`4.0/upgrade.md`** — a new 4.1.15 entry. It covers the mapping, why `:small` became `:md` rather than `:sm` (nothing is narrower than it today, so this leaves `:sm` and `:xs` free for a narrower container later), and — separately, because it is the only part that needs a manual fix — the CSS class rename:

| Before | After |
| --- | --- |
| `.container-large` | `.container-lg` |
| `.container-small` | `.container-md` |
| `.container-full-width` | `.container-full` |

The config values are aliased and warn; the CSS classes cannot be, since an alias cannot help a host override a class the element no longer carries.

**`4.0/customization-api.md`** — value table updated, plus a `:::warning` callout with diff-marked before/after and the class rename.

**`4.0/customization.md`**, **`4.0/forms-and-pages-api.md`**, **`4.0/forms-and-pages.md`** — value tables, prose and examples, including the `self.container_width` option on Avo Forms pages and forms.

`npx vitepress build docs` passes.

Merge after avo-hq/avo#4749.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates for a deprecation and API rename; no runtime or security impact.
> 
> **Overview**
> Documents the Avo 4.1.15 `container_width` rename onto Tailwind’s scale (`:large` → `:lg`, `:small` → `:md`) and the new opt-in `:sm` (720px) width.
> 
> Adds a **4.1.15 upgrade** entry: old symbols stay aliased with a deprecation warning until Avo 5; CSS class names (`.container-large` → `.container-lg`, etc.) are **not** aliased. Reference tables now include max-width and clamp points, and Forms docs cover `self.container_width` plus empty-navigation pages spanning the container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d93e21e3f356cb32d446e96fe1f795a1e766a339. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


## Update: the new `:sm` width

The same release adds a narrow `:sm` (720px, clamping from 768px). The value tables now carry each width's max-width **and** clamp point, because below its clamp point a width simply spans the content area — which is why `:sm` is the only value that narrows anything on a typical laptop.

| Value | Max width | Clamps from |
| --- | --- | --- |
| `:full` | — | — |
| `:lg` | 1536px | 1536px |
| `:md` | 960px | 1280px |
| `:sm` | 720px | 768px |

The upgrade entry now also spells out that `:small` deprecates to `:md`, **not** to `:sm` — the rename keeps every screen at its current width, and `:sm` is opt-in.

