### PR TITLE
docs: `use_browser_timezone` applies to rendering only

### DIFF
--- a/docs/4.0/customization-api.md
+++ b/docs/4.0/customization-api.md
@@ -61,11 +61,26 @@ config.timezone = "UTC"
 
 Render server-side dates and times in each visitor's own time zone instead of the app's `Time.zone`. **On by default** — set it to `false` to render everyone in the app's configured zone.
 
-Avo detects the browser's IANA time zone with JavaScript, stores it in the `avo.browser_timezone` cookie, and wraps every Avo request in `Time.use_zone` with it. The very first page a browser ever loads still renders in the app zone — no HTTP header carries the time zone — so Avo soft-reloads that one page through Turbo and shows an alert telling the user times are now displayed in their zone. Browsers with cookies disabled keep the app zone and never reload.
+Avo detects the browser's IANA time zone with JavaScript, stores it in the `avo.browser_timezone` cookie, and renders every Avo response in it. The very first page a browser ever loads still renders in the app zone — no HTTP header carries the time zone — so Avo soft-reloads that one page through Turbo and shows an alert telling the user times are now displayed in their zone. Browsers with cookies disabled keep the app zone and never reload.
 
 ```ruby
 config.use_browser_timezone = false
 ```
+
+:::warning This is a display setting
+The visitor's zone is applied around **rendering only**. Everything else in the request keeps the app's configured `Time.zone`, so your own code means what it means everywhere else in Rails:
+
+```ruby
+class Avo::Actions::ScheduleReport < Avo::BaseAction
+  def handle(**args)
+    # The app's configured zone, not the visitor's browser zone.
+    Time.zone.local(2026, 1, 1, 9, 0)
+  end
+end
+```
+
+The same holds for `Date.current` and `Time.current` in scopes, filters and query objects, for ActiveRecord's time-zone-aware attribute casting on write, and for model callbacks. If you want a value in the visitor's zone outside a template, convert it explicitly with `in_time_zone`.
+:::
 
 :::info Off in the test environment
 The option defaults to `false` when `Rails.env.test?`, because the first-load soft reload races browser tests — assertions run against a page that is about to be replaced. Enable it explicitly in a test if you are testing the time zone behavior itself.

--- a/docs/4.0/customization.md
+++ b/docs/4.0/customization.md
@@ -56,6 +56,8 @@ end
 
 By default Avo follows each visitor's own time zone via [`use_browser_timezone`](./customization-api.html#use_browser_timezone): it detects the browser's time zone, stores it in a cookie, and renders all server-side dates and times in it — announcing the switch with an alert the first time. Set it to `false` to render everyone in the configured zone above.
 
+This affects rendering only. Your own code — an action's `handle`, a scope, a filter, a model callback — keeps the zone configured above, so `Time.zone` there means what it means everywhere else in your app.
+
 ```ruby
 # config/initializers/avo.rb
 Avo.configure do |config|


### PR DESCRIPTION
Docs side of avo-hq/avo#4752.

`use_browser_timezone` used to swap `Time.zone` for the whole request, which the docs described as "wraps every Avo request in `Time.use_zone`". That turned out to reinterpret app code too, not just display it — [a user lost a couple of hours](https://github.com/avo-hq/avo/pull/4703#issuecomment-5414482140) to a `Time.zone.local` call inside an action handler coming back in their browser's zone instead of the app's.

The gem now scopes the visitor's zone to rendering. These pages say so:

- **`customization-api.md`** — drops the `Time.use_zone`-wraps-the-request wording, and adds a warning block spelling out the boundary with an action-handler example: your code (an action's `handle`, scopes, filters, ActiveRecord's time-zone-aware casting on write, model callbacks) keeps `config.timezone`, and `in_time_zone` is the way to convert explicitly outside a template.
- **`customization.md`** — one sentence in the guide making the same point, linking through to the reference for the detail.

No structural changes; both edits sit inside the existing `<Option>` and time zone sections.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhonHMVdYAoaG3hFqpxrTs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration behavior in this PR.
> 
> **Overview**
> Updates **4.0** customization docs so **`use_browser_timezone`** is described as a **display-only** feature, matching the gem change that no longer wraps the whole request in the visitor’s zone.
> 
> In **`customization-api.md`**, the option text stops saying Avo wraps every request in **`Time.use_zone`** and instead says responses are rendered in the browser cookie zone. A new **warning** block states that **`Time.zone`**, **`Time.current`**, **`Date.current`**, scopes/filters, AR time-zone casting on write, and callbacks still use **`config.timezone`**, with an action **`handle`** example and a note to use **`in_time_zone`** outside templates.
> 
> In **`customization.md`**, the timezone section adds one sentence with the same rendering-only boundary and points readers to the API reference for detail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e13d9efbbdf6899f613f97a67a45aa6c2d8b0e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->